### PR TITLE
Make dynamic search configurable

### DIFF
--- a/app/assets/javascripts/geoblacklight/modules/home.js
+++ b/app/assets/javascripts/geoblacklight/modules/home.js
@@ -1,11 +1,14 @@
 Blacklight.onLoad(function () {
   $('[data-map="home"]').each(function(i, element) {
     var geoblacklight = new GeoBlacklight(this),
-        data = $(this).data(),
-        search;
-    search = new L.Control.GeoSearch(function(querystring) {
-      this.link.href = data.catalogPath + '?' + querystring;
-    }, { button: true });
-    geoblacklight.map.addControl(search);
+        data = $(this).data();
+    geoblacklight.map.addControl(L.control.geosearch({
+      baseUrl: data.catalogPath,
+      dynamic: false,
+      searcher: function() {
+        window.location.href = this.getSearchUrl();
+      },
+      staticButton: '<a class="btn btn-primary">Search Here</a>'
+    }));
   });
 });

--- a/app/assets/stylesheets/geoblacklight/_geoblacklight.css.scss
+++ b/app/assets/stylesheets/geoblacklight/_geoblacklight.css.scss
@@ -20,3 +20,4 @@
 @import 'modules/item';
 @import 'modules/layer_opacity';
 @import 'modules/results';
+@import 'modules/geosearch';

--- a/app/assets/stylesheets/geoblacklight/modules/geosearch.css.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/geosearch.css.scss
@@ -1,0 +1,29 @@
+.search-control {
+  background-color: #FFF;
+  border-radius: 4px;
+  box-shadow: 0 1px 5px rgba(0,0,0,0.65);
+}
+
+.search-control a {
+  color: #FFF
+}
+
+.search-control label {
+  margin: 6px 12px;
+  font-size: 14px;
+  display: block;
+  padding-left: 15px;
+  text-indent: -15px;
+  font-weight: normal;
+  cursor: pointer;
+}
+
+.search-control input[type="checkbox"] {
+  width: 13px;
+  height: 13px;
+  padding: 0;
+  margin: 0;
+  vertical-align: middle;
+  position: relative;
+  top: -1px;
+}

--- a/spec/features/home_page_spec.rb
+++ b/spec/features/home_page_spec.rb
@@ -26,9 +26,8 @@ feature 'Home page', js: true do # use js: true for tests which require js, but 
     end
   end
   scenario 'clicking map search should create a spatial search' do
-    find('#map').double_click
     within '#map' do
-      find('a.search-control').click
+      find('.search-control a').click
       expect(page.current_url).to match /bbox=/
     end
     expect(page).to have_css '#documents'

--- a/spec/features/saved_searches_spec.rb
+++ b/spec/features/saved_searches_spec.rb
@@ -3,9 +3,8 @@ require 'spec_helper'
 feature 'saved searches' do
   scenario 'list spatial search', js: true do
     visit root_path
-    find('#map').double_click
     within '#map' do
-      find('a.search-control').click
+      find('.search-control a').click
       expect(page.current_url).to match /bbox=/
     end
     visit search_history_path


### PR DESCRIPTION
Addresses #150. This pull request will also force browsers that don't support the history API (notably, IE 9) into the static search behavoir.

I don't know if there was consensus or not on what the buttons should be named. I have no strong opinion one way or another. Consider their labels in this PR a placeholder.
