### PR TITLE
add rails-assets as gem source

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -2,6 +2,8 @@ gem 'blacklight'
 gem 'geoblacklight', github: 'geoblacklight/geoblacklight'
 gem 'jettywrapper'
 
+add_source "https://rails-assets.org"
+
 run 'bundle install'
 
 generate 'blacklight:install', '--devise'


### PR DESCRIPTION
Need to add rails-assets gem source so bundle install can run without errors. Closes #254 