### PR TITLE
enables show field configuration in CatalogController

### DIFF
--- a/app/helpers/geoblacklight_helper.rb
+++ b/app/helpers/geoblacklight_helper.rb
@@ -65,4 +65,15 @@ module GeoblacklightHelper
   def show_attribute_table?
     return true if document_available? && @document.viewer_protocol == 'wms'
   end
+
+  ##
+  # Render value for a document's field as a truncate abstract
+  # div. Arguments come from Blacklight::DocumentPresenter's
+  # get_field_values method
+  # @param [Hash] args from get_field_values
+  def render_value_as_truncate_abstract(args)
+    content_tag :div, class: 'truncate-abstract' do
+      args[:value]
+    end
+  end
 end

--- a/app/views/catalog/_abstract_metadata.html.erb
+++ b/app/views/catalog/_abstract_metadata.html.erb
@@ -1,8 +1,0 @@
-<% if @document['dc_description_s'].present? %>
-  <dt>Description</dt>
-  <dd itemprop="description">
-    <div class='truncate-abstract'>
-      <%= @document['dc_description_s'] %>
-    </div>
-  </dd>
-<% end %>

--- a/app/views/catalog/_upper_metadata.html.erb
+++ b/app/views/catalog/_upper_metadata.html.erb
@@ -1,45 +1,19 @@
 <% document ||= @document %>
 <div class="geoblacklight-view-panel">
-
+  
+  <%# From https://github.com/projectblacklight/blacklight/blob/master/app/views/catalog/_show_default.html.erb %>
+  <%# default partial to display solr document fields in catalog show view -%>
   <dl class="dl-horizontal">
-    <% if document['dc_creator_sm'].present? %>
-      <dt>Authors</dt>
-      <dd itemprop="author"><%= document['dc_creator_sm'].join(', ') %>&nbsp;</dd>
+    <%# render 'abstract_metadata' %>
+    <% document_show_fields(document).each do |solr_fname, field| %>
+      <% if should_render_show_field? document, field %>
+        <dt class="blacklight-<%= solr_fname.parameterize %>"><%= render_document_show_field_label document, field: solr_fname %></dt>
+        <dd class="blacklight-<%= solr_fname.parameterize %>"><%= render_document_show_field_value document, field: solr_fname %></dd>
+      <% end %>
     <% end %>
-    <%= render 'abstract_metadata' %>
-    <% if document['dc_publisher_s'].present? %>
-      <dt>Publishers</dt>
-      <dd itemprop="publisher"><%= document['dc_publisher_s'] %>&nbsp;
-          <% if document['dct_issued_s'].present? %>
-            <span itemprop="datePublished">
-                (<%= document['dct_issued_s'] %>)
-            </span>
-          <% end %>       
-      </dd>
-    <% end %>
-    <% if document['dct_isPartOf_sm'].present? %>
-      <dt>Collections</dt>
-      <dd itemprop="isPartOf"><%= document['dct_isPartOf_sm'].sort.uniq.join(', ') %>&nbsp;</dd>
-    <% end %>
-    <% if document['dct_spatial_sm'].present? %>
-      <dt>Places</dt>
-      <dd itemprop="spatial"><%= render_facet_links('dct_spatial_sm', document['dct_spatial_sm']) %>&nbsp;</dd>
-    <% end %>
-    <% if document['dc_subject_sm'].present? %>
-      <dt>Subjects</dt>
-      <dd itemprop="keywords"><%= render_facet_links('dc_subject_sm', document['dc_subject_sm']) %>&nbsp;</dd>
-    <% end %>
-    <% if document['dct_temporal_sm'].present? %>
-      <dt>Years</dt>
-      <dd itemprop="temporal"><%= document['dct_temporal_sm'].sort.uniq.join(', ') %>&nbsp;</dd>
-    <% end %>
-    <% if document['dct_provenance_s'].present? %>
-      <dt>Held by</dt>
-      <dd><%= document['dct_provenance_s'] %></dd>
-    <% end %>      
     <% if !@document.references.nil? && !@document.references.url.nil? %>
