### PR TITLE
adds back in download functionality

### DIFF
--- a/app/assets/javascripts/geoblacklight/modules/download.js
+++ b/app/assets/javascripts/geoblacklight/modules/download.js
@@ -1,0 +1,45 @@
+Blacklight.onLoad(function() {
+  var downloads = [];
+  $('[data-download-path]').each(function(i, element) {
+    downloads.push(new GeoBlacklight.Download(element));
+  });
+});
+
+GeoBlacklight.Download = function(element) {
+  var _this = this;
+  _this.element = $(element);
+  _this.url = _this.element.data('download-path');
+  _this.buttonGroup = _this.element.closest('.btn-group');
+  _this.spinner = $('<i class="fa fa-spinner fa-spin fa-2x fa-align-center"></i>');
+  _this.buttonGroup.append(_this.spinner.hide());
+  _this.setupClickListener();
+};
+
+GeoBlacklight.Download.prototype = {
+  setupClickListener: function() {
+    var _this = this;
+    _this.element.on('click', function(e) {
+      e.preventDefault();
+      _this.requestDownload();
+    });
+  },
+  requestDownload: function() {
+    var _this = this;
+    _this.spinner.show();
+    $.ajax({
+      url: _this.url,
+      dataType: 'json'
+    }).done(function(data) {
+      _this.renderFlashMessage(data);
+      _this.spinner.hide();
+    }).fail(function(data, e) {
+      _this.spinner.hide();
+    });
+  },
+  renderFlashMessage: function(response) {
+    $.each(response, function(i, val) {
+      var flashHtml = '<div class="alert alert-' + val[0] + '"><button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>' + val[1] + '</div>';
+      $('div.flash_messages').append(flashHtml);
+    });
+  }
+};

