### PR TITLE
adds in message to login to view and download

### DIFF
--- a/app/views/catalog/_show_sidebar.html.erb
+++ b/app/views/catalog/_show_sidebar.html.erb
@@ -31,6 +31,8 @@
           <% end %>
         </ul>
       </div>
+    <% elsif document.restricted? && document.same_institution? %>
+      <%= link_to t('geoblacklight.tools.login_to_view'), new_user_session_path(referrer: request.original_url) %>
     <% end %>
   </div>
 </div>

--- a/config/locales/geoblacklight.en.yml
+++ b/config/locales/geoblacklight.en.yml
@@ -3,3 +3,5 @@ en:
     download:
       success: 'Your file %{title} is ready for download'
       error: 'Sorry, the requested file could not be downloaded'
+    tools:
+      login_to_view: 'Login to view and download'

--- a/lib/geoblacklight/solr_document.rb
+++ b/lib/geoblacklight/solr_document.rb
@@ -11,6 +11,10 @@ module Geoblacklight
       get(:dc_rights_s) == 'Public'
     end
 
+    def restricted?
+      get(:dc_rights_s) == 'Restricted'
+    end
+
     def downloadable?
       get(:solr_wfs_url) && get(:solr_wms_url) && available?
     end

--- a/spec/features/download_layer_spec.rb
+++ b/spec/features/download_layer_spec.rb
@@ -17,11 +17,13 @@ feature 'Download layer' do
   end
   scenario 'restricted layer should not have download available to non logged in user' do
     visit catalog_path('stanford-jf841ys4828')
+    expect(page).to have_css 'a', text: 'Login to view and download'
     expect(page).to_not have_css 'button', text: 'Download'
   end
   scenario 'restricted layer should have download available to logged in user' do
     sign_in
     visit catalog_path('stanford-jf841ys4828')
+    expect(page).to_not have_css 'a', text: 'Login to view and download'
     expect(page).to have_css 'button', text: 'Download'
   end
 end


### PR DESCRIPTION
Closes #108 

For restricted layers at parent institution
Adds in referrer as url param which can be utilized by an adopter. See: https://github.com/sul-dlss/earthworks/blob/master/app/controllers/login_controller.rb#L4
### Not logged in

![screen shot 2014-11-12 at 4 46 12 pm](https://cloud.githubusercontent.com/assets/1656824/5021515/7c4709d4-6a8b-11e4-821c-b9c736e83631.png)
### Logged in

![screen shot 2014-11-12 at 4 47 12 pm](https://cloud.githubusercontent.com/assets/1656824/5021532/91f34022-6a8b-11e4-8d06-b95723e8ed38.png)
