### PR TITLE
Configure download

### DIFF
--- a/app/controllers/download_controller.rb
+++ b/app/controllers/download_controller.rb
@@ -42,13 +42,13 @@ class DownloadController < ApplicationController
   def check_type
     case params[:type]
     when 'shapefile'
-      response = ShapefileDownload.new(@document).get
+      response = Geoblacklight::ShapefileDownload.new(@document).get
     when 'kmz'
-      response = KmzDownload.new(@document).get
+      response = Geoblacklight::KmzDownload.new(@document).get
     when 'geojson'
-      response = GeojsonDownload.new(@document).get
+      response = Geoblacklight::GeojsonDownload.new(@document).get
     when 'geotiff'
-      response = GeotiffDownload.new(@document).get
+      response = Geoblacklight::GeotiffDownload.new(@document).get
     end
     response
   end

--- a/app/controllers/download_controller.rb
+++ b/app/controllers/download_controller.rb
@@ -22,7 +22,7 @@ class DownloadController < ApplicationController
   def hgl
     @response, @document = get_solr_response_for_doc_id params[:id]
     if params[:email]
-      response = HglDownload.new(@document, params[:email]).get
+      response = Geoblacklight::HglDownload.new(@document, params[:email]).get
       if response.nil?
         flash[:danger] = t 'geoblacklight.download.error'
       else

--- a/lib/geoblacklight/download.rb
+++ b/lib/geoblacklight/download.rb
@@ -70,5 +70,15 @@ module Geoblacklight
       Geoblacklight.logger.error error.inspect
       nil
     end
+
+    private
+
+    ##
+    # Returns timeout for the download request. `timeout` passed as an option to
+    # the Geoblacklight::Download class
+    # @returns [Fixnum] download timeout in seconds
+    def timeout
+      @options[:timeout] || Settings.TIMEOUT_DOWNLOAD || 20
+    end
   end
 end

--- a/lib/geoblacklight/download.rb
+++ b/lib/geoblacklight/download.rb
@@ -1,72 +1,74 @@
-class Download
-  def initialize(document, options = {})
-    @document = document
-    @options = options
-  end
-
-  def downloadable?
-    @document.downloadable?
-  end
-
-  def file_name
-    "#{@document[:layer_slug_s]}-#{@options[:type]}.#{@options[:extension]}"
-  end
-
-  def file_path
-    "#{Rails.root}/tmp/cache/downloads/#{file_name}"
-  end
-
-  def download_exists?
-    File.file?(file_path)
-  end
-
-  def get
-    if download_exists?
-      file_name
-    else
-      create_download_file
+module Geoblacklight
+  class Download
+    def initialize(document, options = {})
+      @document = document
+      @options = options
     end
-  end
 
-  def create_download_file
-    download = initiate_download
-    unless download.present?
-      raise Geoblacklight::Exceptions::ExternalDownloadFailed
+    def downloadable?
+      @document.downloadable?
     end
-    File.open("#{file_path}.tmp", 'wb')  do |file|
-      if download.headers['content-type'] == @options[:content_type]
-        file.write download.body
+
+    def file_name
+      "#{@document[:layer_slug_s]}-#{@options[:type]}.#{@options[:extension]}"
+    end
+
+    def file_path
+      "#{Rails.root}/tmp/cache/downloads/#{file_name}"
+    end
+
+    def download_exists?
+      File.file?(file_path)
+    end
+
+    def get
+      if download_exists?
+        file_name
       else
-        fail Geoblacklight::Exceptions::WrongDownloadFormat
+        create_download_file
       end
     end
-    File.rename("#{file_path}.tmp", file_path)
-    file_name
-  rescue Geoblacklight::Exceptions::ExternalDownloadFailed
-    Geoblacklight.logger.error 'Download from external server failed'
-    nil
-  rescue Geoblacklight::Exceptions::WrongDownloadFormat => error
-    Geoblacklight.logger.error "#{error} expected #{@options[:content_type]} received #{download.headers['content-type']}"
-    File.delete("#{file_path}.tmp")
-    nil
-  end
 
