### PR TITLE
Update to Engine Cart v0.8 in preparation of Blacklight 6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,5 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
-spec/internal
 jetty
+.internal_test_app

--- a/Gemfile
+++ b/Gemfile
@@ -15,9 +15,28 @@ group :test do
   gem 'coveralls', require: false
 end
 
-# load local rails test instance Gemfile
-file = File.expand_path("Gemfile", ENV['ENGINE_CART_DESTINATION'] || ENV['RAILS_ROOT'] || File.expand_path("../spec/internal", __FILE__))
-if File.exists?(file)
-  puts "Loading #{file} ..." if $DEBUG # `ruby -d` or `bundle -v`
-  instance_eval File.read(file)
+# BEGIN ENGINE_CART BLOCK
+# engine_cart: 0.8.0
+# engine_cart stanza: 0.8.0
+# the below comes from engine_cart, a gem used to test this Rails engine gem in the context of a Rails app.
+file = File.expand_path("Gemfile", ENV['ENGINE_CART_DESTINATION'] || ENV['RAILS_ROOT'] || File.expand_path(".internal_test_app", File.dirname(__FILE__)))
+if File.exist?(file)
+  begin
+    eval_gemfile file
+  rescue Bundler::GemfileError => e
+    Bundler.ui.warn '[EngineCart] Skipping Rails application dependencies:'
+    Bundler.ui.warn e.message
+  end
+else
+  Bundler.ui.warn "[EngineCart] Unable to find test application dependencies in #{file}, using placeholder dependencies"
+
+  gem 'rails', ENV['RAILS_VERSION'] if ENV['RAILS_VERSION']
+
+  if ENV['RAILS_VERSION'].nil? || ENV['RAILS_VERSION'] =~ /^4.2/
+    gem 'responders', "~> 2.0"
+    gem 'sass-rails', ">= 5.0"
+  else
+    gem 'sass-rails', "< 5.0"
+  end
 end
+# END ENGINE_CART BLOCK

--- a/Rakefile
+++ b/Rakefile
@@ -29,7 +29,7 @@ end
 
 desc 'Run Teaspoon JavaScript tests'
 task :teaspoon do
-  system("TEASPOON_RAILS_ENV='./spec/internal/config/environment' teaspoon --require=spec/internal/spec/teaspoon_env.rb")
+  system("TEASPOON_RAILS_ENV='.internal_test_app/config/environment' teaspoon --require=.internal_test_app/spec/teaspoon_env.rb")
 end
 
 desc "Execute Continuous Integration build"

--- a/geoblacklight.gemspec
+++ b/geoblacklight.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10.3.2'
   spec.add_development_dependency 'rspec-rails', '~> 3.0.1'
   spec.add_development_dependency 'jettywrapper', '>= 2.0'
-  spec.add_development_dependency 'engine_cart', '~> 0.4.0'
+  spec.add_development_dependency 'engine_cart', '~> 0.8'
   spec.add_development_dependency 'capybara', '~> 2.3.0'
   spec.add_development_dependency 'poltergeist', '~> 1.5.0'
   spec.add_development_dependency 'factory_girl_rails'

--- a/spec/test_app_templates/lib/generators/test_app_generator.rb
+++ b/spec/test_app_templates/lib/generators/test_app_generator.rb
@@ -1,7 +1,7 @@
 require 'rails/generators'
 
 class TestAppGenerator < Rails::Generators::Base
-  source_root '../../spec/test_app_templates'
+  source_root File.expand_path('../../../../spec/test_app_templates', __FILE__)
 
   def add_gems
     gem 'blacklight', "~> 5.9"


### PR DESCRIPTION
Note to developers: this changes the location of the test app. Test app location now at `.internal_test_app`