### PR TITLE
check to see if method is already in search builder

### DIFF
--- a/lib/geoblacklight/search_builder.rb
+++ b/lib/geoblacklight/search_builder.rb
@@ -1,8 +1,10 @@
 module Geoblacklight
   class SearchBuilder  < Blacklight::Solr::SearchBuilder
+    self.default_processor_chain += [:add_spatial_params]
+
     def initialize(processor_chain, scope)
       super(processor_chain, scope)
-      processor_chain << :add_spatial_params
+      @processor_chain += [:add_spatial_params] unless @processor_chain.include?(:add_spatial_params)
     end
 
     def add_spatial_params(solr_params)

--- a/spec/lib/geoblacklight/search_builder_spec.rb
+++ b/spec/lib/geoblacklight/search_builder_spec.rb
@@ -10,6 +10,26 @@ describe Geoblacklight::SearchBuilder do
 
   subject { search_builder.with(user_params) }
 
+  describe '#initialize' do
+    it 'should have add_spatial_params in processor chain once' do
+      correct_processor_chain = [:default_solr_parameters,
+                                 :add_query_to_solr,
+                                 :add_facet_fq_to_solr,
+                                 :add_facetting_to_solr,
+                                 :add_solr_fields_to_query,
+                                 :add_paging_to_solr,
+                                 :add_sorting_to_solr,
+                                 :add_group_config_to_solr,
+                                 :add_range_limit_params,
+                                 :add_spatial_params]
+      expect(subject.processor_chain).to include :add_spatial_params
+      expect(subject.processor_chain).to match_array correct_processor_chain
+      new_search = described_class.new(subject.processor_chain, context)
+      expect(new_search.processor_chain).to include :add_spatial_params
+      expect(new_search.processor_chain).to match_array correct_processor_chain
+    end
+  end
+
   describe '#add_spatial_params' do
     it 'should return the solr_params when no bbox is given' do
       expect(subject.add_spatial_params(solr_params)).to eq solr_params


### PR DESCRIPTION
This pull request fixes a bug where `: add_spatial_params` was being added on every request to `processor_chain` resulting with an extremely long Solr query.

Thanks to @cbeer for helping diagnose and propose a fix.