-  def initiate_download
-    url = @document.references.send(@options[:service_type]).endpoint
-    url += '/reflect' if @options[:reflect]
-    conn = Faraday.new(url: url)
-    conn.get do |request|
-      request.params = @options[:request_params]
-      request.options = {
-        timeout: Settings.TIMEOUT_DOWNLOAD,
-        open_timeout: Settings.TIMEOUT_DOWNLOAD
-      }
+    def create_download_file
+      download = initiate_download
+      unless download.present?
+        raise Geoblacklight::Exceptions::ExternalDownloadFailed
+      end
+      File.open("#{file_path}.tmp", 'wb')  do |file|
+        if download.headers['content-type'] == @options[:content_type]
+          file.write download.body
+        else
+          fail Geoblacklight::Exceptions::WrongDownloadFormat
+        end
+      end
+      File.rename("#{file_path}.tmp", file_path)
+      file_name
+    rescue Geoblacklight::Exceptions::ExternalDownloadFailed
+      Geoblacklight.logger.error 'Download from external server failed'
+      nil
+    rescue Geoblacklight::Exceptions::WrongDownloadFormat => error
+      Geoblacklight.logger.error "#{error} expected #{@options[:content_type]} received #{download.headers['content-type']}"
+      File.delete("#{file_path}.tmp")
+      nil
     end
-  rescue Faraday::Error::ConnectionFailed => error
-    Geoblacklight.logger.error error.inspect
-    nil
-  rescue Faraday::Error::TimeoutError => error
-    Geoblacklight.logger.error error.inspect
-    nil
+
+    def initiate_download
+      url = @document.references.send(@options[:service_type]).endpoint
+      url += '/reflect' if @options[:reflect]
+      conn = Faraday.new(url: url)
+      conn.get do |request|
+        request.params = @options[:request_params]
+        request.options = {
+          timeout: timeout,
+          open_timeout: timeout
+        }
+      end
+    rescue Faraday::Error::ConnectionFailed => error
+      Geoblacklight.logger.error error.inspect
+      nil
+    rescue Faraday::Error::TimeoutError => error
+      Geoblacklight.logger.error error.inspect
+      nil
+    end
   end
 end

--- a/lib/geoblacklight/download/geojson_download.rb
+++ b/lib/geoblacklight/download/geojson_download.rb
@@ -8,7 +8,7 @@ module Geoblacklight
       outputformat: 'application/json'
     }
 
-    def initialize(document)
+    def initialize(document, options = {})
       request_params = GEOJSON_DOWNLOAD_PARAMS.merge(typeName: document[:layer_id_s])
       super(document, {
         type: 'geojson',
@@ -16,7 +16,7 @@ module Geoblacklight
         request_params: request_params,
         content_type: 'application/json',
         service_type: 'wfs'
-      })
+      }.merge(options))
     end
   end
 end

--- a/lib/geoblacklight/download/geojson_download.rb
+++ b/lib/geoblacklight/download/geojson_download.rb
@@ -1,20 +1,22 @@
-class GeojsonDownload < Download
-  GEOJSON_DOWNLOAD_PARAMS = {
-    service: 'wfs',
-    version: '2.0.0',
-    request: 'GetFeature',
-    srsName: 'EPSG:4326',
-    outputformat: 'application/json'
-  }
+module Geoblacklight
+  class GeojsonDownload < Geoblacklight::Download
+    GEOJSON_DOWNLOAD_PARAMS = {
+      service: 'wfs',
+      version: '2.0.0',
+      request: 'GetFeature',
+      srsName: 'EPSG:4326',
+      outputformat: 'application/json'
+    }
 
-  def initialize(document)
-    request_params = GEOJSON_DOWNLOAD_PARAMS.merge(typeName: document[:layer_id_s])
-    super(document, {
-      type: 'geojson',
-      extension: 'json',
-      request_params: request_params,
-      content_type: 'application/json',
-      service_type: 'wfs'
-    })
+    def initialize(document)
+      request_params = GEOJSON_DOWNLOAD_PARAMS.merge(typeName: document[:layer_id_s])
+      super(document, {
+        type: 'geojson',
+        extension: 'json',
+        request_params: request_params,
+        content_type: 'application/json',
+        service_type: 'wfs'
+      })
+    end
   end
 end

