### PR TITLE
quick fix to error when using bookmarks and document actions framework

### DIFF
--- a/lib/generators/geoblacklight/templates/catalog_controller.rb
+++ b/lib/generators/geoblacklight/templates/catalog_controller.rb
@@ -207,9 +207,9 @@ class CatalogController < ApplicationController
     config.spell_max = 5
 
     # Custom tools for GeoBlacklight
-    config.add_show_tools_partial :web_services, if: proc { |_context, _config, options| (Settings.WEBSERVICES_SHOWN & options[:document].references.refs.map(&:type).map(&:to_s)).any? }
-    config.add_show_tools_partial :metadata, if: proc { |_context, _config, options| (Settings.METADATA_SHOWN & options[:document].references.refs.map(&:type).map(&:to_s)).any? }
-    config.add_show_tools_partial :downloads, partial: 'downloads'
+    config.add_show_tools_partial :web_services, if: proc { |_context, _config, options| options[:document] && (Settings.WEBSERVICES_SHOWN & options[:document].references.refs.map(&:type).map(&:to_s)).any? }
+    config.add_show_tools_partial :metadata, if: proc { |_context, _config, options| options[:document] && (Settings.METADATA_SHOWN & options[:document].references.refs.map(&:type).map(&:to_s)).any? }
+    config.add_show_tools_partial :downloads, partial: 'downloads', if: proc { |_context, _config, options| options[:document] }
   end
 
 

--- a/spec/features/bookmarks_spec.rb
+++ b/spec/features/bookmarks_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+feature 'Blacklight Bookmarks' do
+  scenario 'index has created bookmarks' do
+    visit catalog_path 'columbia-columbia-landinfo-global-aet'
+    click_button 'Bookmark'
+    visit bookmarks_path
+    expect(page).to have_css '.document', count: 1
+  end
+end


### PR DESCRIPTION
Make sure that config[:document] is available ... this was causing an error on bookmarks page.