### PR TITLE
adds in simple wms reflector download for rasters

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -20,6 +20,7 @@ desc "Load fixtures"
 task :fixtures => ['engine_cart:generate'] do
   EngineCart.within_test_app do
     system "rake geoblacklight:solr:seed RAILS_ENV=test"
+    system 'rake geoblacklight:downloads:mkdir'
   end
 end
 

--- a/app/controllers/download_controller.rb
+++ b/app/controllers/download_controller.rb
@@ -29,6 +29,8 @@ class DownloadController < ApplicationController
       response = KmzDownload.new(@document).get
     when 'geojson'
       response = GeojsonDownload.new(@document).get
+    when 'geotiff'
+      response = GeotiffDownload.new(@document).get
     end
     response
   end

--- a/lib/geoblacklight.rb
+++ b/lib/geoblacklight.rb
@@ -4,13 +4,15 @@ module Geoblacklight
   require 'geoblacklight/config'
   require 'geoblacklight/constants'
   require 'geoblacklight/controller_override'
+  require 'geoblacklight/exceptions'
   require 'geoblacklight/view_helper_override'
   require 'geoblacklight/solr_document'
   require 'geoblacklight/wms_layer'
   require 'geoblacklight/download'
-  require 'geoblacklight/download/shapefile_download'
   require 'geoblacklight/download/geojson_download'
+  require 'geoblacklight/download/geotiff_download'
   require 'geoblacklight/download/kmz_download'
+  require 'geoblacklight/download/shapefile_download'
   require 'geoblacklight/reference'
   require 'geoblacklight/references'
   def self.inject!
@@ -22,5 +24,9 @@ module Geoblacklight
       SearchHistoryController.helpers.is_a?(Geoblacklight::ViewHelperOverride)
     SavedSearchesController.send(:helper, Geoblacklight::ViewHelperOverride) unless
       SavedSearchesController.helpers.is_a?(Geoblacklight::ViewHelperOverride)
+  end
+
+  def self.logger
+    ::Rails.logger
   end
 end

--- a/lib/geoblacklight/download/geotiff_download.rb
+++ b/lib/geoblacklight/download/geotiff_download.rb
@@ -1,0 +1,18 @@
+class GeotiffDownload < Download
+  GEOTIFF_DOWNLOAD_PARAMS = {
+    format: 'image/geotiff',
+    width: 4096
+  }
+
+  def initialize(document)
+    request_params = GEOTIFF_DOWNLOAD_PARAMS.merge(layers: document[:layer_id_s])
+    super(document, {
+      type: 'geotiff',
+      extension: 'tif',
+      request_params: request_params,
+      content_type: 'image/geotiff',
+      service_type: 'wms',
+      reflect: true
+    })
+  end
+end

--- a/lib/geoblacklight/exceptions.rb
+++ b/lib/geoblacklight/exceptions.rb
@@ -1,0 +1,6 @@
+module Geoblacklight
+  module Exceptions
+    class WrongDownloadFormat < StandardError
+    end
+  end
+end

--- a/lib/geoblacklight/references.rb
+++ b/lib/geoblacklight/references.rb
@@ -43,6 +43,8 @@ module Geoblacklight
       case format
       when 'Shapefile'
         { shapefile: wfs.to_hash, kmz: wms.to_hash, geojson: wfs.to_hash }
+      when 'GeoTIFF'
+        { geotiff: wms.to_hash } if wms.present?
       end
     end
 

--- a/lib/tasks/geoblacklight.rake
+++ b/lib/tasks/geoblacklight.rake
@@ -24,5 +24,9 @@ namespace :geoblacklight do
     task delete: :environment do
       FileUtils.rm_rf Dir.glob("#{Rails.root}/tmp/cache/downloads/*")
     end
+    desc 'Create download directory'
+    task mkdir: :environment do
+      FileUtils.mkdir_p Dir.glob("#{Rails.root}/tmp/cache/downloads")
+    end
   end
 end

--- a/spec/lib/geoblacklight/download/geotiff_download_spec.rb
+++ b/spec/lib/geoblacklight/download/geotiff_download_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe GeotiffDownload do
+  let(:document) { SolrDocument.new(layer_slug_s: 'test', layer_id_s: 'stanford-test', solr_bbox: '-180 -90 180 90') }
+  let(:download) { GeotiffDownload.new(document) }
+  describe '#initialize' do
+    it 'should initialize as a GeotiffDownload object with specific options' do
+      expect(download).to be_an GeotiffDownload
+      options = download.instance_variable_get(:@options)
+      expect(options[:content_type]).to eq 'image/geotiff'
+      expect(options[:request_params][:layers]).to eq 'stanford-test'
+      expect(options[:reflect]).to be_truthy
+    end
+  end
+end

--- a/spec/lib/geoblacklight/download_spec.rb
+++ b/spec/lib/geoblacklight/download_spec.rb
@@ -42,14 +42,14 @@ describe Download do
       expect(download).to receive(:download_exists?).and_return(false)
       expect(download).to receive(:initiate_download).and_return('')
       expect(File).to receive(:open).with("#{download.file_path}.tmp", 'wb').and_return('')
-      expect(File).to receive(:delete).with("#{download.file_path}.tmp").and_return(nil)
-      expect(download.get).to eq nil
+      expect(File).to receive(:rename)
+      expect(download.get).to eq 'test-shapefile.zip'
     end
   end
   describe '#create_download_file' do
     it 'should create the file in fs and delete it if the content headers are not correct' do
-      expect(download).to receive(:initiate_download).and_return('')
-      expect(File).to receive(:open).with("#{download.file_path}.tmp", 'wb').and_return('')
+      bad_file = OpenStruct.new(headers: { 'content-type' => 'bad/file' })
+      expect(download).to receive(:initiate_download).and_return(bad_file)
       expect(File).to receive(:delete).with("#{download.file_path}.tmp").and_return(nil)
       expect(download.create_download_file).to eq nil
     end


### PR DESCRIPTION
Closes #178 

Similar to kendallite application. Sets default width, but this could be configurable later on. Also has a better way to catch errors for the downloads.