--- a/lib/geoblacklight/download/geotiff_download.rb
+++ b/lib/geoblacklight/download/geotiff_download.rb
@@ -1,18 +1,20 @@
-class GeotiffDownload < Download
-  GEOTIFF_DOWNLOAD_PARAMS = {
-    format: 'image/geotiff',
-    width: 4096
-  }
+module Geoblacklight
+  class GeotiffDownload < Geoblacklight::Download
+    GEOTIFF_DOWNLOAD_PARAMS = {
+      format: 'image/geotiff',
+      width: 4096
+    }
 
-  def initialize(document)
-    request_params = GEOTIFF_DOWNLOAD_PARAMS.merge(layers: document[:layer_id_s])
-    super(document, {
-      type: 'geotiff',
-      extension: 'tif',
-      request_params: request_params,
-      content_type: 'image/geotiff',
-      service_type: 'wms',
-      reflect: true
-    })
+    def initialize(document)
+      request_params = GEOTIFF_DOWNLOAD_PARAMS.merge(layers: document[:layer_id_s])
+      super(document, {
+        type: 'geotiff',
+        extension: 'tif',
+        request_params: request_params,
+        content_type: 'image/geotiff',
+        service_type: 'wms',
+        reflect: true
+      })
+    end
   end
 end

--- a/lib/geoblacklight/download/geotiff_download.rb
+++ b/lib/geoblacklight/download/geotiff_download.rb
@@ -5,7 +5,7 @@ module Geoblacklight
       width: 4096
     }
 
-    def initialize(document)
+    def initialize(document, options = {})
       request_params = GEOTIFF_DOWNLOAD_PARAMS.merge(layers: document[:layer_id_s])
       super(document, {
         type: 'geotiff',
@@ -14,7 +14,7 @@ module Geoblacklight
         content_type: 'image/geotiff',
         service_type: 'wms',
         reflect: true
-      })
+      }.merge(options))
     end
   end
 end

--- a/lib/geoblacklight/download/hgl_download.rb
+++ b/lib/geoblacklight/download/hgl_download.rb
@@ -1,6 +1,6 @@
 module Geoblacklight
   class HglDownload < Geoblacklight::Download
-    def initialize(document, email)
+    def initialize(document, email, options = {})
 
       request_params = {
         "LayerName" => document[:layer_id_s].sub(/^cite:/, ''),
@@ -9,7 +9,7 @@ module Geoblacklight
       super(document, {
         request_params: request_params,
         service_type: 'hgl'
-      })
+      }.merge(options))
     end
 
     def get

--- a/lib/geoblacklight/download/hgl_download.rb
+++ b/lib/geoblacklight/download/hgl_download.rb
@@ -1,17 +1,19 @@
-class HglDownload < Download
-  def initialize(document, email)
+module Geoblacklight
+  class HglDownload < Geoblacklight::Download
+    def initialize(document, email)
 
-    request_params = {
-      "LayerName" => document[:layer_id_s].sub(/^cite:/, ''),
-      "UserEmail" => email
-    }
-    super(document, {
-      request_params: request_params,
-      service_type: 'hgl'
-    })
-  end
+      request_params = {
+        "LayerName" => document[:layer_id_s].sub(/^cite:/, ''),
+        "UserEmail" => email
+      }
+      super(document, {
+        request_params: request_params,
+        service_type: 'hgl'
+      })
+    end
 
-  def get
-    initiate_download
+    def get
+      initiate_download
+    end
   end
 end

--- a/lib/geoblacklight/download/kmz_download.rb
+++ b/lib/geoblacklight/download/kmz_download.rb
@@ -2,7 +2,7 @@ module Geoblacklight
   class KmzDownload < Geoblacklight::Download
     KMZ_DOWNLOAD_PARAMS = { service: 'wms', version: '1.1.0', request: 'GetMap', srsName: 'EPSG:900913', format: 'application/vnd.google-earth.kmz', width: 2000, height: 2000 }
     
