### PR TITLE
Rails 5 Compatibility 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,26 @@
-cache: bundler
 language: ruby
 sudo: false
+
 notifications:
   email: false
 
 rvm:
-  - 2.2.5
+  - 2.3.1
 
-jdk:
-  - oraclejdk8
+matrix:
+  include:
+    - rvm: 2.3.1
+      env: "RAILS_VERSION=4.2.6"
+    - rvm: 2.2.5
+      env: "RAILS_VERSION=5.0.0"
+
+before_install:
+  - gem install bundler
 
 env:
-  global:
-    - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
+ - "RAILS_VERSION=5.0.0"
+
+global_env:
+  - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
+
+jdk: oraclejdk8

--- a/config/initializers/rails_config.rb
+++ b/config/initializers/rails_config.rb
@@ -1,3 +1,3 @@
-RailsConfig.setup do |config|
+Config.setup do |config|
   config.const_name = 'Settings'
 end

--- a/geoblacklight.gemspec
+++ b/geoblacklight.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'blacklight', '~> 6.3'
   spec.add_dependency 'leaflet-rails', '~> 0.7.3'
   spec.add_dependency 'font-awesome-rails'
-  spec.add_dependency 'config', '~> 1.2.1'
+  spec.add_dependency 'config'
   spec.add_dependency 'faraday'
   spec.add_dependency 'coderay'
   spec.add_dependency 'geoblacklight-icons', '>= 0.2'
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec-rails', '~> 3.1'
   spec.add_development_dependency 'engine_cart', '~> 0.10'
   spec.add_development_dependency 'capybara', '>= 2.5.0'
-  spec.add_development_dependency 'poltergeist', '>= 1.5.0'
+  spec.add_development_dependency 'poltergeist'
   spec.add_development_dependency 'factory_girl_rails'
   spec.add_development_dependency 'database_cleaner', '~> 1.3'
 end

--- a/geoblacklight.gemspec
+++ b/geoblacklight.gemspec
@@ -18,22 +18,22 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
+  spec.add_dependency 'rails', '>= 4.2.0', '< 6'
   spec.add_dependency 'blacklight', '~> 6.3'
   spec.add_dependency 'leaflet-rails', '~> 0.7.3'
   spec.add_dependency 'font-awesome-rails'
-  spec.add_dependency 'rails_config', '~> 0.4.2'
+  spec.add_dependency 'config', '~> 1.2.1'
   spec.add_dependency 'faraday'
   spec.add_dependency 'coderay'
   spec.add_dependency 'geoblacklight-icons', '>= 0.2'
   spec.add_dependency 'deprecation'
 
-  spec.add_development_dependency 'bundler', '~> 1.5'
-  spec.add_development_dependency 'rake', '~> 11.0.1'
-  spec.add_development_dependency 'rspec-rails', '~> 3.4.2'
   spec.add_development_dependency 'solr_wrapper'
+  spec.add_development_dependency 'rails-controller-testing'
+  spec.add_development_dependency 'rspec-rails', '~> 3.1'
   spec.add_development_dependency 'engine_cart', '~> 0.10'
-  spec.add_development_dependency 'capybara', '~> 2.3.0'
-  spec.add_development_dependency 'poltergeist', '~> 1.5'
+  spec.add_development_dependency 'capybara', '>= 2.5.0'
+  spec.add_development_dependency 'poltergeist', '>= 1.5.0'
   spec.add_development_dependency 'factory_girl_rails'
-  spec.add_development_dependency 'database_cleaner'
+  spec.add_development_dependency 'database_cleaner', '~> 1.3'
 end

--- a/lib/geoblacklight/engine.rb
+++ b/lib/geoblacklight/engine.rb
@@ -1,7 +1,7 @@
 require 'blacklight'
 require 'leaflet-rails'
 require 'font-awesome-rails'
-require 'rails_config'
+require 'config'
 require 'faraday'
 require 'nokogiri'
 require 'coderay'

--- a/lib/geoblacklight/view_helper_override.rb
+++ b/lib/geoblacklight/view_helper_override.rb
@@ -27,7 +27,7 @@ module Geoblacklight
     def render_constraints_filters(localized_params = params)
       content = super(localized_params)
 
-      if localized_params[:bbox]
+      if localized_params.to_h[:bbox]
         path = search_action_path(remove_spatial_filter_group(:bbox, localized_params))
         content << render_constraint_element('Bounding Box', localized_params[:bbox], remove: path)
       end

