### PR TITLE
update generator to enable blacklight_range_limit by default

### DIFF
--- a/lib/generators/geoblacklight/templates/geoblacklight.css.scss
+++ b/lib/generators/geoblacklight/templates/geoblacklight.css.scss
@@ -1,3 +1,4 @@
 /*
 *= require geoblacklight/application
+*= require blacklight_range_limit
 */

--- a/lib/generators/geoblacklight/templates/geoblacklight.js
+++ b/lib/generators/geoblacklight/templates/geoblacklight.js
@@ -1,1 +1,2 @@
 //= require geoblacklight/application
+//= require blacklight_range_limit

--- a/lib/geoblacklight/engine.rb
+++ b/lib/geoblacklight/engine.rb
@@ -5,6 +5,7 @@ require 'httparty'
 require 'font-awesome-rails'
 require 'rails_config'
 require 'faraday'
+require 'blacklight_range_limit'
 
 module Geoblacklight
   class Engine < ::Rails::Engine


### PR DESCRIPTION
Enables blacklight_range_limit for generated app

![screen shot 2014-11-25 at 2 47 52 pm](https://cloud.githubusercontent.com/assets/1656824/5193074/27ba5b92-74b2-11e4-8b74-967039c33361.png)
