### PR TITLE
Bind result collapse further up DOM tree

### DIFF
--- a/app/assets/javascripts/geoblacklight/modules/collapse.js
+++ b/app/assets/javascripts/geoblacklight/modules/collapse.js
@@ -1,8 +1,6 @@
 Blacklight.onLoad(function() {
-  $('.document').each(function(index, value) {
-    value = $(value);
-    value.find('[data-layer-id]').on('click', function() {
-      value.find('.collapse').collapse('toggle');
+  $('#content')
+    .on('click', '#documents [data-layer-id]', function() {
+      $(this).find('.collapse').collapse('toggle');
     });
-  });
 });


### PR DESCRIPTION
This prevents the event handler from getting clobbered during history
state change. Fixes #88.
