### PR TITLE
add exports to toolbar, implementing export to CartoDB

### DIFF
--- a/app/assets/stylesheets/geoblacklight/modules/icon-customization.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/icon-customization.scss
@@ -37,3 +37,8 @@
 .geoblacklight-metadata {
   @extend .fa, .fa-file-text-o;
 }
+
+.geoblacklight-cartodb {
+  @extend .fa, .fa-map-marker;
+}
+

--- a/app/assets/stylesheets/geoblacklight/modules/toolbar.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/toolbar.scss
@@ -27,4 +27,9 @@
     text-align: center;
     width: 1.4em;
   }
+
+  .geoblacklight-cartodb {
+    text-align: center;
+    width: 1.4em;
+  }
 }

--- a/app/helpers/geoblacklight_helper.rb
+++ b/app/helpers/geoblacklight_helper.rb
@@ -91,4 +91,17 @@ module GeoblacklightHelper
   def geoblacklight_basemap
     blacklight_config.basemap_provider || 'mapquest'
   end
+
+  ##
+  # Creates a CartoDB OneClick link link, using the configuration link
+  # @param [String] file_link
+  # @return [String]
+  def cartodb_link(file_link)
+    params  = URI.encode_www_form(
+      file: file_link,
+      provider: application_name,
+      logo: Settings.APPLICATION_LOGO_URL
+    )
+    Settings.CARTODB_ONECLICK_LINK + '?' + params
+  end
 end

--- a/app/views/catalog/_exports.html.erb
+++ b/app/views/catalog/_exports.html.erb
@@ -1,0 +1,6 @@
+<% document ||= @document %>
+<% if document.cartodb_reference.present? %>
+    <%= link_to(cartodb_link(document.cartodb_reference), target: '_blank') do %>
+    <span class='geoblacklight geoblacklight-cartodb'></span>Open in CartoDB
+    <% end %>
+<% end %>

--- a/lib/generators/geoblacklight/templates/catalog_controller.rb
+++ b/lib/generators/geoblacklight/templates/catalog_controller.rb
@@ -211,6 +211,7 @@ class CatalogController < ApplicationController
     # Custom tools for GeoBlacklight
     config.add_show_tools_partial :web_services, if: proc { |_context, _config, options| options[:document] && (Settings.WEBSERVICES_SHOWN & options[:document].references.refs.map(&:type).map(&:to_s)).any? }
     config.add_show_tools_partial :metadata, if: proc { |_context, _config, options| options[:document] && (Settings.METADATA_SHOWN & options[:document].references.refs.map(&:type).map(&:to_s)).any? }
+    config.add_show_tools_partial :exports, partial: 'exports', if: proc { |_context, _config, options| options[:document] }
     config.add_show_tools_partial :downloads, partial: 'downloads', if: proc { |_context, _config, options| options[:document] }
 
     # Configure basemap provider for GeoBlacklight maps (uses https only basemap

--- a/lib/generators/geoblacklight/templates/settings.yml
+++ b/lib/generators/geoblacklight/templates/settings.yml
@@ -1,3 +1,9 @@
+# Configurable Logo Used for CartoDB export
+APPLICATION_LOGO_URL: 'http://geoblacklight.org/images/geoblacklight-logo.png'
+
+# CartoDB OneClick Service https://cartodb.com/open-in-cartodb/
+CARTODB_ONECLICK_LINK: 'http://oneclick.cartodb.com/'
+
 # Download path can be configured using this setting
 #DOWNLOAD_PATH: "./tmp/cache/downloads"
 

--- a/lib/geoblacklight.rb
+++ b/lib/geoblacklight.rb
@@ -10,6 +10,7 @@ module Geoblacklight
   require 'geoblacklight/view_helper_override'
   require 'geoblacklight/item_viewer'
   require 'geoblacklight/solr_document/finder'
+  require 'geoblacklight/solr_document/carto_db'
   require 'geoblacklight/solr_document'
   require 'geoblacklight/wms_layer'
   require 'geoblacklight/wms_layer/feature_info_response'

--- a/lib/geoblacklight/download.rb
+++ b/lib/geoblacklight/download.rb
@@ -74,6 +74,13 @@ module Geoblacklight
       raise Geoblacklight::Exceptions::ExternalDownloadFailed, message: 'Download timed out', url: conn.url_prefix.to_s
     end
 
+    ##
+    # Creates a download url for the object
+    # @return [String]
+    def url_with_params
+      url + '/?' + URI.encode_www_form(@options[:request_params])
+    end
+
     private
 
     ##

--- a/lib/geoblacklight/solr_document.rb
+++ b/lib/geoblacklight/solr_document.rb
@@ -4,6 +4,7 @@ module Geoblacklight
     extend Blacklight::Solr::Document
 
     include Geoblacklight::SolrDocument::Finder
