### PR TITLE
refactor layer opacity control

### DIFF
--- a/app/assets/javascripts/geoblacklight/modules/layer_opacity.js
+++ b/app/assets/javascripts/geoblacklight/modules/layer_opacity.js
@@ -4,11 +4,19 @@
   'use strict';
 
   L.Control.LayerOpacity = L.Control.extend({
-    initialize: function(layerGroup) {
-      var options = {
-        position: 'topleft',
-        layer: layerGroup.getLayers()[0]
-      };
+    initialize: function(layer) {
+      var options = { position: 'topleft' };
+
+      // check if layer is actually a layer group
+      if (typeof layer.getLayers !== 'undefined') {
+
+        // add first layer from layer group to options 
+        options.layer = layer.getLayers()[0];
+      } else {
+
+        // add layer to options
+        options.layer = layer;
+      }
 
       L.Util.setOptions(this, options);
     },

--- a/app/assets/javascripts/geoblacklight/viewers/map.js
+++ b/app/assets/javascripts/geoblacklight/viewers/map.js
@@ -47,6 +47,13 @@ GeoBlacklight.Viewer.Map = GeoBlacklight.Viewer.extend({
   },
 
   /**
+   * Add an opacity control to map.
+   */
+  addOpacityControl: function() {
+    this.map.addControl(new L.Control.LayerOpacity(this.overlay));
+  },
+
+  /**
   * Selects basemap if specified in data options, if not return mapquest
   */
   selectBasemap: function() {

--- a/app/assets/javascripts/geoblacklight/viewers/wms.js
+++ b/app/assets/javascripts/geoblacklight/viewers/wms.js
@@ -30,10 +30,6 @@ GeoBlacklight.Viewer.Wms = GeoBlacklight.Viewer.Map.extend({
     this.setupInspection();
   },
 
-  addOpacityControl: function() {
-    this.map.addControl(new L.Control.LayerOpacity(this.overlay));
-  },
-
   setupInspection: function() {
     var _this = this;
     this.map.on('click', function(e) {

--- a/app/assets/stylesheets/geoblacklight/modules/item.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/item.scss
@@ -2,7 +2,7 @@
   height: 440px;
 }
 
-[data-protocol="wms"][data-available="true"] {
+[data-inspect="true"][data-available="true"] {
   cursor: crosshair;
 }
 

--- a/app/views/catalog/_show_default_viewer_container.html.erb
+++ b/app/views/catalog/_show_default_viewer_container.html.erb
@@ -1,5 +1,5 @@
 <% document ||= @document %>
 <div id='viewer-container' class="col-md-8">
-  <%= content_tag :div, id: 'map', data: { map: 'item', protocol: document.viewer_protocol, url: document.viewer_endpoint, 'layer-id' => wxs_identifier(document), 'map-bbox' => document.bounding_box_as_wsen, 'catalog-path'=> catalog_index_path, available: document_available?, basemap: geoblacklight_basemap } do %>
+  <%= content_tag :div, id: 'map', data: { map: 'item', protocol: document.viewer_protocol.camelize, url: document.viewer_endpoint, 'layer-id' => wxs_identifier(document), 'map-bbox' => document.bounding_box_as_wsen, 'catalog-path'=> catalog_index_path, available: document_available?, inspect: show_attribute_table?, basemap: geoblacklight_basemap } do %>
   <% end %>
 </div>

--- a/spec/features/layer_opacity_spec.rb
+++ b/spec/features/layer_opacity_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+feature 'Layer opacity', js: true do
+  scenario 'WMS layer should have opacity control' do
+    visit catalog_path('mit-us-ma-e25zcta5dct-2000')
+    expect(page).to have_css('div.opacity-text', text: '75%')
+    expect(page.all('div.leaflet-layer')[1][:style]).to eq('opacity: 0.75; ')
+  end
+end


### PR DESCRIPTION
Pulls layer opacity control up into map.js module from wms viewer. Pulled from ESRI service support PR #335.