### PR TITLE
remove route adds from generator

### DIFF
--- a/lib/generators/geoblacklight/install_generator.rb
+++ b/lib/generators/geoblacklight/install_generator.rb
@@ -44,13 +44,6 @@ module Geoblacklight
       end
     end
 
-    def inject_routes
-      route 'post "wms/handle"'
-      route 'resources :download, only: [:show, :file]'
-      route "get 'download/file/:id' => 'download#file', as: :download_file"
-      route "get 'download/hgl/:id' => 'download#hgl', as: :download_hgl"
-    end
-
     def create_downloads_directory
       FileUtils.mkdir_p("tmp/cache/downloads") unless File.directory?("tmp/cache/downloads")
     end

--- a/lib/geoblacklight/routes.rb
+++ b/lib/geoblacklight/routes.rb
@@ -7,6 +7,10 @@ module Geoblacklight
 
     def web_services_routes(primary_resource)
       add_routes do |options|
+        post 'wms/handle'
+        resources :download, only: [:show, :file]
+        get 'download/file/:id' => 'download#file', as: :download_file
+        get 'download/hgl/:id' => 'download#hgl', as: :download_hgl
         get "#{primary_resource}/:id/web_services" => "#{primary_resource}#web_services", as: "web_services_#{primary_resource}"
       end
     end


### PR DESCRIPTION
Closes #287 

So new routes can added or modified in GeoBlacklight without causing adopters too much pain

This might be controversial... what do others think?