-    def initialize(document)
+    def initialize(document, options = {})
       request_params = KMZ_DOWNLOAD_PARAMS.merge(layers: document[:layer_id_s], bbox: document.bounding_box_as_wsen.split(' ').join(', '))
       super(document, {
         type: 'kmz',
@@ -10,7 +10,7 @@ module Geoblacklight
         request_params: request_params,
         content_type: 'application/vnd.google-earth.kmz',
         service_type: 'wms'
-      })
+      }.merge(options))
     end
   end
 end

--- a/lib/geoblacklight/download/kmz_download.rb
+++ b/lib/geoblacklight/download/kmz_download.rb
@@ -1,14 +1,16 @@
-class KmzDownload < Download
-  KMZ_DOWNLOAD_PARAMS = { service: 'wms', version: '1.1.0', request: 'GetMap', srsName: 'EPSG:900913', format: 'application/vnd.google-earth.kmz', width: 2000, height: 2000 }
-  
-  def initialize(document)
-    request_params = KMZ_DOWNLOAD_PARAMS.merge(layers: document[:layer_id_s], bbox: document.bounding_box_as_wsen.split(' ').join(', '))
-    super(document, {
-      type: 'kmz',
-      extension: 'kmz',
-      request_params: request_params,
-      content_type: 'application/vnd.google-earth.kmz',
-      service_type: 'wms'
-    })
+module Geoblacklight
+  class KmzDownload < Geoblacklight::Download
+    KMZ_DOWNLOAD_PARAMS = { service: 'wms', version: '1.1.0', request: 'GetMap', srsName: 'EPSG:900913', format: 'application/vnd.google-earth.kmz', width: 2000, height: 2000 }
+    
+    def initialize(document)
+      request_params = KMZ_DOWNLOAD_PARAMS.merge(layers: document[:layer_id_s], bbox: document.bounding_box_as_wsen.split(' ').join(', '))
+      super(document, {
+        type: 'kmz',
+        extension: 'kmz',
+        request_params: request_params,
+        content_type: 'application/vnd.google-earth.kmz',
+        service_type: 'wms'
+      })
+    end
   end
 end

--- a/lib/geoblacklight/download/shapefile_download.rb
+++ b/lib/geoblacklight/download/shapefile_download.rb
@@ -1,14 +1,16 @@
-class ShapefileDownload < Download
-  SHAPEFILE_DOWNLOAD_PARAMS = { service: 'wfs', version: '2.0.0', request: 'GetFeature', srsName: 'EPSG:4326', outputformat: 'SHAPE-ZIP' }
-  
-  def initialize(document)
-    request_params = SHAPEFILE_DOWNLOAD_PARAMS.merge(typeName: document[:layer_id_s])
-    super(document, {
-      type: 'shapefile',
-      extension: 'zip',
-      request_params: request_params,
-      content_type: 'application/zip',
-      service_type: 'wfs'
-    })
+module Geoblacklight
+  class ShapefileDownload < Geoblacklight::Download
+    SHAPEFILE_DOWNLOAD_PARAMS = { service: 'wfs', version: '2.0.0', request: 'GetFeature', srsName: 'EPSG:4326', outputformat: 'SHAPE-ZIP' }
+
+    def initialize(document)
+      request_params = SHAPEFILE_DOWNLOAD_PARAMS.merge(typeName: document[:layer_id_s])
+      super(document, {
+        type: 'shapefile',
+        extension: 'zip',
+        request_params: request_params,
+        content_type: 'application/zip',
+        service_type: 'wfs'
+      })
+    end
   end
 end

--- a/lib/geoblacklight/download/shapefile_download.rb
+++ b/lib/geoblacklight/download/shapefile_download.rb
@@ -2,7 +2,7 @@ module Geoblacklight
   class ShapefileDownload < Geoblacklight::Download
     SHAPEFILE_DOWNLOAD_PARAMS = { service: 'wfs', version: '2.0.0', request: 'GetFeature', srsName: 'EPSG:4326', outputformat: 'SHAPE-ZIP' }
 
-    def initialize(document)
+    def initialize(document, options = {})
       request_params = SHAPEFILE_DOWNLOAD_PARAMS.merge(typeName: document[:layer_id_s])
       super(document, {
         type: 'shapefile',
@@ -10,7 +10,7 @@ module Geoblacklight
         request_params: request_params,
         content_type: 'application/zip',
         service_type: 'wfs'
-      })
+      }.merge(options))
     end
   end
 end

