### PR TITLE
update style and functionality of layer opacity widget

### DIFF
--- a/app/assets/javascripts/geoblacklight/modules/layer_opacity.js
+++ b/app/assets/javascripts/geoblacklight/modules/layer_opacity.js
@@ -14,34 +14,43 @@
     },
 
     onAdd: function(map) {
-      var container = L.DomUtil.create('div', 'opacity-control'),
+      var container = L.DomUtil.create('div', 'opacity-control unselectable'),
+        controlArea = L.DomUtil.create('div', 'opacity-area', container),
         handle = L.DomUtil.create('div', 'opacity-handle', container),
-        bottom = L.DomUtil.create('div', 'oppacity-bottom', container);
+        bottom = L.DomUtil.create('div', 'opacity-bottom', container);
 
       L.DomEvent.disableClickPropagation(container);
-      this.setListeners(handle);
+      this.setListeners(handle, bottom);
+      handle.style.top = handle.offsetTop - 12 + 50 + 'px';
+      handle.innerHTML = parseInt(this.options.layer.options.opacity * 100) + '%';
       return container;
     },
 
-    setListeners: function(handle) {
+    setListeners: function(handle, bottom) {
       var _this = this,
         start = false,
         startTop;
 
       L.DomEvent.addListener(document, 'mousemove', function(e) {
         if (!start) return;
-        handle.style.top = Math.max(-5, Math.min(195, startTop + parseInt(e.clientY, 10) - start)) + 'px';
-        _this.options.layer.setOpacity(1 - (handle.offsetTop / 200));
+        var percentInverse = Math.max(0, Math.min(200, startTop + parseInt(e.clientY, 10) - start)) / 2;
+        handle.style.top = ((percentInverse * 2) - 12) + 'px';
+        handle.innerHTML = Math.round((1 - (percentInverse / 100)) * 100) + '%';
+        bottom.style.height = Math.max(0, (((100 - percentInverse) * 2) - 12)) + 'px';
+        bottom.style.top = Math.min(200, (percentInverse * 2) + 12) + 'px';
+        _this.options.layer.setOpacity(1 - (percentInverse / 100));
       });
 
       L.DomEvent.addListener(handle, 'mousedown', function(e) {
+        L.DomEvent.disableClickPropagation(e);
         start = parseInt(e.clientY, 10);
-        startTop = handle.offsetTop - 5;
+        startTop = handle.offsetTop - 12;
         return false;
       });
 
       L.DomEvent.addListener(document, 'mouseup', function(e) {
         L.DomEvent.stopPropagation(e);
+        L.DomEvent.disableClickPropagation(e);
         start = null;
       });
     }

--- a/app/assets/stylesheets/geoblacklight/modules/layer_opacity.css.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/layer_opacity.css.scss
@@ -1,34 +1,58 @@
 .leaflet-control.opacity-control {
-  background: #fff;
-  border: 1px solid #bbb;
-  -webkit-border-radius: 3px;
-  border-radius: 3px;
+  background-color: #a9acb1;
+  border-radius: 15px;
+  display: block;
   height: 200px;
-  position: absolute;
-  text-align: center;
-  top: 120px;
-  width: 28px;
-  z-index: 999;
+  left: 10px;
+  position: relative;
+  top: 15px;
+  width: 5px;
   
   .opacity-handle {
-    background: #000;
-    height: 10px;
-    left: -1px;
+    background-color: #fff;
+    border-radius: 100%;
+    cursor: ns-resize;
+    font-size: 10px;
+    height: 24px;
+    left: -10px;
+    line-height: 24px;
     position: absolute;
-    top: 20px;
-    width: 28px;
-    
-    &:hover {
-      background: #444;
-      cursor: pointer;
-      cursor: ns-resize;
-    }
+    text-align: center;
+    top: 0;
+    width: 24px;
+
+    -webkit-box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
   }
 
   .opacity-bottom {
-    bottom: 0;
-    left: 8px;
-    position: absolute;
-    text-align: center;
+    background-color: #017afd;
+    border-radius: 15px;
+    display: block;
+    height: 138px;
+    left: 0px;
+    position: relative;
+    top: 62px;
+    width: 5px;    
   }
+  
+  // Area underneath slider to prevent unintentioned map clicks
+  .opacity-area {
+    padding: 14px;
+    cursor: default;
+    height: 200px;
+    left: -12px;
+    position: absolute;
+    top: 0px;
+    width: 20px;
+  }
+}
+
+.opacity-control.unselectable {
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  -khtml-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 }


### PR DESCRIPTION
Makes opacity control more usable by setting background area and updates styling. @tcramer suggested style updates.

Closes #126 
### Before

![screen shot 2014-11-17 at 1 43 29 pm](https://cloud.githubusercontent.com/assets/1656824/5078232/caa26e98-6e5f-11e4-8320-e54359ee29f2.png)
### After

![screen shot 2014-11-17 at 1 43 37 pm](https://cloud.githubusercontent.com/assets/1656824/5078236/cf896290-6e5f-11e4-877a-2da6db674f16.png)
