### PR TITLE
Retain previous search params in URL

### DIFF
--- a/app/assets/javascripts/geoblacklight/geoblacklight.js
+++ b/app/assets/javascripts/geoblacklight/geoblacklight.js
@@ -37,17 +37,36 @@ GeoBlacklight.prototype = {
   searchFromBounds: function() {
     var self = this;
     self.params.bbox = GeoBlacklight.boundsToBbox(self._map.getBounds()).join(' ');
-    location = self._map.options.catalogPath + L.Util.getParamString(self.params);
+    window.location = self._map.options.catalogPath + '?' +
+      $.param(self.params, false);
   },
+
   getParams: function() {
-    var queryDict = {};
-    location.search.substr(1).split('&').forEach(function(item) {
-      if (item.length > 0){
-        queryDict[item.split('=')[0]] = item.split('=')[1];
+    var queryDict = {},
+        search = window.location.search.substr(1);
+
+    $.each(search.split('&'), function(index, item) {
+      var param = item.split("="),
+          key = param[0],
+          value = param[1];
+
+      if (!key && !value) {
+        return;
+      }
+
+      key = decodeURIComponent(key).replace(/\[\]$/, '');
+      value = decodeURIComponent(value);
+
+      if (queryDict[key] !== undefined) {
+        queryDict[key].push(value);
+      } else {
+        queryDict[key] = [value];
       }
     });
+
     return queryDict;
   },
+
   // Conversion methods for envelope / bounds / bbox
   envelopeToBounds: function(string){
     var values = string.split(',');

--- a/spec/features/home_page_spec.rb
+++ b/spec/features/home_page_spec.rb
@@ -37,4 +37,14 @@ feature 'Home page', js: true do # use js: true for tests which require js, but 
     expect(page).to have_css '#documents'
   end
 
+  scenario 'clicking map search should retain current search parameters' do
+    visit '/?f[dc_subject_sm][]=polygon&f[dc_subject_sm][]=boundaries'
+    within '#map' do
+      find('a.search-control').click
+    end
+    within '#appliedParams' do
+      expect(page).to have_content('Subject polygon')
+      expect(page).to have_content('Subject boundaries')
+    end
+  end
 end


### PR DESCRIPTION
Leaflet's getParamString doesn't deal with repeated parameters in the
URL. Switching to jQuery.param() so we can retain previous search
terms.
