### PR TITLE
add inspection logic to solr document

### DIFF
--- a/app/helpers/geoblacklight_helper.rb
+++ b/app/helpers/geoblacklight_helper.rb
@@ -71,7 +71,7 @@ module GeoblacklightHelper
   end
 
   def show_attribute_table?
-    return true if document_available? && @document.viewer_protocol == 'wms'
+    document_available? && @document.inspectable?
   end
 
   ##

--- a/lib/geoblacklight.rb
+++ b/lib/geoblacklight.rb
@@ -13,6 +13,7 @@ module Geoblacklight
   require 'geoblacklight/item_viewer'
   require 'geoblacklight/solr_document/finder'
   require 'geoblacklight/solr_document/carto_db'
+  require 'geoblacklight/solr_document/inspection'
   require 'geoblacklight/solr_document'
   require 'geoblacklight/wms_layer'
   require 'geoblacklight/wms_layer/feature_info_response'

--- a/lib/geoblacklight/solr_document.rb
+++ b/lib/geoblacklight/solr_document.rb
@@ -5,6 +5,7 @@ module Geoblacklight
 
     include Geoblacklight::SolrDocument::Finder
     include Geoblacklight::SolrDocument::CartoDb
+    include Geoblacklight::SolrDocument::Inspection
 
     delegate :download_types, to: :references
     delegate :viewer_protocol, to: :item_viewer

--- a/lib/geoblacklight/solr_document/inspection.rb
+++ b/lib/geoblacklight/solr_document/inspection.rb
@@ -1,0 +1,15 @@
+module Geoblacklight
+  module SolrDocument
+    ##
+    # Module to provide inspection logic for solr document
+    module Inspection
+      ##
+      # Returns boolean about whether document viewer protocol is inspectable
+      # @return [Boolean]
+      def inspectable?
+        %w(wms)
+          .include? viewer_protocol
+      end
+    end
+  end
+end

--- a/spec/features/metadata_panel_spec.rb
+++ b/spec/features/metadata_panel_spec.rb
@@ -6,7 +6,7 @@ feature 'Metadata tools' do
       visit catalog_path 'stanford-cg357zz0321'
       expect(page).to have_css 'li.metadata a', text: 'Metadata'
       click_link 'Metadata'
-      within '.modal-body' do
+      within 'div.modal-body' do
         expect(page).to have_css 'div.label', text: 'MODS'
         expect(page).to have_css 'div.CodeRay', count: 2
         expect(page).to have_css 'div.label', text: 'ISO 19139'

--- a/spec/lib/geoblacklight/solr_document/inspection_spec.rb
+++ b/spec/lib/geoblacklight/solr_document/inspection_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe Geoblacklight::SolrDocument::Inspection do
+  let(:subject) { SolrDocument.new }
+  describe '#inspectable?' do
+    it 'returns true for wms viewer protocol' do
+      expect(subject).to receive(:viewer_protocol).and_return('wms')
+      expect(subject.inspectable?).to be_truthy
+    end
+
+    it 'returns false for iiif viewer protocol' do
+      expect(subject).to receive(:viewer_protocol).and_return('iiif')
+      expect(subject.inspectable?).to be_falsy
+    end
+  end
+end


### PR DESCRIPTION
Add configurable inspection logic to solr document. Pulled from ESRI service support PR #335.