### PR TITLE
Fit map to results if no bounding box is present

### DIFF
--- a/app/assets/javascripts/geoblacklight/geoblacklight.js
+++ b/app/assets/javascripts/geoblacklight/geoblacklight.js
@@ -32,9 +32,19 @@
       }
     },
 
-    initialize: function(el) {
+    options: {
+      /**
+       * Initial bounds of map
+       * @type {L.LatLngBounds}
+       */
+      bbox: [[-85, -180], [85, 180]]
+    },
+
+    initialize: function(el, options) {
       var data = $(el).data(),
           basemap, map;
+
+      L.Util.setOptions(this, options);
 
       basemap = L.tileLayer(
         'https://otile{s}-s.mqcdn.com/tiles/1.0.0/map/{z}/{x}/{y}.png', {
@@ -52,11 +62,8 @@
       map.addLayer(basemap);
       map.addLayer(this.overlay);
 
-      if (typeof data['mapBbox'] === "string") {
-        map.fitBounds(L.bboxToBounds(data.mapBbox));
-      } else {
-        map.setView([0,0], 2);
-      }
+      map.fitBounds(this.options.bbox);
+
     },
 
     /**

--- a/app/assets/javascripts/geoblacklight/modules/item.js
+++ b/app/assets/javascripts/geoblacklight/modules/item.js
@@ -1,13 +1,14 @@
 Blacklight.onLoad(function() {
   $('[data-map="item"]').each(function(i, element) {
-    var layerMap = new GeoBlacklight.Item(element);
+    var bbox = L.bboxToBounds($(this).data().mapBbox);
+    new GeoBlacklight.Item(element, { bbox: bbox });
   });
 });
 
 GeoBlacklight.Item = GeoBlacklight.extend({
 
-  initialize: function(element) {
-    GeoBlacklight.prototype.initialize.call(this, element);
+  initialize: function(element, options) {
+    GeoBlacklight.prototype.initialize.call(this, element, options);
     this.dataAttributes = $(element).data();
     this.layer = new L.layerGroup().addTo(this.map);
     if (this.dataAttributes.available) {

--- a/app/assets/javascripts/geoblacklight/modules/results.js
+++ b/app/assets/javascripts/geoblacklight/modules/results.js
@@ -7,12 +7,24 @@ Blacklight.onLoad(function() {
 
   $('[data-map="index"]').each(function() {
     var data = $(this).data(),
-        dynamicSearcher, geoblacklight, search;
+        dynamicSearcher, geoblacklight, search, bbox;
+
+    if (typeof data.mapBbox === "string") {
+      bbox = L.bboxToBounds(data.mapBbox);
+    } else {
+      $('.document [data-bbox]').each(function() {
+        if (typeof bbox === "undefined") {
+          bbox = L.bboxToBounds($(this).data().bbox);
+        } else {
+          bbox.extend(L.bboxToBounds($(this).data().bbox));
+        }
+      });
+    }
 
     dynamicSearcher = GeoBlacklight.debounce(function(querystring) {
       History.pushState(null, null, data.catalogPath + '?' + querystring);
     }, 800);
-    geoblacklight = new GeoBlacklight(this).setHoverListeners();
+    geoblacklight = new GeoBlacklight(this, { bbox: bbox }).setHoverListeners();
     search = new L.Control.GeoSearch(dynamicSearcher);
     geoblacklight.map.addControl(search);
   });

--- a/spec/features/home_page_spec.rb
+++ b/spec/features/home_page_spec.rb
@@ -21,7 +21,7 @@ feature 'Home page', js: true do # use js: true for tests which require js, but 
   scenario 'map should be visible' do
     within '#main-container' do
       expect(page).to have_css('#map')
-      expect(page).to have_css('img.leaflet-tile', count: 4)
+      expect(page).to have_css('img.leaflet-tile', minimum: 3)
     end
   end
   scenario 'clicking map search should create a spatial search' do


### PR DESCRIPTION
Adds an optional options argument to the GeoBlacklight function. The
bbox property can be used to set the initial map view. Fixes #98.
