### PR TITLE
Refactor item page js

### DIFF
--- a/app/assets/javascripts/geoblacklight/geoblacklight.js
+++ b/app/assets/javascripts/geoblacklight/geoblacklight.js
@@ -16,7 +16,10 @@ GeoBlacklight = function(){
 GeoBlacklight.prototype = {
   setupMap: function(element){
     var self = this;
-    self.bounds = self.bboxToBounds(element.dataset.mapBbox);
+    self.dataAttributes = $(element).data();
+    if (self.dataAttributes.mapBbox) {
+      self.bounds = self.bboxToBounds(self.dataAttributes.mapBbox);
+    }
     self.map = L.map('map');
     self.basemap.addTo(self.map);
     self.searchControl = L.searchButton(self);
@@ -33,7 +36,8 @@ GeoBlacklight.prototype = {
       map: self.map,
       basemap: self.basemap,
       searchControl: self.searchControl,
-      params: self.params
+      params: self.params,
+      dataAttributes: self.dataAttributes
     };
   },
   refreshBasemap: function() {
@@ -87,9 +91,9 @@ GeoBlacklight.prototype = {
   },
   bboxToBounds: function(bbox) {
     bbox = bbox.split(' ');
-    if (bbox.length === 4){
+    if (bbox.length === 4) {
       return L.latLngBounds([[bbox[1], bbox[0]], [bbox[3], bbox[2]]]);
-    }else{
+    }else {
       return null;
     }
   },

--- a/app/assets/javascripts/geoblacklight/modules/item.js
+++ b/app/assets/javascripts/geoblacklight/modules/item.js
@@ -1,0 +1,42 @@
+Blacklight.onLoad(function() {
+  $('[data-map="item"]').each(function(i, element) {
+    var layerMap = new GeoBlacklight.Item(element);
+  });
+});
+
+GeoBlacklight.Item = function(element) {
+  _this = this;
+  _this.element = element;
+  L.extend(_this, GeoBlacklight.setupMap(element));
+  _this.map.options.catalogPath = _this.dataAttributes.catalogPath;
+  _this.layer = new L.layerGroup()
+    .addTo(_this.map);
+  if (_this.dataAttributes.available) {
+    _this.addPreviewLayer();
+  } else {
+    _this.addBboxLayer();
+  }
+};
+
+GeoBlacklight.Item.prototype = {
+  addPreviewLayer: function() {
+    _this = this;
+    _this.wmsLayer = L.tileLayer.wms(_this.dataAttributes.wmsUrl, {
+      layers: _this.dataAttributes.layerId,
+      format: 'image/png',
+      transparent: true,
+      tiled: true,
+      CRS: 'EPSG:900913',
+      opacity: 0.75
+    });
+    _this.layer.addLayer(_this.wmsLayer);
+  },
+  addBboxLayer: function() {
+    _this = this;
+    _this.bounds = GeoBlacklight.bboxToBounds(
+      _this.element.dataset.mapBbox
+    );
+    _this.bboxLayer = L.polygon([_this.bounds.getSouthWest(), _this.bounds.getSouthEast(), _this.bounds.getNorthEast(), _this.bounds.getNorthWest()]);
+    _this.layer.addLayer(_this.bboxLayer);
+  }
+};

--- a/app/assets/javascripts/geoblacklight/modules/map-view.js
+++ b/app/assets/javascripts/geoblacklight/modules/map-view.js
@@ -1,9 +1,9 @@
 "use strict";
 
-console.log('DEBUG: Inside geoblacklight/modules/map-view.js');
+// console.log('DEBUG: Inside geoblacklight/modules/map-view.js');
 Blacklight.onLoad(function () {
-  $('#geoblacklight-map-view').geoBlacklight_setupMapView();
-  $('#geoblacklight-tools').geoBlacklight_setupTools();
+  // $('#geoblacklight-map-view').geoBlacklight_setupMapView();
+  // $('#geoblacklight-tools').geoBlacklight_setupTools();
 });
 
 /* Requires leaflet */

--- a/app/assets/javascripts/geoblacklight/modules/results.js
+++ b/app/assets/javascripts/geoblacklight/modules/results.js
@@ -1,4 +1,4 @@
-Blacklight.onLoad( function() 
+Blacklight.onLoad( function() {
   $('[data-map="index"]').each(function(i, element) {
     var resultsMap = new GeoBlacklight.Results(element);
   });
@@ -7,8 +7,7 @@ Blacklight.onLoad( function()
 GeoBlacklight.Results = function(element) {
   var self = this;
   L.extend(self, GeoBlacklight.setupMap(element));
-
-  self.map.options.catalogPath = L.DomUtil.get('map').dataset.catalogPath;
+  self.map.options.catalogPath = self.dataAttributes.catalogPath;
   self.bboxLayers = new L.layerGroup()
     .addTo(self.map);
   self.setHoverListeners();

--- a/app/views/catalog/_show_default.html.erb
+++ b/app/views/catalog/_show_default.html.erb
@@ -1,50 +1,15 @@
-<div class="geoblacklight-view-panel">
+<% document ||= @document %>
 
-  <dl class="dl-horizontal">
-    <% unless document['dc_creator_sm'].nil? %>
-      <dt>Author</dt>
-      <dd><%= document['dc_creator_sm'].join(', ') %>&nbsp;</dd>
-	<% end %>
-    <% unless document['dc_publisher_s'].nil? %>
-      <dt>Publisher</dt>
-      <dd><%= document['dc_publisher_s'] %>&nbsp;</dd>
-	<% end %>
-    <dt>Year</dt>
-    <dd><%= document['solr_year_i'] %>&nbsp;</dd>
-    <dt>Abstract</dt>
-    <dd id=""><%= abstract_truncator(document['dc_description_s']) %>&nbsp;</dd>
-    <% unless document['dct_isPartOf_sm'].nil? %>
-      <dt>Collection</dt>
-      <dd><%= document['dct_isPartOf_sm'].sort.join(', ') %>&nbsp;</dd>
-    <% end %>
-    <% if document['dct_provenance_s'] == 'Stanford' and not document['dc_identifier_s'].nil? %>
-      <dt>Citation</dt>
-      <dd><%= link_to document['dc_identifier_s'], document['dc_identifier_s'] %>&nbsp;</dd>
-    <% end %>
-    <% unless document['dct_spatial_sm'].nil? %>
-      <dt>Places</dt>
-      <dd><%= document['dct_spatial_sm'].sort.join(', ') %>&nbsp;</dd>
-    <% end %>
-    <% unless document['dc_subject_sm'].nil? %>
-      <dt>Subjects</dt>
-      <dd><%= document['dc_subject_sm'].sort.join(', ') %>&nbsp;</dd>
-    <% end %>
-    <% unless document['dct_temporal_sm'].nil? %>
-      <dt>Years</dt>
-      <dd><%= document['dct_temporal_sm'].sort.join(', ') %>&nbsp;</dd>
-    <% end %>
-  </dl>
-</div>
+<%= render 'upper_metadata', locals: { document: document} %>
 
 <div class='row'>
   <div class="col-md-8">
-    <div id='geoblacklight-map-view'>
-      <div id='map' class='mapview-map'></div>
+    <%= content_tag :div, id: 'map', data: { map: 'item', 'catalog-path'=> catalog_index_path , 'map-bbox' => document[:solr_bbox], 'layer-id' => document[:layer_id_s], 'wms-url' => document[:solr_wms_url], available: document.available? } do %>
       <div id='control'>
         <div id='handle'></div>
         <div id='bottom'></div>
       </div>
-    </div>
+    <% end %>
   </div>
   <div id='table-container' class='col-md-4'><div id='attribute-table' ></div></div>
 </div>

--- a/app/views/catalog/_upper_metadata.html.erb
+++ b/app/views/catalog/_upper_metadata.html.erb
@@ -1,0 +1,38 @@
+<% document ||= @document %>
+<div class="geoblacklight-view-panel">
+
+  <dl class="dl-horizontal">
+    <% unless document['dc_creator_sm'].nil? %>
+      <dt>Author</dt>
+      <dd><%= document['dc_creator_sm'].join(', ') %>&nbsp;</dd>
+  <% end %>
+    <% unless document['dc_publisher_s'].nil? %>
+      <dt>Publisher</dt>
+      <dd><%= document['dc_publisher_s'] %>&nbsp;</dd>
+  <% end %>
+    <dt>Year</dt>
+    <dd><%= document['solr_year_i'] %>&nbsp;</dd>
+    <dt>Abstract</dt>
+    <dd id=""><%= abstract_truncator(document['dc_description_s']) %>&nbsp;</dd>
+    <% unless document['dct_isPartOf_sm'].nil? %>
+      <dt>Collection</dt>
+      <dd><%= document['dct_isPartOf_sm'].sort.join(', ') %>&nbsp;</dd>
+    <% end %>
+    <% if document['dct_provenance_s'] == 'Stanford' and not document['dc_identifier_s'].nil? %>
+      <dt>Citation</dt>
+      <dd><%= link_to document['dc_identifier_s'], document['dc_identifier_s'] %>&nbsp;</dd>
+    <% end %>
+    <% unless document['dct_spatial_sm'].nil? %>
+      <dt>Places</dt>
+      <dd><%= document['dct_spatial_sm'].sort.join(', ') %>&nbsp;</dd>
+    <% end %>
+    <% unless document['dc_subject_sm'].nil? %>
+      <dt>Subjects</dt>
+      <dd><%= document['dc_subject_sm'].sort.join(', ') %>&nbsp;</dd>
+    <% end %>
+    <% unless document['dct_temporal_sm'].nil? %>
+      <dt>Years</dt>
+      <dd><%= document['dct_temporal_sm'].sort.join(', ') %>&nbsp;</dd>
+    <% end %>
+  </dl>
+</div>

--- a/config/initializers/rails_config.rb
+++ b/config/initializers/rails_config.rb
@@ -1,0 +1,3 @@
+RailsConfig.setup do |config|
+  config.const_name = "Settings"
+end

--- a/geoblacklight.gemspec
+++ b/geoblacklight.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'blacklight_range_limit', '~> 5.0.1'
   spec.add_dependency 'font-awesome-rails', '~> 4.1.0.0'
   spec.add_dependency 'httparty', '~> 0.13.1'
+  spec.add_dependency 'rails_config'
 
   spec.add_development_dependency 'bundler', '~> 1.5'
   spec.add_development_dependency 'rake', '~> 10.3.2'

--- a/lib/generators/geoblacklight/install_generator.rb
+++ b/lib/generators/geoblacklight/install_generator.rb
@@ -16,6 +16,16 @@ module Geoblacklight
       remove_file "app/controllers/catalog_controller.rb"
       copy_file "catalog_controller.rb", "app/controllers/catalog_controller.rb"
     end
+    
+    def rails_config
+      copy_file 'settings.yml', 'config/settings.yml'
+    end
+    
+    def include_geoblacklight_solrdocument
+      inject_into_file 'app/models/solr_document.rb', after: 'include Blacklight::Solr::Document' do
+        "\n include Geoblacklight::SolrDocument"
+      end
+    end
 
     def fixtures
       FileUtils.mkdir_p "spec/fixtures/geoblacklight_schema"

--- a/lib/generators/geoblacklight/templates/settings.yml
+++ b/lib/generators/geoblacklight/templates/settings.yml
@@ -1,0 +1,1 @@
+INSTITUTION: 'Stanford'

--- a/lib/geoblacklight.rb
+++ b/lib/geoblacklight.rb
@@ -4,6 +4,7 @@ module Geoblacklight
   require 'geoblacklight/config'
   require 'geoblacklight/controller_override'
   require 'geoblacklight/view_helper_override'
+  require 'geoblacklight/solr_document'
   def self.inject!
     CatalogController.send(:include, Geoblacklight::ControllerOverride)
     CatalogController.send(:include, Geoblacklight::ViewHelperOverride)

--- a/lib/geoblacklight/engine.rb
+++ b/lib/geoblacklight/engine.rb
@@ -2,6 +2,7 @@ require 'blacklight'
 require 'leaflet-rails'
 require 'httparty'
 require 'font-awesome-rails'
+require 'rails_config'
 
 module Geoblacklight
   class Engine < ::Rails::Engine

--- a/lib/geoblacklight/solr_document.rb
+++ b/lib/geoblacklight/solr_document.rb
@@ -1,0 +1,18 @@
+module Geoblacklight
+  # Extends Blacklight::Solr::Document for GeoBlacklight specific functionalit
+  module SolrDocument
+    extend Blacklight::Solr::Document
+    
+    def available?
+      public? || same_institution?
+    end
+
+    def public?
+      get(:dc_rights_s) == 'Public'
+    end
+
+    def same_institution?
+      get(:dct_provenance_s) == Settings.Institution
+    end
+  end
+end

--- a/spec/features/layer_preview_spec.rb
+++ b/spec/features/layer_preview_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+feature 'Layer preview', js: true do
+  scenario 'Restricted layer should show bounding box' do
+    visit catalog_path('mit-us-ma-cambridge-s1consv-2007')
+    expect(Nokogiri::HTML.parse(page.body).css('path').length).to eq 1
+  end
+  
+  scenario 'Public layer should show wms layer not bounding box' do
+    visit catalog_path('mit-us-ma-e25zcta5dct-2000')
+    expect(Nokogiri::HTML.parse(page.body).css('path').length).to eq 0
+    within '.leaflet-tile-pane' do
+      expect(page).to have_css('.leaflet-layer', count: 2)
+    end
+  end
+end

--- a/spec/lib/geoblacklight/solr_document.rb
+++ b/spec/lib/geoblacklight/solr_document.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+
+describe Geoblacklight::SolrDocument do
+  let(:document) { SolrDocument.new(document_attributes) }
+  describe '#available?' do
+    let(:document_attributes) { {} }
+    describe 'a public document' do
+      it 'should always be available' do
+        allow(document).to receive('same_institution?').and_return(false)
+        allow(document).to receive('public?').and_return(true)
+        expect(document.available?).to be_truthy
+      end
+    end
+    describe 'a restricted document' do
+      describe 'should only be available if from same institution' do
+        allow(document).to receive('same_institution?').and_return(true)
+        allow(document).to receive('public?').and_return(false)
+        expect(document.available?).to be_truthy
+      end
+    end
+  end
+  describe '#public?' do
+    describe 'a public document' do
+      let(:document_attributes) { { dc_rights_s: 'Public' } }
+      it 'should be public' do
+        expect(document.public?).to be_truthy
+      end
+    end
+    describe 'a restricted resource' do
+      let(:document_attributes) { { dc_rights_s: 'Restricted' } }
+      it 'should not be public' do
+        expect(document.public?).to be_falsey
+      end
+    end
+  end
+  describe '#same_institution?' do
+    describe 'within the same institution' do
+      let(:document_attributes) { { dct_provenance_s: 'Stanford' } }
+      it 'should be true' do
+        allow(Settings).to receive('Institution').and_return('Stanford')
+        expect(document.same_institution?).to be_truthy
+      end
+    end
+    describe 'within a different institution' do
+      let(:document_attributes) { { dct_provenance_s: 'MIT' } }
+      it 'should be false' do
+        allow(Settings).to receive('Institution').and_return('Stanford')
+        expect(document.same_institution?).to be_falsey
+      end
+    end
+  end
+end


### PR DESCRIPTION
Significant updates here to how an item is handled. Removed functionality of downloads #59 and table inspection #60 but created feature tickets for them. Left old js plugin in for reference but `map-view.js` should be removed when those tickets are completed.

Now a geoblacklight application can be configured to it's host institution using the rails_config gem. This settings file should be automatically created at `config/settings.yml` when the generator is run.
