### PR TITLE
fixes search bar display on homepage

### DIFF
--- a/app/assets/stylesheets/geoblacklight/modules/home.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/home.scss
@@ -3,7 +3,15 @@
 }
 
 .home-search-area {
-  text-align: center;
+  
+  h2,
+  h3 {
+    text-align: center;
+  }
+  
+  .input-group.search-input-group {
+    width: 100%;
+  }
 }
 
 .home-facet-link {

--- a/app/helpers/geoblacklight_helper.rb
+++ b/app/helpers/geoblacklight_helper.rb
@@ -36,6 +36,10 @@ module GeoblacklightHelper
     content_tag :span, '', class: "geoblacklight-icon geoblacklight-#{name.downcase.gsub(' ', '-')}", title: name
   end
 
+  def render_search_form_no_navbar
+    render partial: 'catalog/search_form_no_navbar'
+  end
+
   ##
   # Renders an unique array of search links based off of terms
   # passed in using the facet parameter

--- a/app/views/catalog/_home_text.html.erb
+++ b/app/views/catalog/_home_text.html.erb
@@ -2,7 +2,9 @@
   <div class='home-search-area'>
     <%= content_tag :h2, t('geoblacklight.home.headline') %>
     <%= content_tag :h3, t('geoblacklight.home.search_heading') %>
-    <%= render_search_bar %>
+    <div class='col-md-6 col-md-offset-3'>
+      <%= render_search_form_no_navbar %>
+    </div>
   </div>
 </div>
 

--- a/app/views/catalog/_search_form_no_navbar.html.erb
+++ b/app/views/catalog/_search_form_no_navbar.html.erb
@@ -1,0 +1,20 @@
+<%= form_tag search_action_url, :method => :get, :class => 'search-query-form clearfix' do %>
+<%= render_hash_as_hidden_fields(params_for_search().except(:q, :search_field, :qt, :page, :utf8)) %>
+
+<% unless search_fields.empty? %>
+<label for="search_field" class="sr-only"><%= t('blacklight.search.form.search_field.label') %></label>
+<%= select_tag(:search_field, options_for_select(search_fields, h(params[:search_field])), :title => t('blacklight.search.form.search_field.title'), :class=>"search_field form-control") %>
+<span class="sr-only"><%= t('blacklight.search.form.search_field.post_label') %></span>
+<% end %>
+<div class="input-group search-input-group">
+  <label for="q" class="sr-only"><%= t('blacklight.search.form.q') %></label>
+  <%= text_field_tag :q, params[:q], :placeholder => t('blacklight.search.form.q'), :class => "search_q q form-control", :id => "q", :autofocus => should_autofocus_on_search_box? %>
+  
+  <span class="input-group-btn">
+    <button type="submit" class="btn btn-primary search-btn" id="search">
+      <span class="submit-search-text"><%=t('blacklight.search.form.submit')%></span>
+      <span class="glyphicon glyphicon-search"></span>
+    </button>
+  </span>
+</div>
+<% end %>


### PR DESCRIPTION
After Blacklight 5.8.2 update search bar on home page was displaying incorrectly, this fixes it.