### PR TITLE
schema changes for v1.0.0

### DIFF
--- a/lib/tasks/geoblacklight.rake
+++ b/lib/tasks/geoblacklight.rake
@@ -18,6 +18,21 @@ namespace :geoblacklight do
         Blacklight.default_index.connection.commit
       end
     end
+
+    desc "Ingests a directory of geoblacklight.json files"
+    task :ingest, [:directory] => :environment do |_t, args|
+      args.with_default(directory: 'data')
+      Dir.glob(File.join(args[:directory], '**', 'geoblacklight.json')).each do |fn|
+        puts "Ingesting #{fn}"
+        begin
+          Blacklight.default_index.connection.add(JSON.parse(File.read(fn)))
+        rescue => e
+          puts "Failed to ingest #{fn}: #{e.inspect}"
+        end
+      end
+      puts "Committing changes to Solr"
+      Blacklight.default_index.connection.commit
+    end
   end
   namespace :downloads do
     desc 'Delete all cached downloads'

--- a/schema/geoblacklight-schema.json
+++ b/schema/geoblacklight-schema.json
@@ -1,0 +1,207 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Schema for GeoBlacklight as implemented for Solr 4.10+. See http://journal.code4lib.org/articles/9710 for more details. Note that the Solr schema uses dynamic typing based on the suffix of the field name. For example, _s denotes a string where _sm denotes a multi-valued string (array of strings).",
+  "id": "http://geoblacklight.org/schema",
+  "title": "GeoBlacklight Schema",
+  "required": [
+    "dc_title_s",
+    "dc_description_s",
+    "dc_rights_s",
+    "dct_provenance_s",
+    "layer_id_s",
+    "layer_geom_type_s",
+    "layer_modified_dt",
+    "layer_slug_s",
+    "solr_geom"
+  ],
+  "type": "array",
+  "properties": {
+    "layer": {
+      "title": "layer",
+      "description": "A GIS data layer. See [this example](https://github.com/OpenGeoMetadata/edu.stanford.purl/blob/master/bb/099/zb/1450/geoblacklight.json) metadata layer.",
+      "type": "object",
+      "properties": {
+        "uuid": {
+          "type": "string",
+          "description": "*DEPRECATED* (use `dc_identifier_s`): Unique identifier for layer that is globally unique.",
+          "example": "http://purl.stanford.edu/vr593vj7147"
+        },
+        "dc_identifier_s": {
+          "type": "string",
+          "description": "Unique identifier for layer as a URI. It should be globally unique across all institutions, assumed not to be end-user visible, and is usually of the form `http://institution/id`. See https://github.com/geoblacklight/geoblacklight/wiki/Schema for more detailed documentation.",
+          "example": "http://purl.stanford.edu/vr593vj7147"
+        },
+        "dc_title_s": {
+          "type": "string",
+          "description": "Title for the layer.",
+          "example": "My Title"
+        },
+        "dc_description_s": {
+          "type": "string",
+          "description": "Description for the layer.",
+          "example": "My Description"
+        },
+        "dc_rights_s": {
+          "type": "string",
+          "enum": [
+            "Public",
+            "Restricted"
+          ],
+          "description": "Access rights for the layer."
+        },
+        "dct_provenance_s": {
+          "type": "string",
+          "description": "Institution who holds the layer.",
+          "example": "Stanford"
+        },
+        "dct_references_s": {
+          "type": "string",
+          "description": "External resources that are available for the layer. The value is a JSON hash where each key is a URI for the protocol or format, and the value is the URL to the external resource. See `dct_references_s` [detailed documentation](http://geoblacklight.org/tutorial/2015/02/09/geoblacklight-overview.html)",
+          "example": "{ ... }"
+        },
+        "georss_box_s": {
+          "type": "string",
+          "description": "*DEPRECATED* (use `solr_geom`): Bounding box for the layer, as maximum values for S W N E.",
+          "example": "12.6 -119.4 19.9 84.8"
+        },
+        "layer_id_s": {
+          "type": "string",
+          "description": "The complete identifier for the layer via WMS/WFS/WCS protocol.",
+          "example": "druid:vr593vj7147"
+        },
+        "layer_geom_type_s": {
+          "type": "string",
+          "enum": [
+            "Point",
+            "Line",
+            "Polygon",
+            "Raster",
+            "Scanned Map",
+            "Mixed"
+          ],
+          "description": "Geometry type for layer data, using controlled vocabulary."
+        },
+        "layer_modified_dt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Last modification date for the metadata record, using XML Schema dateTime format (YYYY-MM-DDThh:mm:ssZ)."
+        },
+        "layer_slug_s": {
+          "type": "string",
+          "description": "Identifies a layer in human-readable keywords. Note this value is visible to the user, and used for Permalinks. The value should be alpha-numeric characters separated by dashes, and is typically of the form `institution-keyword1-keyword2`. It should also be globally unique across all institutions in *your* GeoBlacklight index. See https://github.com/geoblacklight/geoblacklight/wiki/Schema for more detailed documentation.",
+          "example": "stanford-andhra-pradesh-village-boundaries"
+        },
+        "solr_geom": {
+          "type": "string",
+          "pattern": "ENVELOPE(.*,.*,.*,.*)",
+          "description": "Bounding box of the layer as a ENVELOPE WKT (from the CQL standard) using coordinates in (West, East, North, South) order. Note that this field is indexed as a Solr spatial (RPT) field.",
+          "example": "ENVELOPE(76.76, 84.76, 19.91, 12.62)"
+        },
+        "solr_year_i": {
+          "type": "integer",
+          "description": "*DEPRECATED* (only used by the Blacklight range plugin, not core GeoBlacklight, and generally you want a multi-valued field here): *Derived from* `dct_temporal_sm`. Year for which layer is valid and only a single value. Note that this field is indexed as a Solr numeric field.",
+          "example": "1989"
+        },
+        "dc_creator_sm": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Author(s) of the layer. *Optional*",
+          "example": "George Washington, Thomas Jefferson"
+        },
+        "dc_format_s": {
+          "type": "string",
+          "enum": [
+            "Shapefile",
+            "GeoTIFF",
+            "ArcGRID"
+          ],
+          "description": "File format for the layer, using a controlled vocabulary. *Optional*"
+        },
+        "dc_language_s": {
+          "type": "string",
+          "description": "Language for the layer. *Optional*. Note that future versions of the schema may make this a multi-valued field.",
+          "example": "English"
+        },
+        "dc_publisher_s": {
+          "type": "string",
+          "description": "Publisher of the layer. *Optional*",
+          "example": "ML InfoMap"
+        },
+        "dc_subject_sm": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Subjects for the layer, preferrably in a controlled vocabulary. *Optional*",
+          "example": "Census, Human settlements"
+        },
+        "dc_type_s": {
+          "type": "string",
+          "enum": [
+            "Dataset",
+            "Image",
+            "PhysicalObject"
+          ],
+          "description": "Resource type of the layer, using DCMI Type Vocabulary, usually a `Dataset`. *Optional*"
+        },
+        "dct_spatial_sm": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Spatial coverage and place names for the layer, preferrably in a controlled vocabulary. *Optional*",
+          "example": "Paris, San Francisco"
+        },
+        "dct_temporal_sm": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Temporal coverage for the layer, typically years or dates. Note that this field is not in a specific date format. *Optional*",
+          "example": "1989, circa 2010, 2007-2009"
+        },
+        "dct_issued_dt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Issued date for the layer, using XML Schema dateTime format (YYYY-MM-DDThh:mm:ssZ). *Optional*"
+        },
+        "dct_isPartOf_sm": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Holding dataset for the layer, such as the name of a collection. *Optional*",
+          "example": "Village Maps of India"
+        },
+        "georss_point_s": {
+          "type": "string",
+          "description": "*DEPRECATED* (use `georss_box_s`): Point representation for layer as y, x - i.e., centroid",
+          "example": "12.6 -119.4"
+        },
+        "dc_relation_sm": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "*DEPRECATED* (use `dct_isPartOf_sm`). A reference to a related resource for this layer. *Optional*",
+          "example": "http://purl.stanford.edu/vr593vj7147"
+        },
+        "dc_source_sm": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "The identity of a layer from which this layer's data was derived. *Optional*",
+          "example": "stanford-vr593vj7147"
+        },
+        "geoblacklight_version": {
+          "type": "string",
+          "description": "The version of the GeoBlacklight Schema to which this metadata record conforms.",
+          "example": "1.0"
+        }
+      }
+    }
+  }
+}

