### PR TITLE
handle an Array value in render_value_as_truncate_abstract helper

### DIFF
--- a/app/helpers/geoblacklight_helper.rb
+++ b/app/helpers/geoblacklight_helper.rb
@@ -24,7 +24,7 @@ module GeoblacklightHelper
   # @param [SolrDocument] args
   # @return [String]
   def snippit(args)
-    truncate(Array(args[:value]).flatten.first, length: 150)
+    truncate(Array(args[:value]).flatten.join(' '), length: 150)
   end
 
   def render_facet_tags(facet)
@@ -90,7 +90,7 @@ module GeoblacklightHelper
   # @param [Hash] args from get_field_values
   def render_value_as_truncate_abstract(args)
     content_tag :div, class: 'truncate-abstract' do
-      args[:value]
+      Array(args[:value]).flatten.join(' ')
     end
   end
 

--- a/spec/helpers/geoblacklight_helpers_spec.rb
+++ b/spec/helpers/geoblacklight_helpers_spec.rb
@@ -96,6 +96,19 @@ describe GeoblacklightHelper, type: :helper do
         expect(helper.snippit(document)[-3..-1]).to eq '...'
       end
     end
+    context 'as a multivalued Array' do
+      let(:document_attributes) do
+        {
+          value: %w(short description)
+        }
+      end
+      it 'uses both values' do
+        expect(helper.snippit(document)).to eq 'short description'
+      end
+      it 'does not truncate' do
+        expect(helper.snippit(document)[-3..-1]).not_to eq '...'
+      end
+    end
   end
 
   describe '#cartodb_link' do
@@ -128,6 +141,15 @@ describe GeoblacklightHelper, type: :helper do
   describe '#leaflet_options' do
     it 'returns a hash of options for leaflet' do
       expect(leaflet_options[:VIEWERS][:WMS][:CONTROLS]).to eq(['Opacity'])
+    end
+  end
+
+  describe '#render_value_as_truncate_abstract' do
+    context 'with multiple values' do
+      let(:document) { SolrDocument.new(value: %w(short description)) }
+      it 'wraps in correct DIV class' do
+        expect(helper.render_value_as_truncate_abstract(document)).to eq '<div class="truncate-abstract">short description</div>'
+      end
     end
   end
 end


### PR DESCRIPTION
This PR fixes a problem with a missing "Description" value on the show page. Blacklight sends the `value` argument in as an Array that needs to be unpacked to get at the string in `render_value_as_truncate_abstract`. Not sure if this is the best fix, but I copied what `snippet` was doing already.

![screen shot 2016-07-28 at 2 26 15 pm](https://cloud.githubusercontent.com/assets/1861171/17231396/6d937dfa-54d6-11e6-985c-c1eab03d2f97.png)
