### PR TITLE
adds convenience method to SolrDocument to access endpoint url without h...

### DIFF
--- a/app/assets/javascripts/geoblacklight/modules/item.js
+++ b/app/assets/javascripts/geoblacklight/modules/item.js
@@ -11,7 +11,7 @@ GeoBlacklight.Item = GeoBlacklight.extend({
     GeoBlacklight.prototype.initialize.call(this, element, options);
     this.dataAttributes = $(element).data();
     this.layer = new L.layerGroup().addTo(this.map);
-    if (this.dataAttributes.available) {
+    if (this.dataAttributes.available && this.dataAttributes.wmsUrl !== null) {
       this.addPreviewLayer();
       this.addOpacityControl();
     } else {

--- a/app/views/catalog/_show_default.html.erb
+++ b/app/views/catalog/_show_default.html.erb
@@ -4,7 +4,7 @@
 
 <div class='row'>
   <div class="col-md-8">
-    <%= content_tag :div, id: 'map', data: { map: 'item', 'catalog-path'=> catalog_index_path , 'map-bbox' => document[:solr_bbox], 'layer-id' => document[:layer_id_s], 'wms-url' => document.references.wms.endpoint, available: document_available? } do %>
+    <%= content_tag :div, id: 'map', data: { map: 'item', 'catalog-path'=> catalog_index_path , 'map-bbox' => document[:solr_bbox], 'layer-id' => document[:layer_id_s], 'wms-url' => document.wms_url, available: document_available? } do %>
     <% end %>
   </div>
   <div id='table-container' class='col-md-4'><div id='attribute-table' ></div></div>

--- a/lib/geoblacklight/solr_document.rb
+++ b/lib/geoblacklight/solr_document.rb
@@ -38,5 +38,25 @@ module Geoblacklight
     def itemtype
       "http://schema.org/Dataset"
     end
+
+    ##
+    # Provides a convenience method to access a SolrDocument's References
+    # endpoint url without having to check and see if it is available
+    # :type => a string which if its a Geoblacklight::Constants::URI key
+    #          will return a coresponding Geoblacklight::Reference
+    def checked_endpoint(type)
+      type = references.send(type)
+      type.endpoint if type.present?
+    end
+
+    private
+
+    def method_missing(method, *args, &block)
+      if /.*_url$/ =~ method.to_s
+        checked_endpoint(method.to_s.gsub('_url', ''))
+      else
+        super
+      end
+    end
   end
 end

--- a/spec/lib/geoblacklight/solr_document_spec.rb
+++ b/spec/lib/geoblacklight/solr_document_spec.rb
@@ -86,4 +86,26 @@ describe Geoblacklight::SolrDocument do
       expect(document.direct_download).to be_nil
     end
   end
+  describe 'checked_endpoint' do
+    let(:document_attributes) { {} }
+    let(:reference) { Geoblacklight::Reference.new(['http://www.opengis.net/def/serviceType/ogc/wms', 'http://www.example.com/wms']) }
+    it 'returns endpoint if available' do
+      expect_any_instance_of(Geoblacklight::References).to receive(:wms).and_return(reference)
+      expect(document.checked_endpoint('wms')).to eq 'http://www.example.com/wms'
+    end
+    it 'return nil if not available' do
+      expect_any_instance_of(Geoblacklight::References).to receive(:wms).and_return(nil)
+      expect(document.checked_endpoint('wms')).to be_nil
+    end
+  end
+  describe 'method_missing' do
+    let(:document_attributes) { {} }
+    it 'calls checked_endpoint with parsed method name if matches' do
+      expect(document).to receive(:checked_endpoint).with('wms').and_return(nil)
+      expect(document.wms_url).to be_nil
+    end
+    it 'raises no method error' do
+      expect { document.wms_urlz }.to raise_error NoMethodError
+    end
+  end
 end


### PR DESCRIPTION
...aving to check it

Fixes an issue where if the `Reference` returns as nil the endpoint method is not called on it (in a show page).

Also checks in JS whether or not that the wmsurl is there.