+    include Geoblacklight::SolrDocument::CartoDb
 
     delegate :download_types, to: :references
     delegate :viewer_protocol, to: :item_viewer

--- a/lib/geoblacklight/solr_document/carto_db.rb
+++ b/lib/geoblacklight/solr_document/carto_db.rb
@@ -1,0 +1,15 @@
+module Geoblacklight
+  module SolrDocument
+    ##
+    # Module for providing external CartoDB download references for a document
+    module CartoDb
+      ##
+      # Returns a url to a file that should be used with CartoDB integration
+      # @return [String]
+      def cartodb_reference
+        return unless public? && download_types.try(:[], :geojson).present?
+        Geoblacklight::GeojsonDownload.new(self).url_with_params
+      end
+    end
+  end
+end

--- a/spec/features/exports_spec.rb
+++ b/spec/features/exports_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+feature 'Export features' do
+  feature 'when item is public and wfs is available' do
+    feature 'Open in CartoDB' do
+      scenario 'shows up in tools' do
+        visit catalog_path 'tufts-cambridgegrid100-04'
+        expect(page).to have_css 'li.exports a', text: 'Open in CartoDB'
+        click_link 'Open in CartoDB'
+      end
+    end
+  end
+  feature 'when restricted or no wfs' do
+    scenario 'is not in tools' do
+      visit catalog_path 'princeton-02870w62c'
+      expect(page).to_not have_css 'li.exports a', text: 'Open in CartoDB'
+    end
+  end
+end

--- a/spec/features/split_view.html.erb_spec.rb
+++ b/spec/features/split_view.html.erb_spec.rb
@@ -8,7 +8,7 @@ feature 'Index view', js: true do
   scenario 'should have documents and map on page' do
     visit catalog_index_path(f: { dct_provenance_s: ['Stanford']})
     expect(page).to have_css('#documents')
-    expect(page).to have_css(".document", count: 2)
+    expect(page).to have_css(".document", count: 3)
     expect(page).to have_css('#map')
   end
 
@@ -47,8 +47,8 @@ feature 'Index view', js: true do
 
   scenario 'spatial search should reset to page one' do
     visit '/?per_page=5&q=%2A&page=2'
-    find("#map").double_click
-    expect(find('.page_entries')).to have_content('1 - 2 of 2')
+    find('#map').double_click
+    expect(find('.page_entries')).to have_content(/^1 - \d of \d$/)
   end
 
   scenario 'clicking map search should retain current search parameters' do

--- a/spec/fixtures/solr_documents/public_direct_download.json
+++ b/spec/fixtures/solr_documents/public_direct_download.json
@@ -1,0 +1,31 @@
+{
+  "uuid": "http://purl.stanford.edu/cz128vq0535",
+  "dc_identifier_s": "http://purl.stanford.edu/cz128vq0535",
+  "dc_title_s": "2005 Rural Poverty GIS Database: Uganda",
+  "dc_description_s": "This polygon shapefile contains 2005 poverty data for 855 rural subcounties in Uganda. These data are intended for researchers, students, policy makers and the general public for reference and mapping purposes, and may be used for basic applications such as viewing, querying, and map output production.",
+  "dc_rights_s": "Public",
+  "dct_provenance_s": "Stanford",
+  "dct_references_s": "{\"http://schema.org/url\":\"http://purl.stanford.edu/cz128vq0535\",\"http://schema.org/downloadUrl\":\"http://stacks.stanford.edu/file/druid:cz128vq0535/data.zip\",\"http://www.loc.gov/mods/v3\":\"http://purl.stanford.edu/cz128vq0535.mods\",\"http://www.isotc211.org/schemas/2005/gmd/\":\"http://opengeometadata.stanford.edu/metadata/edu.stanford.purl/druid:cz128vq0535/iso19139.xml\",\"http://www.w3.org/1999/xhtml\":\"http://opengeometadata.stanford.edu/metadata/edu.stanford.purl/druid:cz128vq0535/default.html\",\"http://www.opengis.net/def/serviceType/ogc/wfs\":\"https://geowebservices.stanford.edu/geoserver/wfs\",\"http://www.opengis.net/def/serviceType/ogc/wms\":\"https://geowebservices.stanford.edu/geoserver/wms\"}",
+  "layer_id_s": "druid:cz128vq0535",
+  "layer_slug_s": "stanford-cz128vq0535",
+  "layer_geom_type_s": "Polygon",
+  "layer_modified_dt": "2015-04-16T23:02:57Z",
+  "dc_format_s": "Shapefile",
+  "dc_language_s": "English",
+  "dc_type_s": "Dataset",
+  "dc_publisher_s": "Uganda Bureau of Statistics",
+  "dc_creator_sm": "Uganda Bureau of Statistics",
+  "dc_subject_sm": [
+    "Poverty",
+    "Statistics"
+  ],
+  "dct_issued_s": "2005",
+  "dct_temporal_sm": "2005",
+  "dct_spatial_sm": "Uganda",
+  "dc_relation_sm": "http://sws.geonames.org/226074/about.rdf",
+  "georss_box_s": "-1.478794 29.572742 4.234077 35.000308",
+  "georss_polygon_s": "-1.478794 29.572742 4.234077 29.572742 4.234077 35.000308 -1.478794 35.000308 -1.478794 29.572742",
+  "solr_geom": "ENVELOPE(29.572742, 35.000308, 4.234077, -1.478794)",
+  "solr_year_i": 2005,
+  "stanford_rights_metadata_s": "<?xml version=\"1.0\"?>\n<rightsMetadata>\n  <access type=\"discover\">\n    <machine>\n      <world/>\n    </machine>\n  </access>\n  <access type=\"read\">\n    <machine>\n      <world/>\n    </machine>\n  </access>\n  <use>\n    <human type=\"useAndReproduction\">This item is in the public domain.  There are no restrictions on use.</human>\n    <human type=\"creativeCommons\"/>\n    <machine type=\"creativeCommons\"/>\n  </use>\n  <copyright>\n    <human>This work is in the Public Domain, meaning that it is not subject to copyright.</human>\n  </copyright>\n</rightsMetadata>\n"
+}