-       <dt>More details at</dt>
-       <dd itemprop="url"><%= link_to @document.references.url.endpoint, @document.references.url.endpoint %></dd>
+      <dt>More details at</dt>
+      <dd itemprop="url"><%= link_to @document.references.url.endpoint, @document.references.url.endpoint %></dd>
     <% end %>
   </dl>
 </div>

--- a/lib/generators/geoblacklight/templates/catalog_controller.rb
+++ b/lib/generators/geoblacklight/templates/catalog_controller.rb
@@ -111,22 +111,19 @@ class CatalogController < ApplicationController
 
 
     # solr fields to be displayed in the show (single result) view
-    #   The ordering of the field names is the order of the display
-    # config.add_show_field 'dc_title_t', :label => 'Title:'
-    # config.add_show_field 'title_display', :label => 'Title:'
-    # config.add_show_field 'title_vern_display', :label => 'Title:'
-    # config.add_show_field 'subtitle_display', :label => 'Subtitle:'
-    # config.add_show_field 'subtitle_vern_display', :label => 'Subtitle:'
-    # config.add_show_field 'author_display', :label => 'Author:'
-    # config.add_show_field 'author_vern_display', :label => 'Author:'
-    # config.add_show_field 'format', :label => 'Format:'
-    # config.add_show_field 'url_fulltext_display', :label => 'URL:'
-    # config.add_show_field 'url_suppl_display', :label => 'More Information:'
-    # config.add_show_field 'language_facet', :label => 'Language:'
-    # config.add_show_field 'published_display', :label => 'Published:'
-    # config.add_show_field 'published_vern_display', :label => 'Published:'
-    # config.add_show_field 'lc_callnum_display', :label => 'Call number:'
-    # config.add_show_field 'isbn_t', :label => 'ISBN:'
+    #  The ordering of the field names is the order of the display
+    #
+    # item_prop: [String] property given to span with Schema.org item property
+    # link_to_search: [Boolean] that can be passed to link to a facet search
+    # helper_method: [Symbol] method that can be used to render the value
+    config.add_show_field 'dc_creator_sm', label: 'Author(s)', itemprop: 'author'
+    config.add_show_field 'dc_description_s', label: 'Description', itemprop: 'description', helper_method: :render_value_as_truncate_abstract
+    config.add_show_field 'dc_publisher_s', label: 'Publisher', itemprop: 'publisher'
+    config.add_show_field 'dct_isPartOf_sm', label: 'Collection', itemprop: 'isPartOf'
+    config.add_show_field 'dct_spatial_sm', label: 'Place(s)', itemprop: 'spatial', link_to_search: true
+    config.add_show_field 'dc_subject_sm', label: 'Subject(s)', itemprop: 'keywords', link_to_search: true
+    config.add_show_field 'dct_temporal_sm', label: 'Year', itemprop: 'temporal'
+    config.add_show_field 'dct_provenance_s', label: 'Held by', link_to_search: true
 
     # "fielded" search configuration. Used by pulldown among other places.
     # For supported keys in hash, see rdoc for Blacklight::SearchFields

--- a/spec/features/show_page_metadata_spec.rb
+++ b/spec/features/show_page_metadata_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+feature 'Metadata display on show page' do
+  scenario 'with default CatalogController specified fields' do
+    visit catalog_path 'stanford-dp018hs9766'
+    within '.geoblacklight-view-panel' do
+      expect(page).to have_css 'dt', count: 8
+      expect(page).to have_css 'dd', count: 8
+      expect(page).to have_css 'div.truncate-abstract', count: 1
+    end
+  end
+end


### PR DESCRIPTION
Partially addresses #241 

Enables show field configuration (a Blacklight feature) which was previously disabled. Also adds a linked search to "Held by" institution.