### PR TITLE
updates Downloads to handle errors better

### DIFF
--- a/config/locales/geoblacklight.en.yml
+++ b/config/locales/geoblacklight.en.yml
@@ -5,6 +5,7 @@ en:
       success: 'Your file %{title} is ready for download'
       hgl_success: 'You should receive an email when your download is ready'
       error: 'Sorry, the requested file could not be downloaded'
+      error_with_url: 'Sorry, the requested file could not be downloaded, try downloading it directly from: %{link}'
     home:
       headline: 'Explore and discover...'
       search_heading: 'Find the maps and data you need'

--- a/lib/geoblacklight/download.rb
+++ b/lib/geoblacklight/download.rb
@@ -29,11 +29,12 @@ module Geoblacklight
       end
     end
 
+    ##
+    # Creates temporary file on file system and renames it if download completes
+    # successfully. Will raise and rescue if the wrong file format is downloaded
+    # @return [String] filename of the completed download
     def create_download_file
       download = initiate_download
-      unless download.present?
-        raise Geoblacklight::Exceptions::ExternalDownloadFailed
-      end
       File.open("#{file_path}.tmp", 'wb')  do |file|
         if download.headers['content-type'] == @options[:content_type]
           file.write download.body
@@ -43,18 +44,18 @@ module Geoblacklight
       end
       File.rename("#{file_path}.tmp", file_path)
       file_name
-    rescue Geoblacklight::Exceptions::ExternalDownloadFailed
-      Geoblacklight.logger.error 'Download from external server failed'
-      nil
     rescue Geoblacklight::Exceptions::WrongDownloadFormat => error
       Geoblacklight.logger.error "#{error} expected #{@options[:content_type]} received #{download.headers['content-type']}"
       File.delete("#{file_path}.tmp")
-      nil
+      raise Geoblacklight::Exceptions::ExternalDownloadFailed, message: 'Wrong download type'
     end
 
+    ##
+    # Initiates download from a remote source url using the `request_params`.
+    # Will catch Faraday::Error::ConnectionFailed and
+    # Faraday::Error::TimeoutError 
+    # @return [Faraday::Request] returns a Faraday::Request object
     def initiate_download
-      url = @document.references.send(@options[:service_type]).endpoint
-      url += '/reflect' if @options[:reflect]
       conn = Faraday.new(url: url)
       conn.get do |request|
         request.params = @options[:request_params]
@@ -64,11 +65,9 @@ module Geoblacklight
         }
       end
     rescue Faraday::Error::ConnectionFailed => error
-      Geoblacklight.logger.error error.inspect
-      nil
+      raise Geoblacklight::Exceptions::ExternalDownloadFailed, message: 'Download connection failed', url: conn.url_prefix.to_s
     rescue Faraday::Error::TimeoutError => error
-      Geoblacklight.logger.error error.inspect
-      nil
+      raise Geoblacklight::Exceptions::ExternalDownloadFailed, message: 'Download timed out', url: conn.url_prefix.to_s
     end
 
     private
@@ -76,9 +75,18 @@ module Geoblacklight
     ##
     # Returns timeout for the download request. `timeout` passed as an option to
     # the Geoblacklight::Download class
-    # @returns [Fixnum] download timeout in seconds
+    # @return [Fixnum] download timeout in seconds
     def timeout
       @options[:timeout] || Settings.TIMEOUT_DOWNLOAD || 20
+    end
+
+    ##
+    # URL for download
+    # @return [String] URL that is checked in download
+    def url
+      url = @document.references.send(@options[:service_type]).endpoint
+      url += '/reflect' if @options[:reflect]
+      url
     end
   end
 end

--- a/lib/geoblacklight/exceptions.rb
+++ b/lib/geoblacklight/exceptions.rb
@@ -1,6 +1,23 @@
 module Geoblacklight
   module Exceptions
     class ExternalDownloadFailed < StandardError
+      def initialize(options = {})
+        @options = options
+      end
+
+      ##
+      # URL tried from failed download
+      # @return [String] 
+      def url
+        @options[:url].to_s
+      end
+
+      ##
+      # Message passed from a failed download
+      # @return [String]
+      def message
+        @options[:message].to_s
+      end
     end
     class WrongDownloadFormat < StandardError
     end

--- a/spec/controllers/download_controller_spec.rb
+++ b/spec/controllers/download_controller_spec.rb
@@ -26,7 +26,7 @@ describe Geoblacklight::DownloadController, type: :controller do
     end
     describe 'public file' do
       it 'should initiate download creation' do
-        get 'show', id: 'mit-us-ma-e25zcta5dct-2000'
+        get 'show', id: 'mit-us-ma-e25zcta5dct-2000', type: 'shapefile'
         expect(response.status).to eq 200
       end
     end

--- a/spec/features/download_layer_spec.rb
+++ b/spec/features/download_layer_spec.rb
@@ -7,6 +7,13 @@ feature 'Download layer' do
     find('a', text: 'Download Shapefile').click
     expect(page).to have_css('a', text: 'Your file mit-us-ma-e25zcta5dct-2000-shapefile.zip is ready for download')
   end
+  scenario 'failed download should return message with link to layer', js: true do
+    expect_any_instance_of(Geoblacklight::ShapefileDownload).to receive(:get).and_raise(Geoblacklight::Exceptions::ExternalDownloadFailed.new(message: 'Failed', url: 'http://www.example.com/failed'))
+    visit catalog_path('mit-us-ma-e25zcta5dct-2000')
+    find('a', text: 'Download Shapefile', match: :first).click
+    expect(page).to have_css 'div.alert.alert-danger', text: 'Sorry, the requested file could not be downloaded, try downloading it directly from:'
+    expect(page).to have_css 'a', text: 'http://www.example.com/failed'
+  end
   scenario 'clicking kmz download button should trigger download', js: true do
     expect_any_instance_of(Geoblacklight::KmzDownload).to receive(:get).and_return('mit-us-ma-e25zcta5dct-2000-kmz.kmz')
     visit catalog_path('mit-us-ma-e25zcta5dct-2000')


### PR DESCRIPTION
Does several things:
 - rather than returning `nil` errored downloads raise `Geoblacklight::Exceptions::ExternalDownloadFailed`
 - in `DownloadController` rather than checking for `nil` rescue from `Geoblacklight::Exceptions:ExternalDownloadFailed`
 - adds a test for an errored download message
 - provides a url to the errored download try to the user in a flash message
 - updates documentation for `Download` class