--- a/schema/geoblacklight-schema.md
+++ b/schema/geoblacklight-schema.md
@@ -1,31 +1,39 @@
-# GeoBlacklight-Schema
+## <a name="resource-layer">layer</a>
 
-Table View
 
-Properties | Type | Controlled Values | Description
----------- | ---- | ------------ |-----------
-**uuid** | string || Unique identifier for layer that is globally unique.
-**dc\_identifier\_s** | string || Unique identifier for layer. May be same as UUID but may be an alternate identifier.
-**dc\_title\_s** | string || Title for the layer.
-**dc\_description\_s** | string || Description for the layer.
-**dc\_rights\_s**| string | "Public", "Restricted" | Access rights for the layer.
-**dct\_provenance\_s** | string || Institution who holds the layer.
-**dct\_references\_s** | string || JSON hash for external resources, where each key is a URI for the protocol or format and the value is the URL to the resource.
-**georss\_box\_s** | string || Bounding box as maximum values for S W N E. Example: 12.6 -119.4 19.9 84.8.
-**layer\_id\_s** | string || The complete identifier for the layer via WMS/WFS/WCS protocol. Example: druid:vr593vj7147.
-**layer\_geom\_type\_s** | string | "Point", "Line", "Polygon", "Raster", "Scanned Map", "Mixed" | Geometry type for layer data, using controlled vocabulary.
-**layer\_modified\_dt** | string | date-time | Last modification date for the metadata record, using XML Schema dateTime format (YYYY-MM-DDThh:mm:ssZ).
-**layer\_slug\_s** | string || Unique identifier visible to the user, used for Permalinks. Example: stanford-vr593vj7147.
-**solr\_geom** | string | /ENVELOPE(.\*,.\*,.\*,.\*)/ | **Derived** from georss\_polygon\_s or georss\_box\_s. Shape of the layer as a ENVELOPE WKT using W E N S. Example: ENVELOPE(76.76, 84.76, 19.91, 12.62). Note that this field is indexed as a Solr spatial (RPT) field.
-**solr\_year\_i** | integer || **Derived** from dct\_temporal\_sm. Year for which layer is valid and only a single value. Example: 1989. Note that this field is indexed as a Solr numeric field.
-dc\_creator\_sm | multivalued string || Author(s). Example: George Washington, Thomas Jefferson.
-dc\_format\_s | string | Shapefile, GeoTIFF, ArcGRID | File format for the layer, using a controlled vocabulary.
-dc\_language\_s | string || Language for the layer. Example: English.
-dc\_publisher\_s | string || Publisher. Example: ML InfoMap.
-dc\_subject\_sm | multivalued string || Subjects, preferrably in a controlled vocabulary. Examples: Census, Human settlements.
-dc\_type\_s | string | "Dataset", "Image", "PhysicalObject" | Resource type, using DCMI Type Vocabulary.
-dct\_spatial\_sm | multivalued string || Spatial coverage and place names, perferrably in a controlled vocabulary. Example: "Paris, France".
-dct\_temporal\_sm | multivalued string || Temporal coverage, typically years or dates. Example: 1989, circa 2010, 2007-2009. Note that this field is not in a specific date format.
-dct\_issued\_dt | string | date-time | Issued date for the layer, using XML Schema dateTime format (YYYY-MM-DDThh:mm:ssZ).
-dct\_isPartOf\_sm | multivalued string || Holding dataset for the layer, such as the name of a collection. Example: Village Maps of India.
-georss\_point\_s | string || Point representation for layer as y, x - i.e., centroid. Example: 12.6 -119.4.
+A GIS data layer. See [this example](https://github.com/OpenGeoMetadata/edu.stanford.purl/blob/master/bb/099/zb/1450/geoblacklight.json) metadata layer.
+
+### Attributes
+
+| Name | Type | Description | Example |
+| ------- | ------- | ------- | ------- |
+| **dc_creator_sm** | *array* | Author(s) of the layer. *Optional* | `"George Washington, Thomas Jefferson"` |
+| **dc_description_s** | *string* | Description for the layer. | `"My Description"` |
+| **dc_format_s** | *string* | File format for the layer, using a controlled vocabulary. *Optional*<br/> **one of:**`"Shapefile"` or `"GeoTIFF"` or `"ArcGRID"` | `"Shapefile"` |
+| **dc_identifier_s** | *string* | Unique identifier for layer as a URI. It should be globally unique across all institutions, assumed not to be end-user visible, and is usually of the form `http://institution/id`. See https://github.com/geoblacklight/geoblacklight/wiki/Schema for more detailed documentation. | `"http://purl.stanford.edu/vr593vj7147"` |
+| **dc_language_s** | *string* | Language for the layer. *Optional*. Note that future versions of the schema may make this a multi-valued field. | `"English"` |
+| **dc_publisher_s** | *string* | Publisher of the layer. *Optional* | `"ML InfoMap"` |
+| **dc_relation_sm** | *array* | *DEPRECATED* (use `dct_isPartOf_sm`). A reference to a related resource for this layer. *Optional* | `"http://purl.stanford.edu/vr593vj7147"` |
+| **dc_rights_s** | *string* | Access rights for the layer.<br/> **one of:**`"Public"` or `"Restricted"` | `"Public"` |
+| **dc_source_sm** | *array* | The identity of a layer from which this layer's data was derived. *Optional* | `"stanford-vr593vj7147"` |
+| **dc_subject_sm** | *array* | Subjects for the layer, preferrably in a controlled vocabulary. *Optional* | `"Census, Human settlements"` |
+| **dc_title_s** | *string* | Title for the layer. | `"My Title"` |
+| **dc_type_s** | *string* | Resource type of the layer, using DCMI Type Vocabulary, usually a `Dataset`. *Optional*<br/> **one of:**`"Dataset"` or `"Image"` or `"PhysicalObject"` | `"Dataset"` |
+| **dct_isPartOf_sm** | *array* | Holding dataset for the layer, such as the name of a collection. *Optional* | `"Village Maps of India"` |
+| **dct_issued_dt** | *date-time* | Issued date for the layer, using XML Schema dateTime format (YYYY-MM-DDThh:mm:ssZ). *Optional* | `"2015-01-01T12:00:00Z"` |
+| **dct_provenance_s** | *string* | Institution who holds the layer. | `"Stanford"` |
+| **dct_references_s** | *string* | External resources that are available for the layer. The value is a JSON hash where each key is a URI for the protocol or format, and the value is the URL to the external resource. See `dct_references_s` [detailed documentation](http://geoblacklight.org/tutorial/2015/02/09/geoblacklight-overview.html) | `"{ ... }"` |
+| **dct_spatial_sm** | *array* | Spatial coverage and place names for the layer, preferrably in a controlled vocabulary. *Optional* | `"Paris, San Francisco"` |
+| **dct_temporal_sm** | *array* | Temporal coverage for the layer, typically years or dates. Note that this field is not in a specific date format. *Optional* | `"1989, circa 2010, 2007-2009"` |
+| **geoblacklight_version** | *string* | The version of the GeoBlacklight Schema to which this metadata record conforms. | `"1.0"` |
+| **georss_box_s** | *string* | *DEPRECATED* (use `solr_geom`): Bounding box for the layer, as maximum values for S W N E. | `"12.6 -119.4 19.9 84.8"` |
+| **georss_point_s** | *string* | *DEPRECATED* (use `georss_box_s`): Point representation for layer as y, x - i.e., centroid | `"12.6 -119.4"` |
+| **layer_geom_type_s** | *string* | Geometry type for layer data, using controlled vocabulary.<br/> **one of:**`"Point"` or `"Line"` or `"Polygon"` or `"Raster"` or `"Scanned Map"` or `"Mixed"` | `"Point"` |
+| **layer_id_s** | *string* | The complete identifier for the layer via WMS/WFS/WCS protocol. | `"druid:vr593vj7147"` |
+| **layer_modified_dt** | *date-time* | Last modification date for the metadata record, using XML Schema dateTime format (YYYY-MM-DDThh:mm:ssZ). | `"2015-01-01T12:00:00Z"` |
+| **layer_slug_s** | *string* | Identifies a layer in human-readable keywords. Note this value is visible to the user, and used for Permalinks. The value should be alpha-numeric characters separated by dashes, and is typically of the form `institution-keyword1-keyword2`. It should also be globally unique across all institutions in *your* GeoBlacklight index. See https://github.com/geoblacklight/geoblacklight/wiki/Schema for more detailed documentation. | `"stanford-andhra-pradesh-village-boundaries"` |
+| **solr_geom** | *string* | Bounding box of the layer as a ENVELOPE WKT (from the CQL standard) using coordinates in (West, East, North, South) order. Note that this field is indexed as a Solr spatial (RPT) field.<br/> **pattern:** `ENVELOPE(.*,.*,.*,.*)` | `"ENVELOPE(76.76, 84.76, 19.91, 12.62)"` |
+| **solr_year_i** | *integer* | *DEPRECATED* (only used by the Blacklight range plugin, not core GeoBlacklight, and generally you want a multi-valued field here): *Derived from* `dct_temporal_sm`. Year for which layer is valid and only a single value. Note that this field is indexed as a Solr numeric field. | `"1989"` |
+| **uuid** | *string* | *DEPRECATED* (use `dc_identifier_s`): Unique identifier for layer that is globally unique. | `"http://purl.stanford.edu/vr593vj7147"` |
+
+

--- a/schema/solr/conf/schema.xml
+++ b/schema/solr/conf/schema.xml
@@ -18,6 +18,7 @@
     <dynamicField name="*_dt"   type="date"    stored="true"  indexed="true"/>
     <dynamicField name="*_f"    type="float"   stored="true"  indexed="true"/>
     <dynamicField name="*_i"    type="int"     stored="true"  indexed="true"/>
+    <dynamicField name="*_im"   type="int"     stored="true"  indexed="true" multiValued="true" />
     <dynamicField name="*_l"    type="long"    stored="true"  indexed="true"/>
     <dynamicField name="*_s"    type="string"  stored="true"  indexed="true"/>
     <dynamicField name="*_ss"   type="string"  stored="true"  indexed="false"/>

--- a/schema/solr/conf/schema.xml
+++ b/schema/solr/conf/schema.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schema name="geoblacklight-schema" version="1.5">
-  <uniqueKey>uuid</uniqueKey>
+  <uniqueKey>layer_slug_s</uniqueKey>
   <fields>
     <field name="_version_" type="long"   stored="true" indexed="true"/>
     <field name="timestamp" type="date"   stored="true" indexed="true" default="NOW"/>
-    <field name="uuid"      type="string" stored="true" indexed="true" required="true"/>
+    <field name="layer_slug_s" type="string" stored="true" indexed="true" required="true"/>
+    <field name="geoblacklight_version" type="string" stored="true" indexed="true"/>
+    <field name="uuid"      type="string" stored="true" indexed="true"/><!-- deprecated -->
 
     <!-- core generated fields -->
     <field name="text" type="text_en" stored="false" indexed="true" multiValued="true"

--- a/spec/fixtures/solr_documents/actual-papermap1.json
+++ b/spec/fixtures/solr_documents/actual-papermap1.json
@@ -1,5 +1,5 @@
 {
-  "uuid": "urn:arrowsmith.mit.edu:MIT.001145244",
+  "geoblacklight_version": "1.0",
   "dc_description_s": "Panel title. Depths shown by isolines. \"Geological map [copyright] NERC 1996.\" Also available on flat sheet. \"Sheet 1\"--on panel. Includes text, notes, organizations' logos, and ancillary map of \"Orogenic terranes of Britain, Ireland and surrounding seas.\"",
   "dc_format_s": "Paper",
   "dc_identifier_s": "urn:arrowsmith.mit.edu:MIT.001145244",
@@ -14,8 +14,6 @@
   ],
   "dct_issued_s": "2000",
   "dct_provenance_s": "MIT",
-  "georss_box_s": "49.0 -13.0 62.0 4.0",
-  "georss_polygon_s": "62.0 -13.0 62.0 4.0 49.0 4.0 49.0 -13.0 62.0 -13.0",
   "layer_slug_s": "mit-001145244",
   "layer_id_s": "MIT:001145244",
   "layer_geom_type_s": "Paper Map",

--- a/spec/fixtures/solr_documents/actual-point1.json
+++ b/spec/fixtures/solr_documents/actual-point1.json
@@ -1,5 +1,5 @@
 {
-  "uuid": "urn:columbia.edu:Columbia.landinfo_global_aet",
+  "geoblacklight_version": "1.0",
   "dc_description_s": "Actual Evapotrans is a point theme representing the sum of evaporation and plant transpiration to the atmosphere from throughout the world.  Measurements are represented by points at every.5 degrees and provided for every month of the year. This dataset is a part of the Global Climate Database from the Global Change Department National Institute of Public Health and Environmental Protection.",
   "dc_format_s": "Shapefile",
   "dc_identifier_s": "urn:columbia.edu:Columbia.landinfo_global_aet",
@@ -15,8 +15,6 @@
     "1996"
   ],
   "dct_provenance_s": "Columbia",
-  "georss_box_s": "-56.0 -179.5 83.0 180.0",
-  "georss_polygon_s": "83.0 -179.5 83.0 180.0 -56.0 180.0 -56.0 -179.5 83.0 -179.5",
   "layer_slug_s": "columbia-columbia-landinfo-global-aet",
   "layer_id_s": "Columbia:Columbia.landinfo_global_aet",
   "layer_geom_type_s": "Point",

--- a/spec/fixtures/solr_documents/actual-polygon1.json
+++ b/spec/fixtures/solr_documents/actual-polygon1.json
@@ -1,5 +1,5 @@
 {
-  "uuid": "urn:geodata.tufts.edu:Tufts.CambridgeGrid100_04",
+  "geoblacklight_version": "1.0",
   "dc_description_s": "This polygon dataset is a 100 foot grid overlay for Cambridge, MA.",
   "dc_format_s": "Shapefile",
   "dc_identifier_s": "urn:geodata.tufts.edu:Tufts.CambridgeGrid100_04",
@@ -14,8 +14,6 @@
   ],
   "dct_issued_s": "2005",
   "dct_provenance_s": "Tufts",
-  "georss_box_s": "42.34757 -71.163984 42.408316 -71.052581",
-  "georss_polygon_s": "42.408316 -71.163984 42.408316 -71.052581 42.34757 -71.052581 42.34757 -71.163984 42.408316 -71.163984",
   "layer_slug_s": "tufts-cambridgegrid100-04",
   "layer_id_s": "sde:GISPORTAL.GISOWNER01.CAMBRIDGEGRID100_04",
   "layer_geom_type_s": "Polygon",

--- a/spec/fixtures/solr_documents/actual-raster1.json
+++ b/spec/fixtures/solr_documents/actual-raster1.json
@@ -1,5 +1,5 @@
 {
-  "uuid": "http://purl.stanford.edu/dp018hs9766",
+  "geoblacklight_version": "1.0",
   "dc_identifier_s": "http://purl.stanford.edu/dp018hs9766",
   "dc_title_s": "1-Meter Shaded Relief Multibeam Bathymetry Image (Color): Elkhorn Slough, California, 2005",
   "dc_description_s": "This layer is a 10-color shaded relief GeoTIFF that contains high-resolution bathymetric data collected from the Elkhorn Slough region of Monterey Bay, California. The survey for Elkhorn Slough was conducted 8/12/2005 - 8/15/2005. Elkhorn Slough, one of the largest remaining coastal wetlands in California, has been directly subjected to tidal scour since the opening of Moss Landing Harbor in 1946. This erosion endangers the habitat of several rare and endangered species and disrupts the wetland ecosystem as a whole. In 2003, the Seafloor Mapping Lab of California State University, Monterey Bay created the most detailed bathymetry model of the Slough to date using a combination of multi-beam sonar, single-beam sonar and aerial photography. This layer was created as part of the California Seafloor Mapping Project.This project was conducted to determine changes in the pattern of erosion and deposition in Elkhorn Slough since surveys conducted in 1993, 2001 and 2003. Marine data offered here represent the efforts of a comprehensive state waters mapping program for California launched by the California State Coastal Conservancy, Ocean Protection Council, Department of Fish and Game, and the NOAA National Marine Sanctuary Program. The ultimate goal is the creation of a high-resolution 1:24,000 scale geologic and habitat base map series covering all of California's 14,500 km2 state waters out to the 3 mile limit, and support of the state's Marine Life Protection Act Initiative (MLPA) goal to create a statewide network of Marine Protected Areas (MPAs). This statewide project requires, involves and leverages expertise from industry, resource management agencies and academia. The tiered mapping campaign involves the use of state-of-the-art sonar, LIDAR (aerial laser) and video seafloor mapping technologies; computer aided classification and visualization; expert geologic and habitat interpretations codified into strip maps spanning California's land/sea boundary; and the creation of an online, publicly accessible data repository for the dissemination of all mapping products.\n",
@@ -32,12 +32,6 @@
     "Elkhorn Slough (Calif.)",
     "Monterey Bay (Calif.)"
   ],
-  "dc_relation_sm": [
-    "http://sws.geonames.org/5346182/about.rdf",
-    "http://sws.geonames.org/5374363/about.rdf"
-  ],
-  "georss_box_s": "36.8085911 -121.7948738 36.8606925 -121.7389503",
-  "georss_polygon_s": "36.8085911 -121.7948738 36.8606925 -121.7948738 36.8606925 -121.7389503 36.8085911 -121.7389503 36.8085911 -121.7948738",
   "solr_geom": "ENVELOPE(-121.7948738, -121.7389503, 36.8606925, 36.8085911)",
   "solr_year_i": 2005
 }

--- a/spec/fixtures/solr_documents/esri-dynamic-layer-all-layers.json
+++ b/spec/fixtures/solr_documents/esri-dynamic-layer-all-layers.json
@@ -1,5 +1,5 @@
 {
-    "uuid": "urn-90f14ff4-1359-4beb-b931-5cb41d20ab90",
+    "geoblacklight_version": "1.0",
     "layer_geom_type_s": "Polygon",
     "dc_identifier_s": "urn-90f14ff4-1359-4beb-b931-5cb41d20ab90",
     "dc_title_s": "Glacial Boundaries: Illinois, 1997",
@@ -31,7 +31,6 @@
     "dct_issued_s": "1997-12-13",
     "dct_temporal_sm": "1996",
     "solr_geom": "ENVELOPE(-91.513518, -87.495214, 42.508348, 36.969972)",
-    "georss_box_s": "36.969972 -91.513518 42.508348 -87.495214",
     "solr_year_i": 1997,
     "dct_references_s": "{\"urn:x-esri:serviceType:ArcGIS#DynamicMapLayer\":\"http://data.isgs.illinois.edu/arcgis/rest/services/Geology/Glacial_Boundaries/MapServer\",\"http://schema.org/url\":\"https://clearinghouse.isgs.illinois.edu/data/geology/glacial-boundaries\",\"http://schema.org/downloadUrl\":\"https://clearinghouse.isgs.illinois.edu/sites/clearinghouse.isgs/files/Clearinghouse/data/ISGS/Geology/zips/IL_Glacial_Bndys_Py.zip\"}"
 }

--- a/spec/fixtures/solr_documents/esri-dynamic-layer-single-layer.json
+++ b/spec/fixtures/solr_documents/esri-dynamic-layer-single-layer.json
@@ -1,4 +1,5 @@
 {
+  "geoblacklight_version": "1.0",
   "dc_creator_sm": [
     "State of Michigan"
   ],
@@ -24,13 +25,10 @@
   "dct_spatial_sm": [
     "Michigan"
   ],
-  "georss_box_s": "41.6321 -90.5497 48.2152 -82.0758",
-  "georss_polygon_s": "41.6321 -90.5497 48.2152 -90.5497 48.2152 -82.0758 41.6321 -82.0758 41.6321 -90.5497",
   "layer_geom_type_s": "Polygon",
   "layer_id_s": "urn:urn-ad0e6ebc-824e-4450-a0d9-987f2232724f",
   "layer_modified_dt": "2016-07-18T15:17:46Z",
   "layer_slug_s": "michigan-state-urn-ad0e6ebc-824e-4450-a0d9-987f2232724f",
   "solr_geom": "ENVELOPE(-90.5497, -82.0758, 48.2152, 41.6321)",
-  "solr_year_i": 2015,
-  "uuid": "urn-ad0e6ebc-824e-4450-a0d9-987f2232724f"
+  "solr_year_i": 2015
 }

--- a/spec/fixtures/solr_documents/esri-feature-layer.json
+++ b/spec/fixtures/solr_documents/esri-feature-layer.json
@@ -1,10 +1,10 @@
 {
+  "geoblacklight_version": "1.0",
   "layer_geom_type_s": "Polygon",
   "layer_modified_dt": "2016-07-11T09:15:37Z",
   "solr_geom": "ENVELOPE(-93.3291083642602, -93.1896159986687, 45.0512462600492, 44.8901520021226)",
   "dct_references_s": "{\"http://schema.org/downloadUrl\":\"http://opendata.minneapolismn.gov/datasets/772ebcaf2ec0405ea1b156b5937593e7_0.zip\",\"urn:x-esri:serviceType:ArcGIS#FeatureLayer\":\"https://services.arcgis.com/afSMGVsC7QlRK1kZ/arcgis/rest/services/Fire_Station_Areas/FeatureServer/0\",\"http://schema.org/url\":\"http://opendata.minneapolismn.gov/datasets/772ebcaf2ec0405ea1b156b5937593e7_0\"}",
   "dc_rights_s": "Public",
-  "uuid": "e2f33b52-4039-4bbb-9095-b5cdc0175943",
   "dct_provenance_s": "Minnesota",
   "dc_subject_sm": [
     "utilitiesCommunications",
@@ -19,7 +19,6 @@
   ],
   "dc_type_s": "Dataset",
   "dc_identifier_s": "e2f33b52-4039-4bbb-9095-b5cdc0175943",
-  "georss_polygon_s": "44.8901520021226 -93.3291083642602 45.0512462600492 -93.3291083642602 45.0512462600492 -93.1896159986687 44.8901520021226 -93.1896159986687 44.8901520021226 -93.3291083642602",
   "solr_year_i": 2012,
   "dct_spatial_sm": [
     "City of Minneapolis, Minnesota",
@@ -29,7 +28,6 @@
     "MapIT Minneapolis"
   ],
   "layer_id_s": "urn:e2f33b52-4039-4bbb-9095-b5cdc0175943",
-  "georss_box_s": "44.8901520021226 -93.3291083642602 45.0512462600492 -93.1896159986687",
   "dc_title_s": "Fire Station Areas: Minneapolis, Minnesota",
   "layer_slug_s": "minnesota-e2f33b52-4039-4bbb-9095-b5cdc0175943"
 }

--- a/spec/fixtures/solr_documents/esri-image-map-layer.json
+++ b/spec/fixtures/solr_documents/esri-image-map-layer.json
@@ -1,5 +1,5 @@
 {
-  "uuid": "oregon-naip-2011",
+  "geoblacklight_version": "1.0",
   "dc_description_s": "A Web Mercator mosaic derived from half-meter resolution color Digital Orthophoto Quadrangles (DOQ) of the entire state of Oregon from the summer of 2011 for multiple state agencies in Oregon. The original content was produced utilizing the scanned aerial film acquired during peak agriculture growing seasons under the National Agriculture Imagery Program (NAIP) under contract for the United States Department of Agriculture (USDA) for the Farm Service Agency's (FSA) Compliance Program. A DOQ is a raster image in which displacement in the image caused by sensor orientation and terrain relief has been removed. A DOQ combines the image characteristics of a photograph with the geometric qualities of a map. The geographic extent of the DOQ is a full 7.5-minute map (latitude and longitude) with a nominal buffer. The horizontal accuracy is within 5 meters of reference ortho imagery (1992 USGS DOQs.) The 1992 USGS DOQ imagery met National Map Accuracy Standards at 1:24,000 scale for 7.5-minute quadrangles. Translated to the ground, the 0.5 mm error distance at 1:24,000 scale is 39.4 ft (12 meters), making the absolute accuracy for the 2011 Oregon DOQs +/- 17 meters. The process of reprojecting and mosaicing the images may have added a potential shift of +/-0.75 meters, making the cumulative accuracy +/-17.75 meters. The original images were projected into a GCS_WGS_1984_Web_Mercator(Auxiliary Sphere) for compatibility with other generic web map services.",
   "dc_format_s": "GeoTIFF",
   "dc_identifier_s": "oregon-naip-2011",
@@ -12,7 +12,6 @@
     "2011"
   ],
   "dct_provenance_s": "Princeton",
-  "georss_box_s": "41.91 -124.88 46.34 -116.41",
   "layer_slug_s": "princeton-test-oregon-naip-2011",
   "layer_id_s": "oregon-naip-2011",
   "layer_geom_type_s": "Raster",

--- a/spec/fixtures/solr_documents/esri-tiled_map_layer.json
+++ b/spec/fixtures/solr_documents/esri-tiled_map_layer.json
@@ -1,5 +1,5 @@
 {
-  "uuid": "test-soil-survey-map",
+  "geoblacklight_version": "1.0",
   "dc_description_s": "This map shows the Soil Survey Geographic (SSURGO) by the United States Department of Agriculture's Natural Resources Conservation Service. It also shows data that was developed by the National Cooperative Soil Survey and supersedes the State Soil Geographic (STATSGO) dataset published in 1994. SSURGO digitizing duplicates the original soil survey maps. This level of mapping is designed for use by landowners, townships, and county natural resource planning and management. The user should be knowledgeable of soils data and their characteristics. The smallest scale map shows the Global Soil Regions map by the United States Department of Agriculture’s Natural Resources Conservation Service.",
   "dc_format_s": "GeoTIFF",
   "dc_identifier_s": "test-soil-survey-map",
@@ -13,7 +13,6 @@
     "2010"
   ],
   "dct_provenance_s": "NYU",
-  "georss_box_s": "21.8079 -129.4956 48.6336 -64.4393",
   "layer_slug_s": "nyu-test-soil-survey-map",
   "layer_id_s": "test-soil-survey_map",
   "layer_geom_type_s": "Raster",

--- a/spec/fixtures/solr_documents/esri-wms-layer.json
+++ b/spec/fixtures/solr_documents/esri-wms-layer.json
@@ -1,4 +1,5 @@
 {
+  "geoblacklight_version": "1.0",
   "dc_creator_sm": [
     "(creation): U.S. Geological Survey",
     "(selection/conversion): Bernardin, Lochmueller and Associates"
@@ -23,13 +24,10 @@
     "Indiana"
   ],
   "dct_temporal_sm": "1972-1997",
-  "georss_box_s": "37.7554 -88.1607 41.7753 -84.6882",
-  "georss_polygon_s": "37.7554 -88.1607 41.7753 -88.1607 41.7753 -84.6882 37.7554 -84.6882 37.7554 -88.1607",
   "layer_geom_type_s": "Mixed",
   "layer_id_s": "0",
   "layer_modified_dt": "2016-06-20T16:17:36Z",
   "layer_slug_s": "purdue-urn-f082acb1-b01e-4a08-9126-fd62a23fd9aa",
   "solr_geom": "ENVELOPE(-88.1607, -84.6882, 41.7753, 37.7554)",
-  "solr_year_i": 1972,
-  "uuid": "urn-f082acb1-b01e-4a08-9126-fd62a23fd9aa"
+  "solr_year_i": 1972
 }

--- a/spec/fixtures/solr_documents/harvard_raster.json
+++ b/spec/fixtures/solr_documents/harvard_raster.json
@@ -1,5 +1,5 @@
 {
-  "uuid": "urn:hul.harvard.edu:HARVARD.SDE2.G7064_S2_1834_K3",
+  "geoblacklight_version": "1.0",
   "dc_description_s": "This layer is a georeferenced raster image of the historic paper map entitled: [Karta mesta zanimaemago Sanktpeterburgom : v tom vide v kakom onoe nakhodilos' za god do osnovaniia goroda; sostavlena dlia panoramy S. Peterburga, 1834]. It was published in 1834. Scale [ca. 1:76,000]. Covers Saint Petersburg Region, Russia. Map in Russian and Swedish.\n\nThe image inside the map neatline is georeferenced to the surface of the earth and fit to the 'Pulkovo 1995 Gauss Kruger Zone 6N' coordinate system. All map collar and inset information is also available as part of the raster image, including any inset maps, profiles, statistical tables, directories, text, illustrations, index maps, legends, or other information associated with the principal map.\n\nThis map shows features such as roads, drainage, built-up areas and selected buildings, ground cover, and more. Relief is shown by hachures. Depths shown by soundings. Includes insets: [Retusari island] -- [Sluselberg]. \n\nThis layer is part of a selection of digitally scanned and georeferenced historic maps from The Harvard Map Collection as part of the Imaging the Urban Environment project.  Maps selected for this project represent major urban areas and cities of the world, at various time periods.  These maps typically portray both natural and manmade features at a large scale. The selection represents a range of regions, originators, ground condition dates, scales, and purposes.",
   "dc_format_s": "GeoTIFF",
   "dc_identifier_s": "urn:hul.harvard.edu:HARVARD.SDE2.G7064_S2_1834_K3",
@@ -35,13 +35,10 @@
   ],
   "dct_issued_s": "2000",
   "dct_provenance_s": "Harvard",
-  "georss_box_s": "59.669749 30.013108 60.041712 30.875309",
-  "georss_polygon_s": "60.041712 30.013108 60.041712 30.875309 59.669749 30.875309 59.669749 30.013108 60.041712 30.013108",
   "layer_slug_s": "harvard-g7064-s2-1834-k3",
   "layer_id_s": "cite:SDE2.G7064_S2_1834_K3",
   "layer_geom_type_s": "Raster",
   "layer_modified_dt": "2014-05-27T18:09:36Z",
   "solr_geom": "ENVELOPE(30.013108, 30.875309, 60.041712, 59.669749)",
-  "solr_year_i": 1834,
-  "solr_issued_dt": "2000-01-01T00:00:00Z"
+  "solr_year_i": 1834
 }