--- a/lib/geoblacklight/view_helper_override.rb
+++ b/lib/geoblacklight/view_helper_override.rb
@@ -26,8 +26,9 @@ module Geoblacklight
 
     def render_constraints_filters(localized_params = params)
       content = super(localized_params)
+      localized_params = localized_params.to_unsafe_h unless localized_params.is_a?(Hash)
 
-      if localized_params.to_h[:bbox]
+      if localized_params[:bbox]
         path = search_action_path(remove_spatial_filter_group(:bbox, localized_params))
         content << render_constraint_element('Bounding Box', localized_params[:bbox], remove: path)
       end

--- a/lib/geoblacklight/wms_layer.rb
+++ b/lib/geoblacklight/wms_layer.rb
@@ -1,7 +1,7 @@
 module Geoblacklight
   class WmsLayer
     def initialize(params)
-      @params = params.merge(Settings.WMS_PARAMS)
+      @params = params.to_h.merge(Settings.WMS_PARAMS)
       @response = Geoblacklight::FeatureInfoResponse.new(request_response)
     end
 

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe CatalogController, type: :controller do
   describe '#web_services' do
     it 'returns a document based off an id' do
-      get :web_services, id: 'mit-us-ma-e25zcta5dct-2000'
+      get :web_services, params: { id: 'mit-us-ma-e25zcta5dct-2000' }
       expect(response.status).to eq 200
       expect(assigns(:document)).not_to be_nil
     end

--- a/spec/controllers/download_controller_spec.rb
+++ b/spec/controllers/download_controller_spec.rb
@@ -10,10 +10,9 @@ describe Geoblacklight::DownloadController, type: :controller do
     end
     describe 'public file' do
       it 'initiates download' do
-        expect(controller).to receive(:render)
+        allow(controller).to receive(:render) # Needed for testing with Rails 4
         expect(controller).to receive(:send_file)
         get :file, params: { id: 'mit-us-ma-e25zcta5dct-2000-shapefile', format: 'zip' }
-        expect(response.status).to eq 200
       end
     end
   end
@@ -25,7 +24,14 @@ describe Geoblacklight::DownloadController, type: :controller do
       end
     end
     describe 'public file' do
+      let(:shapefile_download) { instance_double(Geoblacklight::ShapefileDownload) }
+
+      before do
+        allow(Geoblacklight::ShapefileDownload).to receive(:new).and_return(shapefile_download)
+      end
+
       it 'initiates download creation' do
+        allow(shapefile_download).to receive(:get).and_return('success')
         get :show, params: { id: 'mit-us-ma-e25zcta5dct-2000', type: 'shapefile' }
         expect(response.status).to eq 200
       end

--- a/spec/controllers/download_controller_spec.rb
+++ b/spec/controllers/download_controller_spec.rb
@@ -4,7 +4,7 @@ describe Geoblacklight::DownloadController, type: :controller do
   describe '#file' do
     describe 'restricted file' do
       it 'redirects to login for authentication' do
-        get :file, id: 'stanford-cg357zz0321-shapefile', format: 'zip'
+        get :file, params: { id: 'stanford-cg357zz0321-shapefile', format: 'zip' }
         expect(response.status).to eq 401
       end
     end
@@ -12,7 +12,7 @@ describe Geoblacklight::DownloadController, type: :controller do
       it 'initiates download' do
         expect(controller).to receive(:render)
         expect(controller).to receive(:send_file)
-        get :file, id: 'mit-us-ma-e25zcta5dct-2000-shapefile', format: 'zip'
+        get :file, params: { id: 'mit-us-ma-e25zcta5dct-2000-shapefile', format: 'zip' }
         expect(response.status).to eq 200
       end
     end
@@ -20,13 +20,13 @@ describe Geoblacklight::DownloadController, type: :controller do
   describe '#show' do
     describe 'restricted file' do
       it 'redirects to login for authentication' do
-        get 'show', id: 'stanford-cg357zz0321', format: 'json'
+        get :show, params: { id: 'stanford-cg357zz0321', format: 'json' }
         expect(response.status).to eq 401
       end
     end
     describe 'public file' do
       it 'initiates download creation' do
-        get 'show', id: 'mit-us-ma-e25zcta5dct-2000', type: 'shapefile'
+        get :show, params: { id: 'mit-us-ma-e25zcta5dct-2000', type: 'shapefile' }
         expect(response.status).to eq 200
       end
     end
