### PR TITLE
Adds JPG download button when IIIF reference present

### DIFF
--- a/app/helpers/geoblacklight_helper.rb
+++ b/app/helpers/geoblacklight_helper.rb
@@ -15,6 +15,10 @@ module GeoblacklightHelper
     document_available? && @document.downloadable?
   end
 
+  def iiif_jpg_url
+    @document.references.iiif.endpoint.sub! 'info.json', 'full/full/0/default.jpg'
+  end
+
   def snippit(text)
     if text
       if text.length > 150

--- a/app/models/concerns/geoblacklight/solr_document.rb
+++ b/app/models/concerns/geoblacklight/solr_document.rb
@@ -24,7 +24,7 @@ module Geoblacklight
     end
 
     def downloadable?
-      (direct_download || download_types.present?) && available?
+      (direct_download || download_types.present? || iiif_download) && available?
     end
 
     def references
@@ -41,6 +41,10 @@ module Geoblacklight
 
     def same_institution?
       fetch(:dct_provenance_s).downcase == Settings.INSTITUTION.downcase
+    end
+
+    def iiif_download
+      return references.iiif.to_hash unless references.iiif.blank?
     end
 
     def item_viewer

--- a/app/views/catalog/_downloads.html.erb
+++ b/app/views/catalog/_downloads.html.erb
@@ -8,6 +8,8 @@
       <%= link_to(download_text(document.download_types.first[0]),
       download_hgl_path(id: document), data: {ajax_modal: 'trigger', download: 'trigger', download_type: 'harvard-hgl', download_id: document[:layer_slug_s] },
       class: 'btn btn-default') %>
+      <% elsif document.iiif_download.present? %>
+          <%= link_to "Download JPG", iiif_jpg_url, class: 'btn btn-default', download: 'trigger' %>
       <% else %>
       <%= link_to(download_text(document.download_types.first[0]), '', data: { download_path: "#{download_path(document[:layer_slug_s], type: document.download_types.first[0])}", download: 'trigger', download_type: document.download_types.first[0], download_id: document[:layer_slug_s] }, class: 'btn btn-default') %>
       <% end %>
@@ -29,8 +31,16 @@
           <%= link_to(download_text(@document[:dc_format_s]), document.direct_download[:download], 'contentUrl' => document.direct_download[:download], data: { download: 'trigger', download_type: 'direct', download_id: document[:layer_slug_s] }) %>
         </li>
         <% end %>
-        <% if document.download_types.present? %>
+        <% if document.download_types.present? || document.iiif_download.present? %>
         <li role="presentation" class="dropdown-header">Generated</li>
+        <% end %>
+        <% if document.iiif_download.present? %>
+        <li>
+          <%= link_to "Download JPG", iiif_jpg_url, download: 'trigger' %>
+        </li>
+        <% end %>
+
+        <% if document.download_types.present? %>
         <% document.download_types.each do |type| %>
         <%= content_tag(:li) do %>
         <% link_to(download_text(type[0]), '', data: { download_path: "#{download_path(document[:layer_slug_s], type: type[0])}", download: 'trigger', download_type: type[0], download_id: document[:layer_slug_s] }) %>

--- a/config/locales/geoblacklight.en.yml
+++ b/config/locales/geoblacklight.en.yml
@@ -22,6 +22,7 @@ en:
     references:
       wms: 'Web Mapping Service (WMS)'
       wfs: 'Web Feature Service (WFS)'
+      iiif: 'International Image Interoperability Framework (IIIF)'
       iso19139: 'ISO 19139'
       mods: 'MODS'
       fgdc: 'FGDC'

--- a/lib/generators/geoblacklight/templates/settings.yml
+++ b/lib/generators/geoblacklight/templates/settings.yml
@@ -29,6 +29,7 @@ TIMEOUT_WMS: 4
 WEBSERVICES_SHOWN:
   - 'wms'
   - 'wfs'
+  - 'iiif'
   - 'feature_layer'
   - 'tiled_map_layer'
   - 'dynamic_map_layer'

--- a/spec/features/download_layer_spec.rb
+++ b/spec/features/download_layer_spec.rb
@@ -21,6 +21,14 @@ feature 'Download layer' do
     find('a', text: 'Download KMZ').click
     expect(page).to have_css('a', text: 'Your file mit-us-ma-e25zcta5dct-2000-kmz.kmz is ready for download')
   end
+  scenario 'jpg download option should be present under toggle' do
+    visit catalog_path('princeton-02870w62c')
+    expect(page).to have_css('li a', text: 'Download JPG')
+  end
+  scenario 'clicking jpg download button should redirect to external image' do
+    visit catalog_path('princeton-02870w62c')
+    expect(page).to have_css("a.btn.btn-default[href='http://libimages.princeton.edu/loris2/pudl0076%2Fmap_pownall%2F00000001.jp2/full/full/0/default.jpg']", text: 'Download JPG')
+  end
   scenario 'options should be available under toggle' do
     visit catalog_path('mit-us-ma-e25zcta5dct-2000')
     find('button.download-dropdown-toggle').click

--- a/spec/helpers/geoblacklight_helpers_spec.rb
+++ b/spec/helpers/geoblacklight_helpers_spec.rb
@@ -44,6 +44,23 @@ describe GeoblacklightHelper, type: :helper do
       expect(geoblacklight_basemap).to eq 'positron'
     end
   end
+
+  describe '#iiif_jpg_url' do
+    let(:document) { SolrDocument.new(document_attributes) }
+    let(:document_attributes) do
+      {
+        dct_references_s: {
+          'http://iiif.io/api/image' => 'https://example.edu/image/info.json'
+        }.to_json
+      }
+    end
+
+    it 'returns JPG download URL when given URL to a IIIF info.json' do
+      assign(:document, document)
+      expect(helper.iiif_jpg_url).to eq 'https://example.edu/image/full/full/0/default.jpg'
+    end
+  end
+
   describe '#render_web_services' do
     let(:reference) { double(type: 'wms') }
     it 'with a reference to a defined partial' do

--- a/spec/models/concerns/geoblacklight/solr_document_spec.rb
+++ b/spec/models/concerns/geoblacklight/solr_document_spec.rb
@@ -121,6 +121,26 @@ describe Geoblacklight::SolrDocument do
       end
     end
   end
+  describe 'iiif_download' do
+    describe 'with a IIIF download' do
+      let(:document_attributes) do
+        {
+          dct_references_s: {
+            'http://iiif.io/api/image' => 'https://example.edu/images/info.json'
+          }.to_json
+        }
+      end
+      it 'returns a IIIF download hash' do
+        expect(document.iiif_download[:iiif]).to eq('https://example.edu/images/info.json')
+      end
+    end
+    describe 'without a IIIF download' do
+      let(:document_attributes) { {} }
+      it 'returns nil' do
+        expect(document.iiif_download).to be_nil
+      end
+    end
+  end
   describe 'item_viewer' do
     let(:document_attributes) { {} }
     it 'is a ItemViewer' do


### PR DESCRIPTION
I took another quick stab at this. Not sure if it's the most elegant way of going about it... but it does bypass the download controller, so the "Download JPG" button will directly open a `/full/full/0/default.jpg` image in a new window.

Any thoughts? (Also, just to clarify, should I not have pushed this to a branch on the `geoblacklight/geoblacklight` repo? If so, I'll do this on a fork next time.)