--- a/spec/fixtures/solr_documents/public_direct_download.json
+++ b/spec/fixtures/solr_documents/public_direct_download.json
@@ -1,5 +1,5 @@
 {
-  "uuid": "http://purl.stanford.edu/cz128vq0535",
+  "geoblacklight_version": "1.0",
   "dc_identifier_s": "http://purl.stanford.edu/cz128vq0535",
   "dc_title_s": "2005 Rural Poverty GIS Database: Uganda",
   "dc_description_s": "This polygon shapefile contains 2005 poverty data for 855 rural subcounties in Uganda. These data are intended for researchers, students, policy makers and the general public for reference and mapping purposes, and may be used for basic applications such as viewing, querying, and map output production.",
@@ -22,9 +22,6 @@
   "dct_issued_s": "2005",
   "dct_temporal_sm": "2005",
   "dct_spatial_sm": "Uganda",
-  "dc_relation_sm": "http://sws.geonames.org/226074/about.rdf",
-  "georss_box_s": "-1.478794 29.572742 4.234077 35.000308",
-  "georss_polygon_s": "-1.478794 29.572742 4.234077 29.572742 4.234077 35.000308 -1.478794 35.000308 -1.478794 29.572742",
   "solr_geom": "ENVELOPE(29.572742, 35.000308, 4.234077, -1.478794)",
   "solr_year_i": 2005,
   "stanford_rights_metadata_s": "<?xml version=\"1.0\"?>\n<rightsMetadata>\n  <access type=\"discover\">\n    <machine>\n      <world/>\n    </machine>\n  </access>\n  <access type=\"read\">\n    <machine>\n      <world/>\n    </machine>\n  </access>\n  <use>\n    <human type=\"useAndReproduction\">This item is in the public domain.  There are no restrictions on use.</human>\n    <human type=\"creativeCommons\"/>\n    <machine type=\"creativeCommons\"/>\n  </use>\n  <copyright>\n    <human>This work is in the Public Domain, meaning that it is not subject to copyright.</human>\n  </copyright>\n</rightsMetadata>\n"

--- a/spec/fixtures/solr_documents/public_iiif_princeton.json
+++ b/spec/fixtures/solr_documents/public_iiif_princeton.json
@@ -1,5 +1,5 @@
 {
-  "uuid": "http://arks.princeton.edu/ark:/88435/02870w62c",
+  "geoblacklight_version": "1.0",
   "dc_description_s": "Partly colored. Relief shown pictorially. Shows administrative divisions. From Thomas Jefferys's The American atlas, or, A geographical description of the whole continent of America (London : Printed by R. Sayer and Bennett, 1778). Insets: A chart of the mouth of Hudson's River, from Sandy Hook to New York. A plan of the city of New York. Plan of Amboy, with its environs, from an actual survey.",
   "dc_format_s": "Raster",
   "dc_identifier_s": "http://arks.princeton.edu/ark:/88435/02870w62c",
@@ -27,7 +27,6 @@
   ],
   "dct_issued_s": "1778",
   "dct_provenance_s": "Princeton",
-  "georss_box_s": "38.6693 -76.3394 46.5798 -72.1916",
   "layer_slug_s": "princeton-02870w62c",
   "layer_id_s": "02870w62c",
   "layer_geom_type_s": "Raster",

--- a/spec/fixtures/solr_documents/public_polygon_mit.json
+++ b/spec/fixtures/solr_documents/public_polygon_mit.json
@@ -1,5 +1,5 @@
 {
-  "uuid": "urn:arrowsmith.mit.edu:MIT.SDE_DATA.US_MA_E25ZCTA5DCT_2000",
+  "geoblacklight_version": "1.0",
   "dc_format_s": "Shapefile",
   "dc_identifier_s": "urn:arrowsmith.mit.edu:MIT.SDE_DATA.US_MA_E25ZCTA5DCT_2000",
   "dc_language_s": "English",
@@ -30,13 +30,10 @@
   ],
   "dct_issued_s": "2000",
   "dct_provenance_s": "MIT",
-  "georss_box_s": "41.230345 -73.533237 42.888068 -69.898565",
-  "georss_polygon_s": "42.888068 -73.533237 42.888068 -69.898565 41.230345 -69.898565 41.230345 -73.533237 42.888068 -73.533237",
   "layer_slug_s": "mit-us-ma-e25zcta5dct-2000",
   "layer_id_s": "sde:SDE_DATA.US_MA_E25ZCTA5DCT_2000",
   "layer_geom_type_s": "Polygon",
   "layer_modified_dt": "2014-05-27T18:09:34Z",
   "solr_geom": "ENVELOPE(-73.533237, -69.898565, 42.888068, 41.230345)",
-  "solr_year_i": 2000,
-  "solr_issued_dt": "2000-01-01T00:00:00Z"
+  "solr_year_i": 2000
 }

