### PR TITLE
Route to catalog instead of solr_documents

### DIFF
--- a/lib/generators/geoblacklight/install_generator.rb
+++ b/lib/generators/geoblacklight/install_generator.rb
@@ -18,7 +18,7 @@ module Geoblacklight
     def inject_geoblacklight_routes
       route <<-EOF.strip_heredoc
           concern :gbl_exportable, Geoblacklight::Routes::Exportable.new
-          resources :solr_documents, only: [:show], controller: 'catalog' do
+          resources :solr_documents, only: [:show], path: '/catalog', controller: 'catalog' do
             concerns :gbl_exportable
           end
 


### PR DESCRIPTION
Routes to item show pages were going to `/solr_documents/:id` instead of  `catalog/:id`. This fixes it.