### PR TITLE
Correct fixture name in linkfy test

### DIFF
--- a/spec/features/linkified_attribute_table_spec.rb
+++ b/spec/features/linkified_attribute_table_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 feature 'Attribute table values', js: true do
   scenario 'are linkified' do
-    visit solr_document_path 'minnesota-772ebcaf2ec0405ea1b156b5937593e7_0'
+    visit solr_document_path 'minnesota-e2f33b52-4039-4bbb-9095-b5cdc0175943'
     # Wait until SVG elements are added
     expect(page).to have_css '.leaflet-overlay-pane svg'
     page.first('svg g path').click


### PR DESCRIPTION
The fixture used in the linkified_attribute_table_spec changed it's id. This PR corrects it.