### PR TITLE
add configurable basemap

### DIFF
--- a/app/assets/javascripts/geoblacklight/viewers/map.js
+++ b/app/assets/javascripts/geoblacklight/viewers/map.js
@@ -10,14 +10,30 @@ GeoBlacklight.Viewer.Map = GeoBlacklight.Viewer.extend({
     bbox: [[-80, -195], [80, 185]]
   },
 
-  basemap: L.tileLayer(
-    'https://otile{s}-s.mqcdn.com/tiles/1.0.0/map/{z}/{x}/{y}.png', {
-      attribution: '&copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, Tiles Courtesy of <a href="http://www.mapquest.com/" target="_blank">MapQuest</a> <img src="//developer.mapquest.com/content/osm/mq_logo.png" alt="">',
-      maxZoom: 18,
-      worldCopyJump: true,
-      subdomains: '1234' // see http://developer.mapquest.com/web/products/open/map
-    }
-  ),
+  basemap: {
+    darkMatter: L.tileLayer(
+      'https://cartodb-basemaps-{s}.global.ssl.fastly.net/dark_all/{z}/{x}/{y}.png', {
+        attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://cartodb.com/attributions">CartoDB</a>',
+        maxZoom: 18,
+        worldCopyJump: true
+      }
+    ),
+    mapquest: L.tileLayer(
+      'https://otile{s}-s.mqcdn.com/tiles/1.0.0/map/{z}/{x}/{y}.png', {
+        attribution: '&copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, Tiles Courtesy of <a href="http://www.mapquest.com/" target="_blank">MapQuest</a> <img src="//developer.mapquest.com/content/osm/mq_logo.png" alt="">',
+        maxZoom: 18,
+        worldCopyJump: true,
+        subdomains: '1234' // see http://developer.mapquest.com/web/products/open/map
+      }
+    ),
+    positron: L.tileLayer(
+      'https://cartodb-basemaps-{s}.global.ssl.fastly.net/light_all/{z}/{x}/{y}.png', {
+        attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://cartodb.com/attributions">CartoDB</a>',
+        maxZoom: 18,
+        worldCopyJump: true
+      }
+    )
+  },
 
   overlay: L.layerGroup(),
 
@@ -26,7 +42,7 @@ GeoBlacklight.Viewer.Map = GeoBlacklight.Viewer.extend({
       this.options.bbox = L.bboxToBounds(this.data.mapBbox);
     }
     this.map = L.map(this.element).fitBounds(this.options.bbox);
-    this.map.addLayer(this.basemap);
+    this.map.addLayer(this.selectBasemap());
     this.map.addLayer(this.overlay);
     if (this.data.map !== 'index') {
       this.addBoundsOverlay(this.options.bbox);
@@ -53,5 +69,17 @@ GeoBlacklight.Viewer.Map = GeoBlacklight.Viewer.extend({
    */
   removeBoundsOverlay: function() {
     this.overlay.clearLayers();
+  },
+
+  /**
+  * Selects basemap if specified in data options, if not return mapquest
+  */
+  selectBasemap: function() {
+    var _this = this;
+    if (_this.data.basemap) {
+      return _this.basemap[_this.data.basemap];
+    } else {
+      return _this.basemap.mapquest;
+    }
   }
 });

--- a/app/assets/javascripts/geoblacklight/viewers/wms.js
+++ b/app/assets/javascripts/geoblacklight/viewers/wms.js
@@ -5,7 +5,7 @@ GeoBlacklight.Viewer.Wms = GeoBlacklight.Viewer.Map.extend({
   load: function() {
     this.options.bbox = L.bboxToBounds(this.data.mapBbox);
     this.map = L.map(this.element).fitBounds(this.options.bbox);
-    this.map.addLayer(this.basemap);
+    this.map.addLayer(this.selectBasemap());
     this.map.addLayer(this.overlay);
 
     if (this.data.available) {

--- a/app/helpers/geoblacklight_helper.rb
+++ b/app/helpers/geoblacklight_helper.rb
@@ -84,4 +84,11 @@ module GeoblacklightHelper
       args[:value]
     end
   end
+
+  ##
+  # Selects the basemap used for map displays
+  # @return [String]
+  def geoblacklight_basemap
+    blacklight_config.basemap_provider || 'mapquest'
+  end
 end

--- a/app/views/catalog/_document_split.html.erb
+++ b/app/views/catalog/_document_split.html.erb
@@ -1,4 +1,4 @@
 <div id="documents" class="docView col-md-6">
   <%= render documents, :as => :document %>
 </div>
-<%= content_tag :div, '', id: 'map', data: { map: 'index', 'catalog-path'=> catalog_index_path , 'map-bbox' => params[:bbox] } %>
+<%= content_tag :div, '', id: 'map', data: { map: 'index', 'catalog-path'=> catalog_index_path , 'map-bbox' => params[:bbox], basemap: geoblacklight_basemap } %>

--- a/app/views/catalog/_home_text.html.erb
+++ b/app/views/catalog/_home_text.html.erb
@@ -43,7 +43,7 @@
     </div>
     <div class='col-md-6 text-center'>
       <%= content_tag :h3, t('geoblacklight.home.map_heading') %>
-      <%= content_tag :div, '', id: 'map', data: { map: 'home', 'catalog-path'=> catalog_index_path , 'map-bbox' => params[:bbox]} %>
+      <%= content_tag :div, '', id: 'map', data: { map: 'home', 'catalog-path'=> catalog_index_path , 'map-bbox' => params[:bbox], basemap: geoblacklight_basemap } %>
     </div>
   </div>
 </div>

--- a/app/views/catalog/_show_default_viewer_container.html.erb
+++ b/app/views/catalog/_show_default_viewer_container.html.erb
@@ -1,5 +1,5 @@
 <% document ||= @document %>
 <div id='viewer-container' class="col-md-8">
-  <%= content_tag :div, id: 'map', data: { map: 'item', protocol: document.viewer_protocol, url: document.viewer_endpoint, 'layer-id' => document[:layer_id_s], 'map-bbox' => document.bounding_box_as_wsen, 'catalog-path'=> catalog_index_path, available: document_available? } do %>
+  <%= content_tag :div, id: 'map', data: { map: 'item', protocol: document.viewer_protocol, url: document.viewer_endpoint, 'layer-id' => document[:layer_id_s], 'map-bbox' => document.bounding_box_as_wsen, 'catalog-path'=> catalog_index_path, available: document_available?, basemap: geoblacklight_basemap } do %>
   <% end %>
 </div>

--- a/lib/generators/geoblacklight/templates/catalog_controller.rb
+++ b/lib/generators/geoblacklight/templates/catalog_controller.rb
@@ -212,6 +212,14 @@ class CatalogController < ApplicationController
     config.add_show_tools_partial :web_services, if: proc { |_context, _config, options| options[:document] && (Settings.WEBSERVICES_SHOWN & options[:document].references.refs.map(&:type).map(&:to_s)).any? }
     config.add_show_tools_partial :metadata, if: proc { |_context, _config, options| options[:document] && (Settings.METADATA_SHOWN & options[:document].references.refs.map(&:type).map(&:to_s)).any? }
     config.add_show_tools_partial :downloads, partial: 'downloads', if: proc { |_context, _config, options| options[:document] }
+
+    # Configure basemap provider for GeoBlacklight maps (uses https only basemap
+    # providers with open licenses)
+    # Valid basemaps include:
+    # 'mapquest' http://developer.mapquest.com/web/products/open/map
+    # 'positron' http://cartodb.com/basemaps/
+    # 'darkMatter' http://cartodb.com/basemaps/
+    config.basemap_provider = 'mapquest'
   end
 
 

--- a/lib/geoblacklight/version.rb
+++ b/lib/geoblacklight/version.rb
@@ -1,3 +1,3 @@
 module Geoblacklight
-  VERSION = '0.9.0'
+  VERSION = '0.9.1'
 end

--- a/spec/features/configurable_basemap_spec.rb
+++ b/spec/features/configurable_basemap_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+feature 'Configurable basemap', js: true do
+  scenario 'defaults to mapquest' do
+    visit root_path
+    expect(page).to have_css "img[src*='mqcdn.com']"
+  end
+  feature 'without provided basemap config' do
+    before do
+      CatalogController.blacklight_config.basemap_provider = nil
+    end
+    scenario 'has mapquest map' do
+      visit root_path
+      expect(page).to have_css "img[src*='mqcdn.com']"
+    end
+  end
+  feature 'using positron' do
+    before do
+      CatalogController.blacklight_config.basemap_provider = 'positron'
+    end
+    scenario 'has positron map' do
+      visit root_path
+      expect(page).to have_css "img[src*='light_all']"
+    end
+  end
+end

--- a/spec/helpers/geoblacklight_helpers_spec.rb
+++ b/spec/helpers/geoblacklight_helpers_spec.rb
@@ -33,4 +33,16 @@ describe GeoblacklightHelper do
       expect(download_text('GEOJSON')).to eq 'Download GeoJSON'
     end
   end
+
+  describe '#geoblacklight_basemap' do
+    let(:blacklight_config) { double }
+    it 'without configuration' do
+      expect(blacklight_config).to receive(:basemap_provider).and_return(nil)
+      expect(geoblacklight_basemap).to eq 'mapquest'
+    end
+    it 'with custom configuration' do
+      expect(blacklight_config).to receive(:basemap_provider).and_return('positron')
+      expect(geoblacklight_basemap).to eq 'positron'
+    end
+  end
 end


### PR DESCRIPTION
Adds in the ability to configure the basemap. This functionality can be extended in a user's own app:

in a GeoBlacklight apps `app/assets/javascripts/geoblacklight.js`
```javascript
GeoBlacklight.Viewer.Map = GeoBlacklight.Viewer.Map.extend({
  selectBasemap: function() {
    var _this = this;
    return //anything!;
  }
});
```

or add more basemaps:
```javascript
GeoBlacklight.Viewer.Map = GeoBlacklight.Viewer.Map.extend({
  basemap: {
    stamenWatercolor: L.tileLayer(
      'http://{s}.tile.stamen.com/watercolor/{z}/{x}/{y}.{ext}', {
        attribution: 'Map tiles by <a href="http://stamen.com">Stamen Design</a>, <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a> &mdash; Map data &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>',
        subdomains: 'abcd',
        minZoom: 1,
        maxZoom: 16,
        ext: 'png',
        worldCopyJump: true
      }
    )
  }
});
```

![screen shot 2015-04-18 at 10 07 48 am](https://cloud.githubusercontent.com/assets/1656824/7216398/db3f409e-e5b2-11e4-9b8d-d59183eb633f.png)
