### PR TITLE
Fixes CartoDB OneClick multi-value application name bug

### DIFF
--- a/app/helpers/geoblacklight_helper.rb
+++ b/app/helpers/geoblacklight_helper.rb
@@ -106,13 +106,20 @@ module GeoblacklightHelper
   end
 
   ##
+  # Removes blank space from provider to accomodate CartoDB OneClick
+  #
+  def cartodb_provider
+    application_name.delete(' ')
+  end
+
+  ##
   # Creates a CartoDB OneClick link link, using the configuration link
   # @param [String] file_link
   # @return [String]
   def cartodb_link(file_link)
     params  = URI.encode_www_form(
       file: file_link,
-      provider: application_name,
+      provider: cartodb_provider,
       logo: Settings.APPLICATION_LOGO_URL
     )
     Settings.CARTODB_ONECLICK_LINK + '?' + params

--- a/spec/helpers/geoblacklight_helpers_spec.rb
+++ b/spec/helpers/geoblacklight_helpers_spec.rb
@@ -61,6 +61,14 @@ describe GeoblacklightHelper, type: :helper do
     end
   end
 
+  describe '#cartodb_link' do
+    let(:application_name) { 'My GeoBlacklight Deployment' }
+
+    it 'removes spaces from application_name to produce valid CartoDB request URL' do
+      expect(cartodb_link('http://demo.org/wfs/layer.json')).to eq 'http://oneclick.cartodb.com/?file=http%3A%2F%2Fdemo.org%2Fwfs%2Flayer.json&provider=MyGeoBlacklightDeployment&logo=http%3A%2F%2Fgeoblacklight.org%2Fimages%2Fgeoblacklight-logo.png'
+    end
+  end
+
   describe '#render_web_services' do
     let(:reference) { double(type: 'wms') }
     it 'with a reference to a defined partial' do


### PR DESCRIPTION
Removes any whitespace from `application_name` before sending it as the `provider` param.

Referenced in https://github.com/geoblacklight/geoblacklight/issues/386

Issue on the CartoDB side already documented here https://github.com/CartoDB/cartodb/issues/6092