### PR TITLE
Solr doc fetch... and precache downloads

### DIFF
--- a/lib/geoblacklight.rb
+++ b/lib/geoblacklight.rb
@@ -8,6 +8,7 @@ module Geoblacklight
   require 'geoblacklight/exceptions'
   require 'geoblacklight/view_helper_override'
   require 'geoblacklight/item_viewer'
+  require 'geoblacklight/solr_document/finder'
   require 'geoblacklight/solr_document'
   require 'geoblacklight/wms_layer'
   require 'geoblacklight/wms_layer/feature_info_response'

--- a/lib/geoblacklight/solr_document.rb
+++ b/lib/geoblacklight/solr_document.rb
@@ -3,6 +3,8 @@ module Geoblacklight
   module SolrDocument
     extend Blacklight::Solr::Document
 
+    include Geoblacklight::SolrDocument::Finder
+
     delegate :download_types, to: :references
     delegate :viewer_protocol, to: :item_viewer
     delegate :viewer_endpoint, to: :item_viewer

--- a/lib/geoblacklight/solr_document/finder.rb
+++ b/lib/geoblacklight/solr_document/finder.rb
@@ -1,0 +1,39 @@
+module Geoblacklight
+  module SolrDocument
+    ##
+    # Finder methods for SolrDocuments
+    # modeled after Spotlight's Finder module
+    # https://github.com/sul-dlss/spotlight/blob/master/app/models/concerns/spotlight/solr_document/finder.rb
+    module Finder
+      extend ActiveSupport::Concern
+      include Blacklight::Configurable
+
+      ##
+      # Class level finder methods for documents
+      module ClassMethods
+
+        ##
+        # Find a Solr Document from an index
+        # @param [String]
+        def find(id)
+          solr_response = index.find(id)
+          solr_response.documents.first
+        end
+
+        def index
+          @index ||= blacklight_config.repository_class.new(blacklight_config)
+        end
+
+        protected
+
+        def blacklight_config
+          @conf ||= copy_blacklight_config_from(CatalogController)
+        end
+      end
+
+      def blacklight_solr
+        self.class.index.connection
+      end
+    end
+  end
+end

--- a/lib/tasks/geoblacklight.rake
+++ b/lib/tasks/geoblacklight.rake
@@ -28,5 +28,22 @@ namespace :geoblacklight do
     task mkdir: :environment do
       FileUtils.mkdir_p Dir.glob("#{Rails.root}/tmp/cache/downloads")
     end
+    desc 'Precaches a download'
+    task :precache, [:doc_id, :download_type, :timeout] => [:environment] do |t, args|
+      begin
+        fail 'Please supply required arguments [document_id, download_type and timeout]' unless args[:doc_id] && args[:download_type] && args[:timeout]
+        document = Geoblacklight::SolrDocument.find(args[:doc_id])
+        fail Blacklight::Exceptions::RecordNotFound if document[:layer_slug_s] != args[:doc_id]
+        download = "Geoblacklight::#{args[:download_type].capitalize}Download"
+                   .constantize.new(document, timeout: args[:timeout].to_i)
+        download.get
+        Rails.logger.info "Successfully downloaded #{download.file_name}"
+        Rails.logger.info "#{Geoblacklight::ShapefileDownload.file_path}"
+      rescue Geoblacklight::Exceptions::ExternalDownloadFailed => error
+        Rails.logger.error error.message + ' ' + error.url
+      rescue NameError
+        Rails.logger.error "Could not find that download type \"#{args[:download_type]}\""
+      end
+    end
   end
 end

--- a/spec/lib/geoblacklight/solr_document/finder_spec.rb
+++ b/spec/lib/geoblacklight/solr_document/finder_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+describe Geoblacklight::SolrDocument::Finder do
+  let(:subject) { Geoblacklight::SolrDocument }
+  describe '#find' do
+    it 'calls index and returns first document' do
+      documents = %w(first second)
+      response = double('response')
+      index = double('index')
+      expect(response).to receive(:documents).and_return(documents)
+      expect(index).to receive(:find).with('search param').and_return(response)
+      expect(subject).to receive(:index).and_return(index)
+      expect(subject.find('search param')).to eq 'first'
+    end
+  end
+  describe '#index' do
+    it 'creates and returns a Blacklight::SolrRepository' do
+      expect(subject.index).to be_an Blacklight::SolrRepository
+    end
+  end
+end


### PR DESCRIPTION
This pull request adds class methods for finding Solr documents to the `Geoblacklight::SolrDocument` class. Also enables the ability to precache downloads using a rake task.

Rake task call would look something like: 

```sh
$ rake 'geoblacklight:downloads:precache[tufts-cambridgegrid100-04, shapefile, 50]'
```