--- a/spec/fixtures/solr_documents/restricted-line.json
+++ b/spec/fixtures/solr_documents/restricted-line.json
@@ -1,5 +1,5 @@
 {
-  "uuid": "http://purl.stanford.edu/cg357zz0321",
+  "geoblacklight_version": "1.0",
   "dc_identifier_s": "http://purl.stanford.edu/cg357zz0321",
   "dc_title_s": "10 Meter Countours: Russian River Basin, California",
   "dc_description_s": "This line shapefile contains contours that were derived from a mosiac of 10 meter digital elevation models for the extent of the Russian River basin, located in Sonoma and Mendocino Counties, California.This layer can be used for watershed analysis and planning in the Russian River region of California.",
@@ -31,12 +31,6 @@
     "Sonoma County (Calif.)",
     "Mendocino County (Calif.)"
   ],
-  "dc_relation_sm": [
-    "http://sws.geonames.org/5397100/about.rdf",
-    "http://sws.geonames.org/5372163/about.rdf"
-  ],
-  "georss_box_s": "38.302994 -123.387366 39.398403 -122.52958",
-  "georss_polygon_s": "38.302994 -123.387366 39.398403 -123.387366 39.398403 -122.52958 38.302994 -122.52958 38.302994 -123.387366",
   "solr_geom": "ENVELOPE(-123.387366, -122.52958, 39.398403, 38.302994)",
   "solr_year_i": 2002
 }


### PR DESCRIPTION
This PR is connected to #393. It does the following:

- switches to `layer_slug_s` as the primary key in Solr index
- adds support for the `_im` suffix in the Solr index
- deprecates the fields in #393 and drops them from the fixtures
- adds `geoblacklight_version` to documentation and fixtures
- adds `dc_source_sm` field to documentation
- migrates the JSON-Schema definition of the GeoBlacklight schema from geoblacklight-schema repo
- improves documentation and support for auto-generation of docs (via `prmd doc geoblacklight-schema.json`) -- see https://github.com/geoblacklight/geoblacklight/blob/d01a9c1152849838ecee4d069a25c58210837961/schema/geoblacklight-schema.md
- adds the `geoblacklight:solr:ingest[directory]` rake task

NOTE that this branch *requires* you to reconfigure your jetty instance -- I just did `rm -rf jetty` and reinstalled it

Also, there's a guide on the schema now in the wiki -- https://github.com/geoblacklight/geoblacklight/wiki/Schema