### PR TITLE
remove bootstrap-sass gem version locks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,12 +8,6 @@ gemspec
 # it'll want sprockets 2.11.0 and we'll have a conflict
 gem 'sprockets', '2.11.0'
 
-# If we don't specify 3.2.15 we'll end up with sass 3.3.2 in the main
-# Gemfile.lock but since sass-rails gets generated (rails new) into the test app
-# it'll want sass 3.2.0 and we'll have a conflict
-gem 'sass', '~> 3.2.0'
-gem 'bootstrap-sass', ">= 3.2"
-
 group :test do
   # Peg simplecov to < 0.8 until this is resolved:
   # https://github.com/colszowka/simplecov/issues/281


### PR DESCRIPTION
With the latest bootstrap-sass release, we can now remove this from the gem's Gemfile.