### PR TITLE
adds more information to download data attributes

### DIFF
--- a/app/controllers/download_controller.rb
+++ b/app/controllers/download_controller.rb
@@ -57,7 +57,7 @@ class DownloadController < ApplicationController
     if response.nil?
       flash[:danger] = t 'geoblacklight.download.error'
     else
-      flash[:success] = view_context.link_to(t('geoblacklight.download.success', title: response), download_file_path(response))
+      flash[:success] = view_context.link_to(t('geoblacklight.download.success', title: response), download_file_path(response), data: { download: 'trigger', download_id: params[:id], download_type: "generated-#{params[:type]}"})
     end
   end
 

--- a/app/views/catalog/_show_sidebar.html.erb
+++ b/app/views/catalog/_show_sidebar.html.erb
@@ -18,13 +18,13 @@
       <% if document_downloadable? %>
         <div class='btn-group' itemprop='distribution' itemscope='itemscope' itemtype='http://schema.org/DataDownload'>
           <% if document.direct_download.present? %>
-            <%= link_to(download_text(@document[:dc_format_s]), document.direct_download[:download], class: 'btn btn-default', 'contentUrl' => document.direct_download[:download]) %>
+            <%= link_to(download_text(@document[:dc_format_s]), document.direct_download[:download], class: 'btn btn-default', 'contentUrl' => document.direct_download[:download], data: { download: 'trigger', download_type: 'direct', download_id: document[:layer_slug_s] }) %>
           <% elsif document.hgl_download.present? %>
             <%= link_to(download_text(document.download_types.first[0]),
-                download_hgl_path(id: document), data: {ajax_modal: 'trigger'},
+                download_hgl_path(id: document), data: {ajax_modal: 'trigger', download: 'trigger', download_type: 'harvard-hgl', download_id: document[:layer_slug_s] },
                 class: 'btn btn-default') %>
           <% else %>
-            <%= link_to(download_text(document.download_types.first[0]), '', data: { download_path: "#{download_path(document[:layer_slug_s], type: document.download_types.first[0])}"}, class: 'btn btn-default') %>
+            <%= link_to(download_text(document.download_types.first[0]), '', data: { download_path: "#{download_path(document[:layer_slug_s], type: document.download_types.first[0])}", download: 'trigger', download_type: document.download_types.first[0], download_id: document[:layer_slug_s] }, class: 'btn btn-default') %>
           <% end %>
           <button type='button' class='btn btn-default dropdown-toggle download-dropdown-toggle' data-toggle='dropdown' aria-expanded='false'>
             <span class='caret'></span>
@@ -35,20 +35,20 @@
               <li role="presentation" class="dropdown-header">Original</li>
               <li>
                 <%= link_to(download_text(document.download_types.first[0]),
-                download_hgl_path(id: document), data: {ajax_modal: 'trigger'}) %>
+                download_hgl_path(id: document), data: {ajax_modal: 'trigger', download: 'trigger', download_type: 'harvard-hgl', download_id: document[:layer_slug_s] }) %>
               </li>
             <% else %>
               <% if document.direct_download.present? %>
                 <li role="presentation" class="dropdown-header">Original</li>
                 <li>
-                  <%= link_to(download_text(@document[:dc_format_s]), document.direct_download[:download], 'contentUrl' => document.direct_download[:download]) %>
+                  <%= link_to(download_text(@document[:dc_format_s]), document.direct_download[:download], 'contentUrl' => document.direct_download[:download], data: { download: 'trigger', download_type: 'direct', download_id: document[:layer_slug_s] }) %>
                 </li>
               <% end %>
               <% if document.download_types.present? %>
                 <li role="presentation" class="dropdown-header">Generated</li>
                 <% document.download_types.each do |type| %>
                   <%= content_tag(:li) do %>
-                    <% link_to(download_text(type[0]), '', data: { download_path: "#{download_path(document[:layer_slug_s], type: type[0])}" }) %>
+                    <% link_to(download_text(type[0]), '', data: { download_path: "#{download_path(document[:layer_slug_s], type: type[0])}", download: 'trigger', download_type: type[0], download_id: document[:layer_slug_s] }) %>
                   <% end %>
                 <% end %>
               <% end %>


### PR DESCRIPTION
Adds several data attributes to download links to better enable analytics.

Adds the following:
- `data-download="trigger"` general selector to help with adding events
- `data-download-id="id-of-layer"` institutuion-abc123
- `data-download-type="type of download"` geojson, shapefile, geotiff, harvard-hgl, generated-geotiff, etc
