### PR TITLE
allow Faraday timeouts to be configurable, better exception reporting

### DIFF
--- a/app/assets/javascripts/geoblacklight/viewers/wms.js
+++ b/app/assets/javascripts/geoblacklight/viewers/wms.js
@@ -54,7 +54,7 @@ GeoBlacklight.Viewer.Wms = GeoBlacklight.Viewer.Map.extend({
         url: '/wms/handle',
         data: wmsoptions,
         success: function(data) {
-          if (data.hasOwnProperty('error')) {
+          if (data.hasOwnProperty('error') || data.values.length === 0) {
             $('.attribute-table-body').html('<tbody class="attribute-table-body"><tr><td colspan="2">Could not find that feature</td></tr></tbody>');
             return;
           }

--- a/lib/generators/geoblacklight/templates/settings.yml
+++ b/lib/generators/geoblacklight/templates/settings.yml
@@ -1,4 +1,13 @@
+# Institution deployed at
 INSTITUTION: 'Stanford'
+
+# (For external Download) timeout and open_timeout parameters for Faraday
+TIMEOUT_DOWNLOAD: 16
+
+# (For WMS inspection) timeout and open_timeout parameters for Faraday
+TIMEOUT_WMS: 4
+
+# WMS Parameters
 WMS_PARAMS:
   :SERVICE: 'WMS'
   :VERSION: '1.1.1'

--- a/lib/geoblacklight/exceptions.rb
+++ b/lib/geoblacklight/exceptions.rb
@@ -1,5 +1,7 @@
 module Geoblacklight
   module Exceptions
+    class ExternalDownloadFailed < StandardError
+    end
     class WrongDownloadFormat < StandardError
     end
   end

--- a/lib/geoblacklight/wms_layer.rb
+++ b/lib/geoblacklight/wms_layer.rb
@@ -25,14 +25,16 @@ class WmsLayer
       conn.get do |request|
         request.params = search_params
         request.options = {
-          timeout: 2,
-          open_timeout: 2
+          timeout: Settings.TIMEOUT_WMS,
+          open_timeout: Settings.TIMEOUT_WMS
         }
       end
     rescue Faraday::Error::ConnectionFailed => error
-      { error: error }
+      Geoblacklight.logger.error error.inspect
+      { error: error.inspect }
     rescue Faraday::Error::TimeoutError => error
-      { error: error }
+      Geoblacklight.logger.error error.inspect
+      { error: error.inspect }
     end
   end
 end

--- a/spec/lib/geoblacklight/download_spec.rb
+++ b/spec/lib/geoblacklight/download_spec.rb
@@ -40,7 +40,7 @@ describe Download do
     end
     it 'should call create_download_file if it does not exist' do
       expect(download).to receive(:download_exists?).and_return(false)
-      expect(download).to receive(:initiate_download).and_return('')
+      expect(download).to receive(:initiate_download).and_return(object: 'file')
       expect(File).to receive(:open).with("#{download.file_path}.tmp", 'wb').and_return('')
       expect(File).to receive(:rename)
       expect(download.get).to eq 'test-shapefile.zip'


### PR DESCRIPTION
Allows needed timeout configuration for downloads and feature inspection.

Closes #117 
