### PR TITLE
change map height based on view type

### DIFF
--- a/app/assets/stylesheets/geoblacklight/_geoblacklight.css.scss
+++ b/app/assets/stylesheets/geoblacklight/_geoblacklight.css.scss
@@ -15,5 +15,6 @@
 @import 'geoblacklight/styles';
 @import 'modules/icons';
 @import 'modules/icon-customization';
+@import 'modules/home';
 @import 'modules/item';
 @import 'modules/results';

--- a/app/assets/stylesheets/geoblacklight/_styles.css.scss
+++ b/app/assets/stylesheets/geoblacklight/_styles.css.scss
@@ -1,11 +1,3 @@
-#map {
-  height: 400px;
-}
-
-#map.listview-map {
-  height: 485px;
-}
-
 #table-container{
   overflow:scroll;
   max-height: 450px;

--- a/app/assets/stylesheets/geoblacklight/modules/home.css.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/home.css.scss
@@ -1,0 +1,3 @@
+[data-map="home"] {
+  height: 600px;
+}

--- a/app/assets/stylesheets/geoblacklight/modules/results.css.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/results.css.scss
@@ -1,3 +1,7 @@
+[data-map="index"] {
+  height: 480px;
+}
+
 .more-info-area {
   max-height: 100px;
 }

--- a/spec/features/home_page_spec.rb
+++ b/spec/features/home_page_spec.rb
@@ -26,7 +26,7 @@ feature 'Home page', js: true do # use js: true for tests which require js, but 
   scenario 'map should be visible' do
     within '#content' do
       expect(page).to have_css('#map')
-      expect(page).to have_css('img.leaflet-tile', count: 8)
+      expect(page).to have_css('img.leaflet-tile', count: 16)
     end
   end
   scenario 'clicking map search should create a spatial search' do


### PR DESCRIPTION
Height of the results view map was bothering me. This bases height on the type of map view rather than `id`

![screen shot 2014-11-06 at 11 39 12 pm](https://cloud.githubusercontent.com/assets/1656824/4948547/297402ea-6638-11e4-8e0a-c2517e45c292.png)
