### PR TITLE
fix issue with precompiling favicon

### DIFF
--- a/lib/generators/geoblacklight/install_generator.rb
+++ b/lib/generators/geoblacklight/install_generator.rb
@@ -21,6 +21,9 @@ module Geoblacklight
     def assets
       copy_file "geoblacklight.css.scss", "app/assets/stylesheets/geoblacklight.css.scss"
       copy_file "geoblacklight.js", "app/assets/javascripts/geoblacklight.js"
+
+      append_to_file 'config/initializers/assets.rb',
+        "\nRails.application.config.assets.precompile += %w( favicon.ico )\n"
     end
 
     def create_blacklight_catalog


### PR DESCRIPTION
Not sure about the origin of this error, but this PR addresses an issue where running the rails console raises an asset not compiled exception. Closes #364