@@ -40,11 +40,11 @@ describe Geoblacklight::DownloadController, type: :controller do
 
     it 'requests file' do
       allow(hgl_download).to receive(:get).and_return('success')
-      get :hgl, id: 'harvard-g7064-s2-1834-k3', email: 'foo@example.com'
+      get :hgl, params: { id: 'harvard-g7064-s2-1834-k3', email: 'foo@example.com' }
       expect(response.status).to eq 200
     end
     it 'renders form' do
-      get :hgl, id: 'harvard-g7064-s2-1834-k3'
+      get :hgl, params: { id: 'harvard-g7064-s2-1834-k3' }
       expect(response).to render_template('hgl')
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -53,6 +53,12 @@ RSpec.configure do |config|
   config.after do
     DatabaseCleaner.clean
   end
+  if Rails::VERSION::MAJOR >= 5
+    config.include ::Rails.application.routes.url_helpers
+    config.include ::Rails.application.routes.mounted_helpers
+  else
+    config.include BackportTestHelpers, type: :controller
+  end
 
   config.include Devise::Test::ControllerHelpers, type: :controller
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,7 @@ require 'coveralls'
 Coveralls.wear!('rails')
 EngineCart.load_application!
 
+require 'rails-controller-testing' if Rails::VERSION::MAJOR >= 5
 require 'rspec/rails'
 require 'capybara/rspec'
 require 'capybara/poltergeist'

--- a/spec/support/backport_test_helpers.rb
+++ b/spec/support/backport_test_helpers.rb
@@ -1,0 +1,45 @@
+# Backport the Rails 5 controller test methods to Rails 4
+module BackportTestHelpers
+  def delete(*args)
+    (action, rest) = *args
+    rest ||= {}
+
+    @request.env['HTTP_X_REQUESTED_WITH'] = 'XMLHttpRequest' if rest[:xhr]
+
+    super(action, rest[:params])
+  end
+
+  def get(*args)
+    (action, rest) = *args
+    rest ||= {}
+    @request.env['HTTP_X_REQUESTED_WITH'] = 'XMLHttpRequest' if rest[:xhr]
+    super(action, rest[:params])
+  end
+
+  def post(*args)
+    (action, rest) = *args
+    rest ||= {}
+    body = rest[:body]
+    @request.env['HTTP_X_REQUESTED_WITH'] = 'XMLHttpRequest' if rest[:xhr]
+
+    if body
+      super(action, body, rest.except(:params).merge(rest[:params]))
+    else
+      super(action, rest[:params])
+    end
+  end
+
+  def put(*args)
+    (action, rest) = *args
+    rest ||= {}
+    @request.env['HTTP_X_REQUESTED_WITH'] = 'XMLHttpRequest' if rest[:xhr]
+    super(action, rest[:params])
+  end
+
+  def patch(*args)
+    (action, rest) = *args
+    rest ||= {}
+    @request.env['HTTP_X_REQUESTED_WITH'] = 'XMLHttpRequest' if rest[:xhr]
+    super(action, rest[:params])
+  end
+end


### PR DESCRIPTION
Initial experiments with rails 5 compatibility. There are 11 broken tests and a slew of deprecation warnings, but the app seems to run just fine. Here are the steps I used to get this running:

1. Start with a clean gemset and switch to the `rails-5` branch.
1. Run `RAILS_VERSION=5.0.0 bundle install`
1. Monkey patch rails to fix error with the squish method.
    - Not sure what this is about, but this can be tracked down later.
    - This is the [line in actionpack](https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/routing.rb#L257) that needs to be patched.
   - Find that file in your gemset. For me, this was the path:  
     
     ```
     /Users/eliotj/.rvm/gems/ruby-2.2.2@r5-bl/gems/actionpack-5.0.0/lib/action_dispatch/routing.rb`
     ```
  - Using the `gem which rails` command can help you find the gem location.
  - Remove the `.squish` method so that line 257 looks like:

    ```
    INSECURE_URL_PARAMETERS_MESSAGE = <<-MSG
    ```
1. Then execute the standard set of commands to get GeoBlacklight running.

```
bundle exec rake engine_cart:generate
bundle exec rake jetty:clean
bundle exec rake geoblacklight:configure_solr
bundle exec rake jetty:start
cd .internal_test_app/
rake geoblacklight:solr:seed
rails s
```