--- a/spec/lib/geoblacklight/download_spec.rb
+++ b/spec/lib/geoblacklight/download_spec.rb
@@ -6,7 +6,7 @@ describe Geoblacklight::Download do
   let(:body) { double('body') }
   let(:document) { SolrDocument.new(layer_slug_s: 'test', dct_references_s: {'http://www.opengis.net/def/serviceType/ogc/wms' => 'http://www.example.com/wms'}.to_json) }
   let(:options) { { type: 'shapefile', extension: 'zip', service_type: 'wms', content_type: 'application/zip' } }
-  let(:download) { Geoblacklight::Download.new(document, options) }
+  let(:download) { Geoblacklight::ShapefileDownload.new(document, options) }
 
   describe '#initialize' do
     it 'should initialize as a Download object' do
@@ -76,6 +76,13 @@ describe Geoblacklight::Download do
       expect(response).to receive(:get).and_raise(Faraday::Error::ConnectionFailed.new('Failed'))
       expect(Faraday).to receive(:new).with(url: 'http://www.example.com/wms').and_return(response)
       expect { download.initiate_download }.to raise_error(Geoblacklight::Exceptions::ExternalDownloadFailed)
+    end
+  end
+  describe '#url_with_params' do
+    it 'creates a download url with params' do
+      expect(download.url_with_params).to eq 'http://www.example.com/wms/?ser' \
+        'vice=wfs&version=2.0.0&request=GetFeature&srsName=EPSG%3A4326&output' \
+        'format=SHAPE-ZIP&typeName'
     end
   end
 end

--- a/spec/lib/geoblacklight/solr_document/carto_db_spec.rb
+++ b/spec/lib/geoblacklight/solr_document/carto_db_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe Geoblacklight::SolrDocument::CartoDb do
+  let(:subject) { SolrDocument.new }
+  describe '#cartodb_reference' do
+    it 'returns nil for restricted documents' do
+      expect(subject).to receive(:public?).and_return(false)
+      expect(subject.cartodb_reference).to be_nil
+    end
+    it 'returns nil for no download_types' do
+      expect(subject).to receive(:public?).and_return(true)
+      expect(subject).to receive(:download_types).and_return(nil)
+      expect(subject.cartodb_reference).to be_nil
+    end
+    it 'returns nil with no :geojson download type' do
+      expect(subject).to receive(:public?).and_return(true)
+      expect(subject).to receive(:download_types).and_return(geotiff: 'geotiff')
+      expect(subject.cartodb_reference).to be_nil
+    end
+    it 'Creates and returns a GeojsonDownload url' do
+      expect(subject).to receive(:public?).and_return(true)
+      expect(subject).to receive(:download_types)
+        .and_return(geojson: { 'stuff' => 'stuff' })
+      expect_any_instance_of(Geoblacklight::GeojsonDownload)
+        .to receive(:url_with_params)
+        .and_return('http://www.example.com/geojsonDownload')
+      expect(subject.cartodb_reference).to eq 'http://www.example.com/geojsonDownload'
+    end
+  end
+end


### PR DESCRIPTION
Adds an "Open in CartoDB" link to toolbar for public docs with a wfs web service

<img width="1197" alt="screen shot 2015-07-21 at 8 23 15 am" src="https://cloud.githubusercontent.com/assets/1656824/8804578/c6e3a1d0-2f81-11e5-8d25-f25b9c750451.png">

This also opens up the possibility of adding in a "Open in ArcGIS.com" link as well, but there are still some information barriers before adding that feature.