### PR TITLE
Adds simple IIIF generated JPEG download option

### DIFF
--- a/app/assets/javascripts/geoblacklight/modules/layer_opacity.js
+++ b/app/assets/javascripts/geoblacklight/modules/layer_opacity.js
@@ -4,11 +4,19 @@
   'use strict';
 
   L.Control.LayerOpacity = L.Control.extend({
-    initialize: function(layerGroup) {
-      var options = {
-        position: 'topleft',
-        layer: layerGroup.getLayers()[0]
-      };
+    initialize: function(layer) {
+      var options = { position: 'topleft' };
+
+      // check if layer is actually a layer group
+      if (typeof layer.getLayers !== 'undefined') {
+
+        // add first layer from layer group to options 
+        options.layer = layer.getLayers()[0];
+      } else {
+
+        // add layer to options
+        options.layer = layer;
+      }
 
       L.Util.setOptions(this, options);
     },

--- a/app/assets/javascripts/geoblacklight/viewers/map.js
+++ b/app/assets/javascripts/geoblacklight/viewers/map.js
@@ -47,6 +47,13 @@ GeoBlacklight.Viewer.Map = GeoBlacklight.Viewer.extend({
   },
 
   /**
+   * Add an opacity control to map.
+   */
+  addOpacityControl: function() {
+    this.map.addControl(new L.Control.LayerOpacity(this.overlay));
+  },
+
+  /**
   * Selects basemap if specified in data options, if not return mapquest
   */
   selectBasemap: function() {

--- a/app/assets/javascripts/geoblacklight/viewers/wms.js
+++ b/app/assets/javascripts/geoblacklight/viewers/wms.js
@@ -30,10 +30,6 @@ GeoBlacklight.Viewer.Wms = GeoBlacklight.Viewer.Map.extend({
     this.setupInspection();
   },
 
-  addOpacityControl: function() {
-    this.map.addControl(new L.Control.LayerOpacity(this.overlay));
-  },
-
   setupInspection: function() {
     var _this = this;
     this.map.on('click', function(e) {

--- a/app/assets/stylesheets/geoblacklight/modules/item.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/item.scss
@@ -2,7 +2,7 @@
   height: 440px;
 }
 
-[data-protocol="wms"][data-available="true"] {
+[data-inspect="true"][data-available="true"] {
   cursor: crosshair;
 }
 

--- a/app/controllers/download_controller.rb
+++ b/app/controllers/download_controller.rb
@@ -4,13 +4,13 @@ class DownloadController < ApplicationController
   rescue_from Geoblacklight::Exceptions::ExternalDownloadFailed do |exception|
     Geoblacklight.logger.error exception.message + ' ' + exception.url
     flash[:danger] = view_context
-                         .content_tag(:span,
-                                      flash_error_message(exception),
-                                      data: {
-                                          download: 'error',
-                                          download_id: params[:id],
-                                          download_type: "generated-#{params[:type]}"
-                                      })
+                     .content_tag(:span,
+                         flash_error_message(exception),
+                         data: {
+                           download: 'error',
+                           download_id: params[:id],
+                           download_type: "generated-#{params[:type]}"
+                         })
     respond_to do |format|
       format.json { render json: flash, response: response }
       format.html { render json: flash, response: response }
@@ -64,10 +64,10 @@ class DownloadController < ApplicationController
     if exception.url
       message = t('geoblacklight.download.error_with_url',
                   link: view_context
-                            .link_to(exception.url,
-                                     exception.url,
-                                     target: 'blank'))
-                    .html_safe
+                        .link_to(exception.url,
+                                 exception.url,
+                                 target: 'blank'))
+                .html_safe
     else
       message = t('geoblacklight.download.error')
     end
@@ -81,17 +81,17 @@ class DownloadController < ApplicationController
 
   def check_type
     response = case params[:type]
-                 when 'shapefile'
-                   Geoblacklight::ShapefileDownload.new(@document).get
-                 when 'kmz'
-                   Geoblacklight::KmzDownload.new(@document).get
-                 when 'geojson'
-                   Geoblacklight::GeojsonDownload.new(@document).get
-                 when 'geotiff'
-                   Geoblacklight::GeotiffDownload.new(@document).get
-                 when 'jpg'
-                   Geoblacklight::JpgDownload.new(@document).get
-               end
+    when 'shapefile'
+      Geoblacklight::ShapefileDownload.new(@document).get
+    when 'kmz'
+      Geoblacklight::KmzDownload.new(@document).get
+    when 'geojson'
+      Geoblacklight::GeojsonDownload.new(@document).get
+    when 'geotiff'
+      Geoblacklight::GeotiffDownload.new(@document).get
+    when 'jpg'
+      Geoblacklight::JpgDownload.new(@document).get
+    end
   end
 
   def validate(response)

--- a/app/controllers/download_controller.rb
+++ b/app/controllers/download_controller.rb
@@ -4,13 +4,13 @@ class DownloadController < ApplicationController
   rescue_from Geoblacklight::Exceptions::ExternalDownloadFailed do |exception|
     Geoblacklight.logger.error exception.message + ' ' + exception.url
     flash[:danger] = view_context
-                     .content_tag(:span,
-                                  flash_error_message(exception),
-                                  data: {
-                                    download: 'error',
-                                    download_id: params[:id],
-                                    download_type: "generated-#{params[:type]}"
-                                  })
+                         .content_tag(:span,
+                                      flash_error_message(exception),
+                                      data: {
+                                          download: 'error',
+                                          download_id: params[:id],
+                                          download_type: "generated-#{params[:type]}"
+                                      })
     respond_to do |format|
       format.json { render json: flash, response: response }
       format.html { render json: flash, response: response }
@@ -64,10 +64,10 @@ class DownloadController < ApplicationController
     if exception.url
       message = t('geoblacklight.download.error_with_url',
                   link: view_context
-                        .link_to(exception.url,
-                                 exception.url,
-                                 target: 'blank'))
-                .html_safe
+                            .link_to(exception.url,
+                                     exception.url,
+                                     target: 'blank'))
+                    .html_safe
     else
       message = t('geoblacklight.download.error')
     end
@@ -81,19 +81,21 @@ class DownloadController < ApplicationController
 
   def check_type
     response = case params[:type]
-    when 'shapefile'
-      Geoblacklight::ShapefileDownload.new(@document).get
-    when 'kmz'
-      Geoblacklight::KmzDownload.new(@document).get
-    when 'geojson'
-      Geoblacklight::GeojsonDownload.new(@document).get
-    when 'geotiff'
-      Geoblacklight::GeotiffDownload.new(@document).get
-    end
+                 when 'shapefile'
+                   Geoblacklight::ShapefileDownload.new(@document).get
+                 when 'kmz'
+                   Geoblacklight::KmzDownload.new(@document).get
+                 when 'geojson'
+                   Geoblacklight::GeojsonDownload.new(@document).get
+                 when 'geotiff'
+                   Geoblacklight::GeotiffDownload.new(@document).get
+                 when 'jpg'
+                   Geoblacklight::JpgDownload.new(@document).get
+               end
   end
 
   def validate(response)
-    flash[:success] = view_context.link_to(t('geoblacklight.download.success', title: response), download_file_path(response), data: { download: 'trigger', download_id: params[:id], download_type: "generated-#{params[:type]}"})
+    flash[:success] = view_context.link_to(t('geoblacklight.download.success', title: response), download_file_path(response), data: {download: 'trigger', download_id: params[:id], download_type: "generated-#{params[:type]}"})
   end
 
   # Checks whether a document is public, if not require user to authenticate

--- a/app/views/catalog/_show_default_viewer_container.html.erb
+++ b/app/views/catalog/_show_default_viewer_container.html.erb
@@ -1,5 +1,5 @@
 <% document ||= @document %>
 <div id='viewer-container' class="col-md-8">
-  <%= content_tag :div, id: 'map', data: { map: 'item', protocol: document.viewer_protocol, url: document.viewer_endpoint, 'layer-id' => wxs_identifier(document), 'map-bbox' => document.bounding_box_as_wsen, 'catalog-path'=> catalog_index_path, available: document_available?, basemap: geoblacklight_basemap } do %>
+  <%= content_tag :div, id: 'map', data: { map: 'item', protocol: document.viewer_protocol.camelize, url: document.viewer_endpoint, 'layer-id' => wxs_identifier(document), 'map-bbox' => document.bounding_box_as_wsen, 'catalog-path'=> catalog_index_path, available: document_available?, inspect: show_attribute_table?, basemap: geoblacklight_basemap } do %>
   <% end %>
 </div>

--- a/config/locales/geoblacklight.en.yml
+++ b/config/locales/geoblacklight.en.yml
@@ -19,9 +19,11 @@ en:
       geotiff: 'GeoTIFF'
       kmz: 'KMZ'
       shapefile: 'Shapefile'
+      jpg: 'JPEG'
     references:
       wms: 'Web Mapping Service (WMS)'
       wfs: 'Web Feature Service (WFS)'
+      iiif: 'International Image Interoperability Framework (IIIF)'
       iso19139: 'ISO 19139'
       mods: 'MODS'
       fgdc: 'FGDC'

--- a/lib/generators/geoblacklight/templates/settings.yml
+++ b/lib/generators/geoblacklight/templates/settings.yml
@@ -29,6 +29,7 @@ TIMEOUT_WMS: 4
 WEBSERVICES_SHOWN:
   - 'wms'
   - 'wfs'
+  - 'iiif'
 
 # WMS Parameters
 WMS_PARAMS:

--- a/lib/geoblacklight.rb
+++ b/lib/geoblacklight.rb
@@ -23,6 +23,7 @@ module Geoblacklight
   require 'geoblacklight/download/kmz_download'
   require 'geoblacklight/download/shapefile_download'
   require 'geoblacklight/download/hgl_download'
+  require 'geoblacklight/download/jpg_download'
   require 'geoblacklight/metadata'
   require 'geoblacklight/reference'
   require 'geoblacklight/references'

--- a/lib/geoblacklight/download.rb
+++ b/lib/geoblacklight/download.rb
@@ -63,10 +63,8 @@ module Geoblacklight
       conn = Faraday.new(url: url)
       conn.get do |request|
         request.params = @options[:request_params]
-        request.options = {
-            timeout: timeout,
-            open_timeout: timeout
-        }
+        request.options.timeout = timeout
+        request.options.open_timeout = timeout
       end
     rescue Faraday::Error::ConnectionFailed => error
       raise Geoblacklight::Exceptions::ExternalDownloadFailed, message: 'Download connection failed', url: conn.url_prefix.to_s
@@ -95,13 +93,7 @@ module Geoblacklight
     # URL for download
     # @return [String] URL that is checked in download
     def url
-      if @options[:service_type] == "iiif" # If generated JPG download, the URL sent to Faraday is altered here to remove '/info.json' from the IIIF endpoint
-        url = @document.download_types[:jpg][:iiif]
-        url.slice! "info.json"
-        url += "/full/full/0/default.jpg"
-      else
-        url = @document.references.send(@options[:service_type]).endpoint
-      end
+      url = @document.references.send(@options[:service_type]).endpoint
       url += '/reflect' if @options[:reflect]
       url
     end

--- a/lib/geoblacklight/download.rb
+++ b/lib/geoblacklight/download.rb
@@ -63,8 +63,10 @@ module Geoblacklight
       conn = Faraday.new(url: url)
       conn.get do |request|
         request.params = @options[:request_params]
-        request.options.timeout = timeout
-        request.options.open_timeout = timeout
+        request.options = {
+            timeout: timeout,
+            open_timeout: timeout
+        }
       end
     rescue Faraday::Error::ConnectionFailed => error
       raise Geoblacklight::Exceptions::ExternalDownloadFailed, message: 'Download connection failed', url: conn.url_prefix.to_s
@@ -93,7 +95,13 @@ module Geoblacklight
     # URL for download
     # @return [String] URL that is checked in download
     def url
-      url = @document.references.send(@options[:service_type]).endpoint
+      if @options[:service_type] == "iiif" # If generated JPG download, the URL sent to Faraday is altered here to remove '/info.json' from the IIIF endpoint
+        url = @document.download_types[:jpg][:iiif]
+        url.slice! "info.json"
+        url += "/full/full/0/default.jpg"
+      else
+        url = @document.references.send(@options[:service_type]).endpoint
+      end
       url += '/reflect' if @options[:reflect]
       url
     end

--- a/lib/geoblacklight/download/jpg_download.rb
+++ b/lib/geoblacklight/download/jpg_download.rb
@@ -1,0 +1,14 @@
+module Geoblacklight
+  class JpgDownload < Geoblacklight::Download
+
+    def initialize(document, options = {})
+      super(document, {
+                        type: 'jpg',
+                        extension: 'jpg',
+                        request_params: {},
+                        content_type: 'image/jpeg',
+                        service_type: 'iiif'
+                    }.merge(options))
+    end
+  end
+end

--- a/lib/geoblacklight/download/jpg_download.rb
+++ b/lib/geoblacklight/download/jpg_download.rb
@@ -1,6 +1,12 @@
 module Geoblacklight
   class JpgDownload < Geoblacklight::Download
 
+    def url
+      url = @document.download_types[:jpg][:iiif]
+      url.slice! "info.json"
+      url += "full/full/0/default.jpg"
+    end
+
     def initialize(document, options = {})
       super(document, {
                         type: 'jpg',

--- a/lib/geoblacklight/references.rb
+++ b/lib/geoblacklight/references.rb
@@ -34,14 +34,14 @@ module Geoblacklight
     # @return [Hash, nil]
     def downloads_by_format
       case format
-        when 'Scanned Map'
-          scanned_download_formats
-        when 'Shapefile'
-          vector_download_formats
-        when 'GeoTIFF'
-          geotiff_download_formats
-        when 'ArcGRID'
-          arcgrid_download_formats
+      when 'Scanned Map'
+        scanned_download_formats
+      when 'Shapefile'
+        vector_download_formats
+      when 'GeoTIFF'
+        geotiff_download_formats
+      when 'ArcGRID'
+        arcgrid_download_formats
       end
     end
 

--- a/lib/geoblacklight/references.rb
+++ b/lib/geoblacklight/references.rb
@@ -34,12 +34,14 @@ module Geoblacklight
     # @return [Hash, nil]
     def downloads_by_format
       case format
-      when 'Shapefile'
-        vector_download_formats
-      when 'GeoTIFF'
-        geotiff_download_formats
-      when 'ArcGRID'
-        arcgrid_download_formats
+        when 'Scanned Map'
+          scanned_download_formats
+        when 'Shapefile'
+          vector_download_formats
+        when 'GeoTIFF'
+          geotiff_download_formats
+        when 'ArcGRID'
+          arcgrid_download_formats
       end
     end
 
@@ -78,6 +80,13 @@ module Geoblacklight
       if wfs && wms
         { shapefile: wfs.to_hash, kmz: wms.to_hash, geojson: wfs.to_hash } if wms.present? && wfs.present?
       end
+    end
+
+    ##
+    # Download hash for a JPG file with a IIIF reference present
+    # @return (see #downloads_by_format)
+    def scanned_download_formats
+      { jpg: iiif.to_hash } if iiif.present?
     end
 
     ##

--- a/spec/features/layer_opacity_spec.rb
+++ b/spec/features/layer_opacity_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+feature 'Layer opacity', js: true do
+  scenario 'WMS layer should have opacity control' do
+    visit catalog_path('mit-us-ma-e25zcta5dct-2000')
+    expect(page).to have_css('div.opacity-text', text: '75%')
+    expect(page.all('div.leaflet-layer')[1][:style]).to eq('opacity: 0.75; ')
+  end
+end


### PR DESCRIPTION
This pull request adds support for a "JPEG Download" option, nested under "Generated" in the download box, whenever a IIIF endpoint is available. It requests a full-sized JPEG image (/full/full/0/default.jpg) from that endpoint.

I really have no idea if I've implemented this in the best possible way, so please let me know what I can improve.