### PR TITLE
[Proposal] move some documentation back to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,39 @@ of the Blacklight Solr-powered discovery interface and the
 multi-institutional OpenGeoportal federated metadata sharing
 communities. We're actively looking for community input and development partners.
 
-View documentation on our [Wiki](https://github.com/geoblacklight/geoblacklight/wiki)
+###[Installation](https://github.com/geoblacklight/geoblacklight/wiki/Installation)
+
+Creating a new GeoBlacklight application from the template
+
+```
+$ rails new app-name -m https://raw.githubusercontent.com/geoblacklight/geoblacklight/master/template.rb
+```
+
+To install Solr (with Jetty)
+
+```
+$ cd app-name
+$ rake jetty:download
+$ rake jetty:unzip
+$ rake geoblacklight:configure_jetty
+```
+
+Or install with [Docker](https://github.com/geoblacklight/geoblacklight-docker)
+For more information see the [installation guide](https://github.com/geoblacklight/geoblacklight/wiki/Installation)
+
+###[Contributing](https://github.com/geoblacklight/geoblacklight/wiki/Contributing)
+
+1. Fork it ( http://github.com/my-github-username/geoblacklight/fork )
+2. Create your feature branch (`git checkout -b my-new-feature`)
+3. Commit your changes (`git commit -am 'Add some feature'`)
+4. Push to the branch (`git push origin my-new-feature`)
+5. Create new Pull Request
+
+Also, if you wish to ask questions or participate further, email the [GeoBlacklight Working Group](https://groups.google.com/forum/#!forum/geoblacklight-working-group) at [geoblacklight-working-group@googlegroups.com](mailto:geoblacklight-working-group@googlegroups.com).
+
+###[Development](https://github.com/geoblacklight/geoblacklight/wiki/Development)
+
+See the [development guide](https://github.com/geoblacklight/geoblacklight/wiki/Development) on our wiki for more information about setting up your development environment.
+
+
+Please see the full documentation hosted on our Wiki [Wiki](https://github.com/geoblacklight/geoblacklight/wiki)


### PR DESCRIPTION
I felt like the homepage readme was a little empty without having some documentation, and it seems like on the Blacklight email list, the wiki pages can be hard to find and navigate. Adopters will often comment about having difficulty finding things on the wiki and I wanted to make it as easy as possible for someone to get going.

Adding some documentation back to main Readme and linking through to the various documentation pages.

Thoughts?
