### PR TITLE
use boost query rather than q

### DIFF
--- a/lib/geoblacklight/controller_override.rb
+++ b/lib/geoblacklight/controller_override.rb
@@ -7,8 +7,8 @@ module Geoblacklight
     
     def add_spatial_params(solr_params, req_params)
       if req_params[:bbox]
-        solr_params[:q] ||= "*"
-        solr_params[:q] += " solr_bbox:\"IsWithin(#{req_params[:bbox]})\"^10"
+        solr_params[:bq] ||= []
+        solr_params[:bq] = ["solr_bbox:\"IsWithin(#{req_params[:bbox]})\"^10"]
         solr_params[:fq] ||= []
         solr_params[:fq] << "solr_bbox:\"Intersects(#{req_params[:bbox]})\""
       end

--- a/spec/features/split_view.html.erb_spec.rb
+++ b/spec/features/split_view.html.erb_spec.rb
@@ -48,7 +48,7 @@ feature 'Index view', js: true do
   scenario 'spatial search should reset to page one' do
     visit '/?per_page=5&q=%2A&page=2'
     find("#map").double_click
-    expect(find('.page_entries')).to have_content('1 entry found')
+    expect(find('.page_entries')).to have_content('1 - 2 of 2')
   end
 
   scenario 'clicking map search should retain current search parameters' do


### PR DESCRIPTION
This fixes the rest of the problem. They q param to solr wasn't really what we wanted and was causing results to not show up which intersected. 