### PR TITLE
uses simplified MIME type of download for comparison

### DIFF
--- a/lib/geoblacklight/download.rb
+++ b/lib/geoblacklight/download.rb
@@ -40,11 +40,8 @@ module Geoblacklight
     def create_download_file
       download = initiate_download
       File.open("#{file_path_and_name}.tmp", 'wb') do |file|
-        if download.headers['content-type'] == @options[:content_type]
-          file.write download.body
-        else
-          fail Geoblacklight::Exceptions::WrongDownloadFormat
-        end
+        fail Geoblacklight::Exceptions::WrongDownloadFormat unless matches_mimetype?(download)
+        file.write download.body
       end
       File.rename("#{file_path_and_name}.tmp", file_path_and_name)
       file_name
@@ -85,6 +82,10 @@ module Geoblacklight
     end
 
     private
+
+    def matches_mimetype?(download)
+      MIME::Type.simplified(download.headers['content-type']) == @options[:content_type]
+    end
 
     ##
     # Returns timeout for the download request. `timeout` passed as an option to

--- a/spec/lib/geoblacklight/download_spec.rb
+++ b/spec/lib/geoblacklight/download_spec.rb
@@ -64,6 +64,13 @@ describe Geoblacklight::Download do
       expect(File).to receive(:rename)
       expect(download.create_download_file).to eq download.file_name
     end
+    it 'accepts response MIME type that is more complex than requested' do
+      geojson = OpenStruct.new(headers: { 'content-type' => 'application/json;charset=utf-8' })
+      expect(download).to receive(:initiate_download).and_return(geojson)
+      expect(File).to receive(:open).with("#{download.file_path_and_name}.tmp", 'wb').and_return('')
+      expect(File).to receive(:rename)
+      expect(download.create_download_file).to eq download.file_name
+    end
   end
   describe '#initiate_download' do
     it 'request download from server' do


### PR DESCRIPTION
To get around an error in which GeoServer returns a download with a Content-Type that is correct, but more detailed than what was requested. Like when `application/json` is requested but the download from GeoServer is `application/json; chartype=UTF-8`