--- a/spec/controllers/download_controller_spec.rb
+++ b/spec/controllers/download_controller_spec.rb
@@ -33,7 +33,7 @@ describe Geoblacklight::DownloadController, type: :controller do
   end
   describe '#hgl' do
     it 'should request file' do
-      expect_any_instance_of(HglDownload).to receive(:get).and_return('success')
+      expect_any_instance_of(Geoblacklight::HglDownload).to receive(:get).and_return('success')
       get :hgl, id: 'harvard-g7064-s2-1834-k3', email: 'foo@example.com'
       expect(response.status).to eq 200
     end

--- a/spec/features/download_layer_spec.rb
+++ b/spec/features/download_layer_spec.rb
@@ -2,13 +2,13 @@ require 'spec_helper'
 
 feature 'Download layer' do
   scenario 'clicking initial shapefile download button should trigger download', js: true do
-    expect_any_instance_of(ShapefileDownload).to receive(:get).and_return('mit-us-ma-e25zcta5dct-2000-shapefile.zip')
+    expect_any_instance_of(Geoblacklight::ShapefileDownload).to receive(:get).and_return('mit-us-ma-e25zcta5dct-2000-shapefile.zip')
     visit catalog_path('mit-us-ma-e25zcta5dct-2000')
     find('a', text: 'Download Shapefile').click
     expect(page).to have_css('a', text: 'Your file mit-us-ma-e25zcta5dct-2000-shapefile.zip is ready for download')
   end
   scenario 'clicking kmz download button should trigger download', js: true do
-    expect_any_instance_of(KmzDownload).to receive(:get).and_return('mit-us-ma-e25zcta5dct-2000-kmz.kmz')
+    expect_any_instance_of(Geoblacklight::KmzDownload).to receive(:get).and_return('mit-us-ma-e25zcta5dct-2000-kmz.kmz')
     visit catalog_path('mit-us-ma-e25zcta5dct-2000')
     find('button.download-dropdown-toggle').click
     find('a', text: 'Download KMZ').click
@@ -48,7 +48,7 @@ feature 'Download layer' do
     expect(page).to have_css('#hglRequest')
   end
   scenario 'submitting email form should trigger HGL request', js: true do
-    expect_any_instance_of(HglDownload).to receive(:get).and_return('success')
+    expect_any_instance_of(Geoblacklight::HglDownload).to receive(:get).and_return('success')
     visit catalog_path('harvard-g7064-s2-1834-k3')
     find('a', text: 'Download GeoTIFF').click
     within '#hglRequest' do

--- a/spec/lib/geoblacklight/download/geojson_download_spec.rb
+++ b/spec/lib/geoblacklight/download/geojson_download_spec.rb
@@ -1,11 +1,11 @@
 require 'spec_helper'
 
-describe GeojsonDownload do
+describe Geoblacklight::GeojsonDownload do
   let(:document) { SolrDocument.new(layer_slug_s: 'test', solr_wfs_url: 'http://www.example.com/wfs', layer_id_s: 'stanford-test', solr_geom: 'ENVELOPE(-180, 180, 90, -90)') }
-  let(:download) { GeojsonDownload.new(document) }
+  let(:download) { Geoblacklight::GeojsonDownload.new(document) }
   describe '#initialize' do
     it 'should initialize as a GeojsonDownload object with specific options' do
-      expect(download).to be_an GeojsonDownload
+      expect(download).to be_an Geoblacklight::GeojsonDownload
       options = download.instance_variable_get(:@options)
       expect(options[:content_type]).to eq 'application/json'
       expect(options[:request_params][:typeName]).to eq 'stanford-test'

--- a/spec/lib/geoblacklight/download/geojson_download_spec.rb
+++ b/spec/lib/geoblacklight/download/geojson_download_spec.rb
@@ -10,5 +10,10 @@ describe Geoblacklight::GeojsonDownload do
       expect(options[:content_type]).to eq 'application/json'
       expect(options[:request_params][:typeName]).to eq 'stanford-test'
     end
