### PR TITLE
switch from querying solr using rectangle to envelope syntax

### DIFF
--- a/lib/geoblacklight.rb
+++ b/lib/geoblacklight.rb
@@ -1,6 +1,7 @@
 require "geoblacklight/engine"
 
 module Geoblacklight
+  require 'geoblacklight/bounding_box'
   require 'geoblacklight/catalog_helper_override'
   require 'geoblacklight/config'
   require 'geoblacklight/constants'

--- a/lib/geoblacklight/bounding_box.rb
+++ b/lib/geoblacklight/bounding_box.rb
@@ -1,0 +1,44 @@
+module Geoblacklight
+  ##
+  # Transforms and parses a bounding box for various formats
+  class BoundingBox
+    ##
+    # @param [String, Integer, Float] west
+    # @param [String, Integer, Float] south
+    # @param [String, Integer, Float] east
+    # @param [String, Integer, Float] north
+    def initialize(west, south, east, north)
+      @west = west
+      @south = south
+      @east = east
+      @north = north
+      # TODO: check for valid Geometry and raise if not
+    end
+
+    ##
+    # Returns a bounding box in ENVELOPE syntax
+    # @return [String]
+    def to_envelope
+      "ENVELOPE(#{west}, #{east}, #{north}, #{south})"
+    end
+
+    ##
+    # Create a Geoblacklight::BoundingBox from a Solr rectangle syntax
+    # @param [String] bbox as "W S E N"
+    # @return [Geoblacklight::BoundingBox]
+    def self.from_rectangle(rectangle)
+      rectangle_array = rectangle.split(' ')
+      fail Geoblacklight::Exceptions::WrongBoundingBoxFormat, 'Bounding box should be a string in Solr rectangle syntax e.g."W S E N"' if rectangle_array.count != 4
+      new(
+        rectangle_array[0],
+        rectangle_array[1],
+        rectangle_array[2],
+        rectangle_array[3]
+      )
+    end
+
+    private
+
+    attr_reader :west, :south, :east, :north
+  end
+end

--- a/lib/geoblacklight/exceptions.rb
+++ b/lib/geoblacklight/exceptions.rb
@@ -21,5 +21,7 @@ module Geoblacklight
     end
     class WrongDownloadFormat < StandardError
     end
+    class WrongBoundingBoxFormat < StandardError
+    end
   end
 end

--- a/lib/geoblacklight/search_builder.rb
+++ b/lib/geoblacklight/search_builder.rb
@@ -10,11 +10,27 @@ module Geoblacklight
     def add_spatial_params(solr_params)
       if blacklight_params[:bbox]
         solr_params[:bq] ||= []
-        solr_params[:bq] = ["#{Settings.GEOMETRY_FIELD}:\"IsWithin(#{blacklight_params[:bbox]})\"^10"]
+        solr_params[:bq] = ["#{Settings.GEOMETRY_FIELD}:\"IsWithin(#{envelope_bounds})\"^10"]
         solr_params[:fq] ||= []
-        solr_params[:fq] << "#{Settings.GEOMETRY_FIELD}:\"Intersects(#{blacklight_params[:bbox]})\""
+        solr_params[:fq] << "#{Settings.GEOMETRY_FIELD}:\"Intersects(#{envelope_bounds})\""
       end
       solr_params
+    rescue Geoblacklight::Exceptions::WrongBoundingBoxFormat
+      # TODO: Potentially delete bbox params here so that its not rendered as search param
+      solr_params
+    end
+
+    ##
+    # @return [String]
+    def envelope_bounds
+      bounding_box.to_envelope
+    end
+
+    ##
+    # Returns a Geoblacklight::BoundingBox built from the blacklight_params
+    # @return [Geoblacklight::BoundingBox]
+    def bounding_box
+      Geoblacklight::BoundingBox.from_rectangle(blacklight_params[:bbox])
     end
   end
 end

--- a/spec/features/search_bar_spec.rb
+++ b/spec/features/search_bar_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 feature 'search bar' do
   scenario 'present on a spatial search' do
-    visit catalog_index_path(bbox: '25, 3, 75, 35')
+    visit catalog_index_path(bbox: '25 3 75 35')
     expect(page).to have_css '#search-navbar'
   end
   scenario 'present on a text search' do

--- a/spec/lib/geoblacklight/bounding_box_spec.rb
+++ b/spec/lib/geoblacklight/bounding_box_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe Geoblacklight::BoundingBox do
+  describe '#initialize' do
+    it 'handles multiple input types as arguments' do
+      expect(Geoblacklight::BoundingBox.new('1', '1', '1', '1')).to be_an Geoblacklight::BoundingBox
+      expect(Geoblacklight::BoundingBox.new(1, 2, 3, 3)).to be_an Geoblacklight::BoundingBox
+      expect(Geoblacklight::BoundingBox.new(1.1, 2.1, 3.1, 3.1)).to be_an Geoblacklight::BoundingBox
+    end
+  end
+  describe '#to_envelope' do
+    let(:example_box) { Geoblacklight::BoundingBox.new(-160, -80, 120, 70) }
+    it 'creates an envelope syntax version of the bounding box' do
+      expect(example_box.to_envelope).to eq 'ENVELOPE(-160, 120, 70, -80)'
+    end
+  end
+  describe '#from_rectangle' do
+    let(:example_box) { Geoblacklight::BoundingBox.from_rectangle('-160 -80 120 70') }
+    it 'parses and creates a Geoblacklight::BoundingBox from a Solr lat-lon' do
+      expect(example_box).to be_an Geoblacklight::BoundingBox
+      expect(example_box.to_envelope).to eq 'ENVELOPE(-160, 120, 70, -80)'
+    end
+    it 'checks for valididity' do
+      expect { Geoblacklight::BoundingBox.from_rectangle('-160 -80 120') }.to raise_error Geoblacklight::Exceptions::WrongBoundingBoxFormat
+    end
+  end
+end

--- a/spec/lib/geoblacklight/search_builder_spec.rb
+++ b/spec/lib/geoblacklight/search_builder_spec.rb
@@ -36,10 +36,23 @@ describe Geoblacklight::SearchBuilder do
     end
 
     it 'should return a spatial search if bbox is given' do
-      params = { :bbox => '123' }
+      params = { bbox: '-180 -80 120 80' }
       subject.with(params)
-      expect(subject.add_spatial_params(solr_params)[:fq].to_s).to include("Intersects")
+      expect(subject.add_spatial_params(solr_params)[:fq].to_s).to include('Intersects')
+    end
+  end
+  describe '#envelope_bounds' do
+    it 'calls to_envelope on the bounding box' do
+      bbox = double('bbox', to_envelope: 'test')
+      expect(subject).to receive(:bounding_box).and_return bbox
+      expect(subject.envelope_bounds).to eq 'test'
+    end
+  end
+  describe '#bounding_box' do
+    it 'creates a bounding box from a Solr lat-lon rectangle format' do
+      params = { bbox: '-120 -80 120 80' }
+      subject.with(params)
+      expect(subject.bounding_box).to be_an Geoblacklight::BoundingBox
     end
   end
 end
-


### PR DESCRIPTION
Closes #333 & closes #332 

Preliminary testing with Solr 4.10.4 and Solr 5.1 and spatial search seems to be functional. Holding off on  using Solr 5.x in tests until Blacklight does so. https://github.com/projectblacklight/blacklight/pull/1100