### PR TITLE
Remove rails and sass dependencies from Gemspec

### DIFF
--- a/geoblacklight.gemspec
+++ b/geoblacklight.gemspec
@@ -18,9 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rails', '~> 4.0.0' # Rails 4.1.x has Spring on by default
   spec.add_dependency 'blacklight', '~> 5.4.0'
-  spec.add_dependency 'bootstrap-sass', '~> 3.0'
   spec.add_dependency 'leaflet-rails', '~> 0.7.3'
   spec.add_dependency 'blacklight_range_limit', '~> 5.0.1'
   spec.add_dependency 'font-awesome-rails', '~> 4.1.0.0'


### PR DESCRIPTION
This was causing a conflict with my `bundle install`. The two gem's are already required by Blacklight, I don't think we need them in here too.
