### PR TITLE
Make detect retina configurable

### DIFF
--- a/app/assets/javascripts/geoblacklight/viewers/map.js
+++ b/app/assets/javascripts/geoblacklight/viewers/map.js
@@ -47,14 +47,20 @@ GeoBlacklight.Viewer.Map = GeoBlacklight.Viewer.extend({
   },
 
   /**
-  * Selects basemap if specified in data options, if not return mapquest
+  * Selects basemap if specified in data options, if not return positron.
   */
   selectBasemap: function() {
     var _this = this;
+    var basemap;
+
     if (_this.data.basemap) {
-      return GeoBlacklight.Basemaps[_this.data.basemap];
+      basemap = GeoBlacklight.Basemaps[_this.data.basemap];
     } else {
-      return _this.basemap.positron;
+      basemap = _this.basemap.positron;
     }
+
+    // Use value from app settings to set the detect retina option.
+    basemap.options.detectRetina = _this.detectRetina();
+    return basemap;
   }
 });

--- a/app/assets/javascripts/geoblacklight/viewers/viewer.js
+++ b/app/assets/javascripts/geoblacklight/viewers/viewer.js
@@ -51,5 +51,17 @@ GeoBlacklight.Viewer = L.Class.extend({
   **/
   controlPreload: function() {
     return;
+  },
+
+  /**
+  * Gets the value of detect retina from application settings.
+  **/
+  detectRetina: function() {
+    var options = this.data.leafletOptions;
+    if (options && options.LAYERS) {
+      return options.LAYERS.DETECT_RETINA ? options.LAYERS.DETECT_RETINA : false;
+    } else {
+      return false;
+    }
   }
 });

--- a/app/assets/javascripts/geoblacklight/viewers/wms.js
+++ b/app/assets/javascripts/geoblacklight/viewers/wms.js
@@ -17,6 +17,7 @@ GeoBlacklight.Viewer.Wms = GeoBlacklight.Viewer.Map.extend({
   },
 
   addPreviewLayer: function() {
+    var _this = this;
     var wmsLayer = L.tileLayer.wms(this.data.url, {
       layers: this.data.layerId,
       format: 'image/png',
@@ -24,7 +25,7 @@ GeoBlacklight.Viewer.Wms = GeoBlacklight.Viewer.Map.extend({
       tiled: true,
       CRS: 'EPSG:900913',
       opacity: this.options.opacity,
-      detectRetina: true
+      detectRetina: _this.detectRetina()
     });
     this.overlay.addLayer(wmsLayer);
     this.setupInspection();

--- a/app/views/catalog/_document_split.html.erb
+++ b/app/views/catalog/_document_split.html.erb
@@ -1,4 +1,4 @@
 <div id="documents" class="docView col-md-6">
   <%= render documents, :as => :document %>
 </div>
-<%= content_tag :div, '', id: 'map', data: { map: 'index', 'catalog-path'=> search_catalog_path , 'map-bbox' => params[:bbox], basemap: geoblacklight_basemap } %>
+<%= content_tag :div, '', id: 'map', data: { map: 'index', 'catalog-path'=> search_catalog_path , 'map-bbox' => params[:bbox], basemap: geoblacklight_basemap, leaflet_options: leaflet_options } %>

--- a/app/views/catalog/_home_text.html.erb
+++ b/app/views/catalog/_home_text.html.erb
@@ -43,7 +43,7 @@
     </div>
     <div class='col-md-6 text-center'>
       <%= content_tag :h3, t('geoblacklight.home.map_heading') %>
-      <%= content_tag :div, '', id: 'map', data: { map: 'home', 'catalog-path'=> search_catalog_path , 'map-bbox' => params[:bbox], basemap: geoblacklight_basemap } %>
+      <%= content_tag :div, '', id: 'map', data: { map: 'home', 'catalog-path'=> search_catalog_path , 'map-bbox' => params[:bbox], basemap: geoblacklight_basemap, leaflet_options: leaflet_options } %>
     </div>
   </div>
 </div>

--- a/lib/generators/geoblacklight/templates/settings.yml
+++ b/lib/generators/geoblacklight/templates/settings.yml
@@ -72,6 +72,7 @@ OPACITY_CONTROL: &opacity_control
 LEAFLET:
   MAP:
   LAYERS:
+    DETECT_RETINA: true
   VIEWERS:
     WMS:
       <<: *opacity_control


### PR DESCRIPTION
Make leaflet retina detection configurable in `settings.yml`. This directly impacts all base maps as well as the `wms` viewer. Closes #415.