### PR TITLE
subs spaces for hyphens in geomtype icon

### DIFF
--- a/app/helpers/geoblacklight_helper.rb
+++ b/app/helpers/geoblacklight_helper.rb
@@ -41,7 +41,7 @@ module GeoblacklightHelper
   end
 
   def layer_type_image(type)
-    content_tag :span, '', class: "geoblacklight-icon geoblacklight-#{type.downcase}"
+    content_tag :span, '', class: "geoblacklight-icon geoblacklight-#{type.downcase.gsub(' ', '-')}"
   end
 
   def layer_institution_image(institution)

--- a/spec/helpers/geoblacklight_helpers_spec.rb
+++ b/spec/helpers/geoblacklight_helpers_spec.rb
@@ -13,4 +13,10 @@ describe GeoblacklightHelper do
       expect(html).to have_css 'a', text: 'Science', count: 1
     end
   end
+  describe '#layer_type_image' do
+    it 'lowercases and subs spaces for hyphens' do
+      html = Capybara.string(layer_type_image('TEst 123'))
+      expect(html).to have_css '.geoblacklight-test-123'
+    end
+  end
 end


### PR DESCRIPTION
This now enables `paper-map` icon
