### PR TITLE
Fix for typeahead / search span issue

### DIFF
--- a/app/assets/stylesheets/geoblacklight/_geoblacklight.scss
+++ b/app/assets/stylesheets/geoblacklight/_geoblacklight.scss
@@ -26,3 +26,4 @@
 @import 'modules/search_widgets';
 @import 'modules/toolbar';
 @import 'modules/web_services';
+@import 'modules/twitter-typeahead';

--- a/app/assets/stylesheets/geoblacklight/modules/twitter-typeahead.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/twitter-typeahead.scss
@@ -1,0 +1,11 @@
+.twitter-typeahead {
+
+  .tt-input.form-control {
+    width: 100%;
+  }
+
+  .tt-hint.form-control {
+    width: 100%;
+  }
+
+}


### PR DESCRIPTION
Fixes issue https://github.com/geoblacklight/geoblacklight/issues/437 by including twitter-typehead scss from Blacklight core as a geoblacklight module.