+    it 'should merge custom options' do
+      download = Geoblacklight::GeojsonDownload.new(document, timeout: 33)
+      options = download.instance_variable_get(:@options)
+      expect(options[:timeout]).to eq 33
+    end
   end
 end

--- a/spec/lib/geoblacklight/download/geotiff_download_spec.rb
+++ b/spec/lib/geoblacklight/download/geotiff_download_spec.rb
@@ -1,11 +1,11 @@
 require 'spec_helper'
 
-describe GeotiffDownload do
+describe Geoblacklight::GeotiffDownload do
   let(:document) { SolrDocument.new(layer_slug_s: 'test', layer_id_s: 'stanford-test', solr_geom: 'ENVELOPE(-180, 180, 90, -90)') }
-  let(:download) { GeotiffDownload.new(document) }
+  let(:download) { Geoblacklight::GeotiffDownload.new(document) }
   describe '#initialize' do
     it 'should initialize as a GeotiffDownload object with specific options' do
-      expect(download).to be_an GeotiffDownload
+      expect(download).to be_an Geoblacklight::GeotiffDownload
       options = download.instance_variable_get(:@options)
       expect(options[:content_type]).to eq 'image/geotiff'
       expect(options[:request_params][:layers]).to eq 'stanford-test'

--- a/spec/lib/geoblacklight/download/geotiff_download_spec.rb
+++ b/spec/lib/geoblacklight/download/geotiff_download_spec.rb
@@ -11,5 +11,10 @@ describe Geoblacklight::GeotiffDownload do
       expect(options[:request_params][:layers]).to eq 'stanford-test'
       expect(options[:reflect]).to be_truthy
     end
+    it 'should merge custom options' do
+      download = Geoblacklight::GeotiffDownload.new(document, timeout: 33)
+      options = download.instance_variable_get(:@options)
+      expect(options[:timeout]).to eq 33
+    end
   end
 end

--- a/spec/lib/geoblacklight/download/hgl_download_spec.rb
+++ b/spec/lib/geoblacklight/download/hgl_download_spec.rb
@@ -1,11 +1,11 @@
 require 'spec_helper'
 
-describe HglDownload do
+describe Geoblacklight::HglDownload do
   let(:document) { SolrDocument.new(layer_slug_s: 'test', layer_id_s: 'cite:harvard-test') }
-  let(:download) { HglDownload.new(document, 'foo@example.com') }
+  let(:download) { Geoblacklight::HglDownload.new(document, 'foo@example.com') }
   describe '#initialize' do
     it 'should initialize as an HglDownload object with specific options' do
-      expect(download).to be_an HglDownload
+      expect(download).to be_an Geoblacklight::HglDownload
       options = download.instance_variable_get(:@options)
       expect(options[:request_params]['LayerName']).to eq 'harvard-test'
       expect(options[:request_params]['UserEmail']).to eq 'foo@example.com'

--- a/spec/lib/geoblacklight/download/hgl_download_spec.rb
+++ b/spec/lib/geoblacklight/download/hgl_download_spec.rb
@@ -10,5 +10,10 @@ describe Geoblacklight::HglDownload do
       expect(options[:request_params]['LayerName']).to eq 'harvard-test'
       expect(options[:request_params]['UserEmail']).to eq 'foo@example.com'
     end
+    it 'should merge custom options' do
+      download = Geoblacklight::HglDownload.new(document, 'foo@example.com', timeout: 33)
+      options = download.instance_variable_get(:@options)
+      expect(options[:timeout]).to eq 33
+    end
   end
 end

--- a/spec/lib/geoblacklight/download/kmz_download_spec.rb
+++ b/spec/lib/geoblacklight/download/kmz_download_spec.rb
@@ -1,11 +1,11 @@
 require 'spec_helper'
 
-describe KmzDownload do
+describe Geoblacklight::KmzDownload do
   let(:document) { SolrDocument.new(layer_slug_s: 'test', solr_wfs_url: 'http://www.example.com/wfs', layer_id_s: 'stanford-test', solr_geom: 'ENVELOPE(-180, 180, 90, -90)') }
