### PR TITLE
fixes a regression where the toggle collapse wasnt working properly

### DIFF
--- a/app/assets/javascripts/geoblacklight/modules/collapse.js
+++ b/app/assets/javascripts/geoblacklight/modules/collapse.js
@@ -1,8 +1,8 @@
-Blacklight.onLoad(function(){
-  $('.document').each(function(index, value){
+Blacklight.onLoad(function() {
+  $('.document').each(function(index, value) {
     value = $(value);
-    value.find('[data-layer-id]').on('click', function(){
-      value.find('.collapse').toggle();
+    value.find('[data-layer-id]').on('click', function() {
+      value.find('.collapse').collapse('toggle');
     });
   });
 });

--- a/spec/features/split_view.html.erb_spec.rb
+++ b/spec/features/split_view.html.erb_spec.rb
@@ -10,14 +10,14 @@ feature 'Index view', js: true do
     expect(page).to have_css(".document", count: 2)
     expect(page).to have_css('#map')
   end
-  
+
   scenario 'hover on record should produce bounding box on map' do
     # Needed to find an svg element on the page
     expect(Nokogiri::HTML.parse(page.body).css('path').length).to eq 0
     find('.documentHeader', match: :first).trigger(:mouseover)
     expect(Nokogiri::HTML.parse(page.body).css('path').length).to eq 1
   end
-  
+
   scenario 'click on a record area to expand collapse' do
     within('.documentHeader', match: :first) do
       expect(page).to_not have_css('.collapse')


### PR DESCRIPTION
Rather than using jQuery `.toggle()` use Bootstrap plugin (already provided)