--- a/app/assets/javascripts/geoblacklight/modules/map-view.js
+++ b/app/assets/javascripts/geoblacklight/modules/map-view.js
@@ -21,7 +21,7 @@ Blacklight.onLoad(function () {
     return this.each(function () {
       console.log(this)
       map = L.map('map');
-      console.log(solrDoc)
+      // console.log(solrDoc)
       // var layerBbox;
       // var location = JSON.parse(doc.Location);
       if (solrDoc.solr_bbox){

--- a/app/controllers/download_controller.rb
+++ b/app/controllers/download_controller.rb
@@ -1,107 +1,35 @@
-require 'nokogiri'
-require 'httparty'
-require 'net/http'
-
-class Layer
-  include HTTParty
-  format :json
-
-  def self.getInfo(params)
-    url = params['URL']
-    params['BBOX'] = formatLatLng(params['BBOX'])
-    puts params
-    get(url, :query => params.except('URL'))
-  end
-end
-
 class DownloadController < ApplicationController
+  include Blacklight::SolrHelper
+
+  def show
+    @response, @document = get_solr_response_for_doc_id
+    response = check_type
+    validate response
+    respond_to do |format|
+      format.json { render json: flash, response: response }
+      format.html { render json: flash, response: response }
+    end
+  end
+
   def file
-    
-    send_file "tmp/data/#{params['q']}", :type=>"application/zip", :x_sendfile=>true 
-
+    send_file "tmp/downloads/#{params[:id]}.#{params[:format]}", type: 'application/zip', x_sendfile: true
   end
 
-  def shapefile
- 
-    puts session['session_id']
-    uuid = params['layer_slug_s']
-    layername = params['layer_id_s']
-    wfsurl = params['solr_wfs_url']
-    
-    params = {:service => 'wfs', :version => '2.0.0', :request => 'GetFeature', :srsName => 'EPSG:4326', :outputformat => 'SHAPE-ZIP', :typeName => layername}
-    
-    # token = SecureRandom.base64(8).tr('+/=lIO0', 'abc123')
-    error = ''
-
-    if !Dir.exists?('tmp/data')
-      Dir.mkdir('tmp/data')
+  def check_type
+    case params[:type]
+    when 'shapefile'
+      response = ShapefileDownload.new(@document).get
+    when 'kmz'
+      response = KmzDownload.new(@document).get
     end
-    if (!File.file?("tmp/data/#{uuid}-shapefile.zip"))
-      File.open("tmp/data/#{uuid}-shapefile.zip", 'wb')  do |f|
-          puts "#{uuid}-shapefile.zip created"
-          dl = HTTParty.get(wfsurl, :query => params)
-          if dl.headers['content-type'] == 'application/zip'
-            f.write dl.parsed_response
-          else
-            error = dl.parsed_response
-          end
-      end
-    else
-      puts "#{uuid}-shapefile.zip already exists"
-    end
-    respond_to do |format|
-      if error.length > 0
-         puts 'error!'
-        format.json { render :json => {:error => error}}
-        File.delete("tmp/data/#{uuid}-shapefile.zip")
-        puts "#{uuid}-shapefile.zip deleted"
-      else
-        format.json { render :json => {:data => "#{uuid}-shapefile.zip"}}
-      end
-    end
-
+    response
   end
 
-  def kml
-    layername = params['layer_id_s']
-    puts layername
-    bbox = [params['solr_sw_pt_1_d'], params['solr_sw_pt_0_d'], params['solr_ne_pt_1_d'], params['solr_ne_pt_0_d']]
-    bbox = bbox.join(',')
-    wmsurl = params['solr_wms_url']
-    uuid = params['layer_slug_s']
-    puts bbox
-
-    params = {:service => 'wms', :version => '1.1.0', :request => 'GetMap', :srsName => 'EPSG:900913', :format => 'application/vnd.google-earth.kmz', :layers => layername, :bbox => bbox, :width => 2000, :height => 2000}
-    
-    error = ''
-
-    if !Dir.exists?('tmp/data')
-      Dir.mkdir('tmp/data')
-    end
-    if (!File.file?("tmp/data/#{uuid}.kmz"))
-      File.open("tmp/data/#{uuid}.kmz", 'wb')  do |f|
-          puts "#{uuid}.kmz created"
-          dl = HTTParty.get(wmsurl, :query => params)
-          puts dl.headers.inspect
-          puts dl.request.inspect
-          if dl.headers['content-type'] == 'application/vnd.google-earth.kmz'
-            f.write dl.parsed_response
-          else
-            error = dl.parsed_response
-          end
-      end
+  def validate(response)
+    if response.nil?
+      flash[:danger] = t 'geoblacklight.download.error'
     else
-      puts "#{uuid}.kmz already exists"
-    end
-    respond_to do |format|
-      if error.length > 0
-         puts 'error!'
-        format.json { render :json => {:error => error}}
-        File.delete("tmp/data/#{uuid}.kmz")
-        puts "#{uuid}.kmz deleted"
-      else
-        format.json { render :json => {:data => "#{uuid}.kmz"}}
-      end
+      flash[:success] = view_context.link_to(t('geoblacklight.download.success', title: response), download_file_path(response))
     end
   end
 end

--- a/app/views/catalog/_show_default.html.erb
+++ b/app/views/catalog/_show_default.html.erb
@@ -13,16 +13,3 @@
   </div>
   <div id='table-container' class='col-md-4'><div id='attribute-table' ></div></div>
 </div>
-<% if @document['dct_provenance_s'] == 'Stanford' %>
-<div class='geoblacklight-view-panel-footer'>
-  <br>
-  <br>
-  <hr/>
-  <p align="right">
-    <small>
-      <a href="<%= @document['dc_identifier_s'] %>.mods">Librarian View</a>
-    </small>
-  </p>
-</div>
-<% end %>
-<%= javascript_tag "var solrDoc = #{@document.to_json};" %>

--- a/app/views/catalog/_show_sidebar.html.erb
+++ b/app/views/catalog/_show_sidebar.html.erb
@@ -1,12 +1,5 @@
-<%-
-  # Compare with render_document_functions_partial helper, and
-  # _document_functions partial. BL actually has two groups
-  # of document-related tools. "document functions" by default
-  # contains Bookmark functionality shown on both results and
-  # item view. While "document tools" contains external export type
-  # functions by default only on detail.
+<% document ||= @document %>
 
--%>
 <div id='geoblacklight-tools'>
   <div class="panel panel-default show-tools">
     <div class="panel-heading"> 
@@ -25,49 +18,19 @@
         <i class="fa fa-bookmark fa-fw"></i>&nbsp;Cite This
       </a>    
     </ul>
-    <ul class="list-group">
-    <a id="download-metadata" data-no-turbolink class="list-group-item"
-      <% if @document['dct_provenance_s'] == 'Stanford' %>
-      href="<%= @document['dc_identifier_s'] %>.mods"
-      <% else %>
-      href="#" 
-      <% end %>
-      >
-      <i class="fa fa-download fa-fw" id="icon-metadata"></i>&nbsp;Metadata
-    </a>
-    <% if @document['dc_rights_s'] == 'Restricted' and @document['dct_provenance_s'] != 'Stanford' %>
-      <a href="#" data-no-turbolink class="list-group-item">
-        <i class="fa fa-download fa-fw" id="icon-request"></i>&nbsp;Request This
-      </a><br/>
-    <% else %>
-      <a href="#" id="download-kml" data-no-turbolink class="list-group-item">
-        <i class="fa fa-download fa-fw" id="icon-kml"></i>&nbsp;KML
-      </a>
-      <% if @document['dc_format_s'] == 'Shapefile' %>
-        <a href="#" id="download-shapefile" data-no-turbolink class="list-group-item">
-          <i class="fa fa-download fa-fw" id="icon-shapefile"></i>&nbsp;Shapefile
-        </a>
-      <% end %>
+    <% if document.downloadable? %>
+      <div class='btn-group'>
+        <%= button_tag(type: 'button', class: 'btn btn-default dropdown-toggle', data: { toggle: 'dropdown' }) do %>
+          Download <span class='caret'></span>
+        <% end %>
+        <ul class="dropdown-menu" role="menu">
+          <% document.download_types.each do |type| %>
+            <%= content_tag(:li) do %>
+              <%= link_to(type[:label], '', data: { download_path: "#{download_path(document[:layer_slug_s], type: type[:type])}" }) %>
+            <% end %>
+          <% end %>
+        </ul>
+      </div>
     <% end %>
- 
-    </ul>
-    <% unless @document['dc_rights_s'] == 'Restricted' and @document['dct_provenance_s'] != 'Stanford' %>
-  
-    <ul class="list-group">
-      <a href="<%= @document['solr_wms_url'] %>?request=GetCapabilities" data-no-turbolink class="list-group-item">
-        <i class="fa fa-link fa-fw"></i>&nbsp;WMS Link
-      </a>
-      <% if @document['layer_geom_type_s'] == 'Raster' %>
-        <a href="<%= @document['solr_wcs_url'] %>?request=GetCapabilities" data-no-turbolink class="list-group-item">
-          <i class="fa fa-link fa-fw"></i>&nbsp;WCS Link
-        </a>
-        <% else %>
-      <a href="<%= @document['solr_wfs_url'] %>?request=GetCapabilities" data-no-turbolink class="list-group-item">
-        <i class="fa fa-link fa-fw"></i>&nbsp;WFS Link
-      </a>
-      <% end %>
-    </ul>
-    <% end %>
-    </div>
   </div>
 </div>

--- a/config/locales/geoblacklight.en.yml
+++ b/config/locales/geoblacklight.en.yml
@@ -1,0 +1,5 @@
+en:
+  geoblacklight:
+    download:
+      success: 'Your file %{title} is ready for download'
+      error: 'Sorry, the requested file could not be downloaded'

--- a/lib/generators/geoblacklight/install_generator.rb
+++ b/lib/generators/geoblacklight/install_generator.rb
@@ -39,17 +39,15 @@ module Geoblacklight
     end
 
     def inject_routes
-      # route 'devise_for :users'
-      # route 'constraints(:id => /[0-9A-Za-z\-\.\:\_\/]+/) do
-      #          blacklight_for :catalog
-      #          resources :bookmarks
-      #        end'
-      # route 'get \'/catalog/facet/:id\' => \'catalog#facet\''
-      # route 'root :to => "catalog#index"'
       route 'post "wms/handle"'
-      route 'post "download/kml"'
-      route 'post "download/shapefile"'
-      route 'get "download/file"'
+      route 'resources :download, only: [:show, :file]'
+      route "get 'download/file/:id' => 'download#file', as: :download_file"
+    end
+
+    def create_downloads_directory
+      if !Dir.exists?('tmp/downloads')
+        Dir.mkdir('tmp/downloads')
+      end
     end
 
     # Necessary for bootstrap-sass 3.2

--- a/lib/geoblacklight.rb
+++ b/lib/geoblacklight.rb
@@ -6,6 +6,9 @@ module Geoblacklight
   require 'geoblacklight/view_helper_override'
   require 'geoblacklight/solr_document'
   require 'geoblacklight/wms_layer'
+  require 'geoblacklight/download'
+  require 'geoblacklight/download/shapefile_download'
+  require 'geoblacklight/download/kmz_download'
   def self.inject!
     CatalogController.send(:include, Geoblacklight::ControllerOverride)
     CatalogController.send(:include, Geoblacklight::ViewHelperOverride)

--- a/lib/geoblacklight/download.rb
+++ b/lib/geoblacklight/download.rb
@@ -1,0 +1,63 @@
+class Download
+  def initialize(document, options = {})
+    @document = document
+    @options = options
+  end
+
+  def downloadable?
+    @document.downloadable?
+  end
+
+  def file_name
+    "#{@document[:layer_slug_s]}-#{@options[:type]}.#{@options[:extension]}"
+  end
+
+  def file_path
+    "#{Rails.root}/tmp/downloads/#{file_name}"
+  end
+
+  def download_exists?
+    File.file?(file_path)
+  end
+
+  def get
+    if download_exists?
+      file_name
+    else
+      create_download_file
+    end
+  end
+
+  def create_download_file
+    download = initiate_download
+    File.open("#{file_path}.tmp", 'wb')  do |file|
+      if download.headers['content-type'] == @options[:content_type]
+        file.write download.body
+      else
+        fail 'Wrong type of download'
+      end
+    end
+    File.rename("#{file_path}.tmp", file_path)
+    file_name
+  rescue
+    File.delete("#{file_path}.tmp")
+    nil
+  end
+
+  def initiate_download
+    conn = Faraday.new(url: @document[@options[:service_type]])
+    conn.get do |request|
+      request.params = @options[:request_params]
+      request.options = {
+        timeout: 10,
+        open_timeout: 10
+      }
+    end
+  rescue Faraday::Error::ConnectionFailed => error
+    puts error
+    nil
+  rescue Faraday::Error::TimeoutError => error
+    puts error
+    nil
+  end
+end

--- a/lib/geoblacklight/download/kmz_download.rb
+++ b/lib/geoblacklight/download/kmz_download.rb
@@ -1,0 +1,14 @@
+class KmzDownload < Download
+  KMZ_DOWNLOAD_PARAMS = { service: 'wms', version: '1.1.0', request: 'GetMap', srsName: 'EPSG:900913', format: 'application/vnd.google-earth.kmz', width: 2000, height: 2000 }
+  
+  def initialize(document)
+    request_params = KMZ_DOWNLOAD_PARAMS.merge(layers: document[:layer_id_s], bbox: document[:solr_bbox].split(' ').join(', '))
+    super(document, {
+      type: 'kmz',
+      extension: 'kmz',
+      request_params: request_params,
+      content_type: 'application/vnd.google-earth.kmz',
+      service_type: :solr_wms_url
+    })
+  end
+end

--- a/lib/geoblacklight/download/shapefile_download.rb
+++ b/lib/geoblacklight/download/shapefile_download.rb
@@ -1,0 +1,14 @@
+class ShapefileDownload < Download
+  SHAPEFILE_DOWNLOAD_PARAMS = { service: 'wfs', version: '2.0.0', request: 'GetFeature', srsName: 'EPSG:4326', outputformat: 'SHAPE-ZIP' }
+  
+  def initialize(document)
+    request_params = SHAPEFILE_DOWNLOAD_PARAMS.merge(typeName: document[:layer_id_s])
+    super(document, {
+      type: 'shapefile',
+      extension: 'zip',
+      request_params: request_params,
+      content_type: 'application/zip',
+      service_type: :solr_wfs_url
+    })
+  end
+end

--- a/lib/geoblacklight/solr_document.rb
+++ b/lib/geoblacklight/solr_document.rb
@@ -11,6 +11,14 @@ module Geoblacklight
       get(:dc_rights_s) == 'Public'
     end
 
+    def downloadable?
+      get(:solr_wfs_url) && get(:solr_wms_url) && available?
+    end
+
+    def download_types
+      [{ label: 'Shapefile', type: 'shapefile' }, { label: 'KMZ', type: 'kmz' }]
+    end
+
     def same_institution?
       get(:dct_provenance_s) == Settings.Institution
     end

--- a/lib/geoblacklight/wms_layer.rb
+++ b/lib/geoblacklight/wms_layer.rb
@@ -1,7 +1,6 @@
 require 'nokogiri'
 require 'geoblacklight/wms_layer/feature_info_response'
 class WmsLayer
-  include HTTParty
 
   def initialize(params)
     @params = params.merge(Settings.WMS_PARAMS)

--- a/lib/tasks/geoblacklight.rake
+++ b/lib/tasks/geoblacklight.rake
@@ -19,4 +19,10 @@ namespace :geoblacklight do
       end
     end
   end
+  namespace :downloads do
+    desc 'Delete all cached downloads'
+    task delete: :environment do
+      FileUtils.rm_rf Dir.glob("#{Rails.root}/tmp/downloads/*")
+    end
+  end
 end

--- a/spec/features/download_layer_spec.rb
+++ b/spec/features/download_layer_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+feature 'Download layer', js: true do
+  scenario 'clicking shapefile download button should trigger download' do
+    expect_any_instance_of(ShapefileDownload).to receive(:get).and_return('mit-us-ma-e25zcta5dct-2000-shapefile.zip')
+    visit catalog_path('mit-us-ma-e25zcta5dct-2000')
+    find('button', text: 'Download').click
+    find('a', text: 'Shapefile').click
+    expect(page).to have_css('a', text: 'Your file mit-us-ma-e25zcta5dct-2000-shapefile.zip is ready for download')
+  end
+  scenario 'clicking kmz download button should trigger download' do
+    expect_any_instance_of(KmzDownload).to receive(:get).and_return('mit-us-ma-e25zcta5dct-2000-kmz.kmz')
+    visit catalog_path('mit-us-ma-e25zcta5dct-2000')
+    find('button', text: 'Download').click
+    find('a', text: 'KMZ').click
+    expect(page).to have_css('a', text: 'Your file mit-us-ma-e25zcta5dct-2000-kmz.kmz is ready for download')
+  end
+end

--- a/spec/lib/geoblacklight/download/kmz_download_spec.rb
+++ b/spec/lib/geoblacklight/download/kmz_download_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe KmzDownload do
+  let(:document) { SolrDocument.new(layer_slug_s: 'test', solr_wfs_url: 'http://www.example.com/wfs', layer_id_s: 'stanford-test', solr_bbox: '-180 -90 180 90') }
+  let(:download) { KmzDownload.new(document) }
+  describe '#initialize' do
+    it 'should initialize as a KmzDownload object with specific options' do
+      expect(download).to be_an KmzDownload
+      options = download.instance_variable_get(:@options)
+      expect(options[:content_type]).to eq 'application/vnd.google-earth.kmz'
+      expect(options[:request_params][:layers]).to eq 'stanford-test'
+      expect(options[:request_params][:bbox]).to eq '-180, -90, 180, 90'
+    end
+  end
+end

--- a/spec/lib/geoblacklight/download/shapefile_download_spec.rb
+++ b/spec/lib/geoblacklight/download/shapefile_download_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe ShapefileDownload do
+  let(:document) { SolrDocument.new(layer_slug_s: 'test', solr_wfs_url: 'http://www.example.com/wfs', layer_id_s: 'stanford-test', solr_bbox: '-180 -90 180 90') }
+  let(:download) { ShapefileDownload.new(document) }
+  describe '#initialize' do
+    it 'should initialize as a ShapefileDownload object with specific options' do
+      expect(download).to be_an ShapefileDownload
+      options = download.instance_variable_get(:@options)
+      expect(options[:content_type]).to eq 'application/zip'
+      expect(options[:request_params][:typeName]).to eq 'stanford-test'
+    end
+  end
+end

--- a/spec/lib/geoblacklight/download_spec.rb
+++ b/spec/lib/geoblacklight/download_spec.rb
@@ -1,0 +1,76 @@
+require 'spec_helper'
+
+describe Download do
+  let(:response) { double('response') }
+  let(:get) { double('get') }
+  let(:body) { double('body') }
+  let(:document) { SolrDocument.new(layer_slug_s: 'test', solr_wms_url: 'http://www.example.com/wms') }
+  let(:options) { { type: 'shapefile', extension: 'zip', service_type: :solr_wms_url, content_type: 'application/zip' } }
+  let(:download) { Download.new(document, options) }
+
+  describe '#initialize' do
+    it 'should initialize as a Download object' do
+      expect(download).to be_an Download
+    end
+  end
+  describe '#file_name' do
+    it 'should give the file name with path and extension' do
+      expect(download.file_name).to eq 'test-shapefile.zip'
+    end
+  end
+  describe '#file_path' do
+    it 'should return the path with name and extension' do
+      expect(download.file_path).to eq "#{Rails.root}/tmp/downloads/#{download.file_name}"
+    end
+  end
+  describe '#download_exists?' do
+    it 'should return false if file does not exist' do
+      expect(File).to receive(:file?).and_return(false)
+      expect(download.download_exists?).to be_falsey
+    end
+    it 'should return true if file does not exist' do
+      expect(File).to receive(:file?).and_return(true)
+      expect(download.download_exists?).to be_truthy
+    end
+  end
+  describe '#get' do
+    it 'should return filename if download exists' do
+      expect(download).to receive(:download_exists?).and_return(true)
+      expect(download.get).to eq download.file_name
+    end
+    it 'should call create_download_file if it does not exist' do
+      expect(download).to receive(:download_exists?).and_return(false)
+      expect(download).to receive(:initiate_download).and_return('')
+      expect(File).to receive(:open).with("#{download.file_path}.tmp", 'wb').and_return('')
+      expect(File).to receive(:delete).with("#{download.file_path}.tmp").and_return(nil)
+      expect(download.get).to eq nil
+    end
+  end
+  describe '#create_download_file' do
+    it 'should create the file in fs and delete it if the content headers are not correct' do
+      expect(download).to receive(:initiate_download).and_return('')
+      expect(File).to receive(:open).with("#{download.file_path}.tmp", 'wb').and_return('')
+      expect(File).to receive(:delete).with("#{download.file_path}.tmp").and_return(nil)
+      expect(download.create_download_file).to eq nil
+    end
+    it 'should create the file, write it, and then rename from tmp if everything is ok' do
+      shapefile = OpenStruct.new(headers: {'content-type' => 'application/zip'})
+      expect(download).to receive(:initiate_download).and_return(shapefile)
+      expect(File).to receive(:open).with("#{download.file_path}.tmp", 'wb').and_return('')
+      expect(File).to receive(:rename)
+      expect(download.create_download_file).to eq download.file_name
+    end
+  end
+  describe '#initiate_download' do
+    it 'request download from server' do
+      expect(response).to receive(:get).and_return(get)
+      expect(Faraday).to receive(:new).with(url: 'http://www.example.com/wms').and_return(response)
+      download.initiate_download
+    end
+    it 'should return nil with a connection failure' do
+      expect(response).to receive(:get).and_return(Faraday::Error::ConnectionFailed)
+      expect(Faraday).to receive(:new).with(url: 'http://www.example.com/wms').and_return(response)
+      expect(download.initiate_download).to be Faraday::ConnectionFailed
+    end
+  end
+end


### PR DESCRIPTION
Adds back in download functionality. Note: deploying this without modifying `downloadable?` might indirectly make private resources available to the public. Further configuration around auth is needed here.