-  let(:download) { KmzDownload.new(document) }
+  let(:download) { Geoblacklight::KmzDownload.new(document) }
   describe '#initialize' do
     it 'should initialize as a KmzDownload object with specific options' do
-      expect(download).to be_an KmzDownload
+      expect(download).to be_an Geoblacklight::KmzDownload
       options = download.instance_variable_get(:@options)
       expect(options[:content_type]).to eq 'application/vnd.google-earth.kmz'
       expect(options[:request_params][:layers]).to eq 'stanford-test'

--- a/spec/lib/geoblacklight/download/kmz_download_spec.rb
+++ b/spec/lib/geoblacklight/download/kmz_download_spec.rb
@@ -11,5 +11,10 @@ describe Geoblacklight::KmzDownload do
       expect(options[:request_params][:layers]).to eq 'stanford-test'
       expect(options[:request_params][:bbox]).to eq '-180, -90, 180, 90'
     end
+    it 'should merge custom options' do
+      download = Geoblacklight::KmzDownload.new(document, timeout: 33)
+      options = download.instance_variable_get(:@options)
+      expect(options[:timeout]).to eq 33
+    end
   end
 end

--- a/spec/lib/geoblacklight/download/shapefile_download_spec.rb
+++ b/spec/lib/geoblacklight/download/shapefile_download_spec.rb
@@ -10,5 +10,10 @@ describe Geoblacklight::ShapefileDownload do
       expect(options[:content_type]).to eq 'application/zip'
       expect(options[:request_params][:typeName]).to eq 'stanford-test'
     end
+    it 'should merge custom options' do
+      download = Geoblacklight::ShapefileDownload.new(document, timeout: 33)
+      options = download.instance_variable_get(:@options)
+      expect(options[:timeout]).to eq 33
+    end
   end
 end

--- a/spec/lib/geoblacklight/download/shapefile_download_spec.rb
+++ b/spec/lib/geoblacklight/download/shapefile_download_spec.rb
@@ -1,11 +1,11 @@
 require 'spec_helper'
 
-describe ShapefileDownload do
+describe Geoblacklight::ShapefileDownload do
   let(:document) { SolrDocument.new(layer_slug_s: 'test', solr_wfs_url: 'http://www.example.com/wfs', layer_id_s: 'stanford-test', solr_geom: 'ENVELOPE(-180, 180, 90, -90)') }
-  let(:download) { ShapefileDownload.new(document) }
+  let(:download) { Geoblacklight::ShapefileDownload.new(document) }
   describe '#initialize' do
     it 'should initialize as a ShapefileDownload object with specific options' do
-      expect(download).to be_an ShapefileDownload
+      expect(download).to be_an Geoblacklight::ShapefileDownload
       options = download.instance_variable_get(:@options)
       expect(options[:content_type]).to eq 'application/zip'
       expect(options[:request_params][:typeName]).to eq 'stanford-test'

--- a/spec/lib/geoblacklight/download_spec.rb
+++ b/spec/lib/geoblacklight/download_spec.rb
@@ -1,16 +1,16 @@
 require 'spec_helper'
 
-describe Download do
+describe Geoblacklight::Download do
   let(:response) { double('response') }
   let(:get) { double('get') }
   let(:body) { double('body') }
   let(:document) { SolrDocument.new(layer_slug_s: 'test', dct_references_s: {'http://www.opengis.net/def/serviceType/ogc/wms' => 'http://www.example.com/wms'}.to_json) }
   let(:options) { { type: 'shapefile', extension: 'zip', service_type: 'wms', content_type: 'application/zip' } }
-  let(:download) { Download.new(document, options) }
+  let(:download) { Geoblacklight::Download.new(document, options) }
 
   describe '#initialize' do
     it 'should initialize as a Download object' do
-      expect(download).to be_an Download
+      expect(download).to be_an Geoblacklight::Download
     end
   end
   describe '#file_name' do


### PR DESCRIPTION
Does a few things here:

 - moves `Download` classes underneath the `Geoblacklight` module. 656c316
 - Allows subclassed downloads to take an options parameter which gets merged in. This allows for a `timeout` parameter that can be configured individually on instantiation independent of an apps configuration