### PR TITLE
Add detectRetina option for Leaflet basemaps and WMS layers

### DIFF
--- a/app/assets/javascripts/geoblacklight/basemaps.js
+++ b/app/assets/javascripts/geoblacklight/basemaps.js
@@ -5,7 +5,8 @@ GeoBlacklight.Basemaps = {
     'https://cartodb-basemaps-{s}.global.ssl.fastly.net/dark_all/{z}/{x}/{y}.png', {
       attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://cartodb.com/attributions">CartoDB</a>',
       maxZoom: 18,
-      worldCopyJump: true
+      worldCopyJump: true,
+      detectRetina: true
     }
   ),
   mapquest: L.tileLayer(
@@ -13,14 +14,16 @@ GeoBlacklight.Basemaps = {
       attribution: '&copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, Tiles Courtesy of <a href="http://www.mapquest.com/" target="_blank">MapQuest</a> <img src="//developer.mapquest.com/content/osm/mq_logo.png" alt="">',
       maxZoom: 18,
       worldCopyJump: true,
-      subdomains: '1234' // see http://developer.mapquest.com/web/products/open/map
+      subdomains: '1234', // see http://developer.mapquest.com/web/products/open/map
+      detectRetina: true
     }
   ),
   positron: L.tileLayer(
     'https://cartodb-basemaps-{s}.global.ssl.fastly.net/light_all/{z}/{x}/{y}.png', {
       attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://cartodb.com/attributions">CartoDB</a>',
       maxZoom: 18,
-      worldCopyJump: true
+      worldCopyJump: true,
+      detectRetina: true
     }
   )
 };

--- a/app/assets/javascripts/geoblacklight/viewers/wms.js
+++ b/app/assets/javascripts/geoblacklight/viewers/wms.js
@@ -23,7 +23,8 @@ GeoBlacklight.Viewer.Wms = GeoBlacklight.Viewer.Map.extend({
       transparent: true,
       tiled: true,
       CRS: 'EPSG:900913',
-      opacity: 0.75
+      opacity: 0.75,
+      detectRetina: true
     });
     this.overlay.addLayer(wmsLayer);
     this.setupInspection();


### PR DESCRIPTION
'detectRetina' documented [here](http://leafletjs.com/reference.html#tilelayer-detectretina):

> If true and user is on a retina display, it will request four tiles of half the specified size and a bigger zoom level in place of one to utilize the high resolution.