### PR TITLE
unpin the version of font-awesome-rails gem

### DIFF
--- a/geoblacklight.gemspec
+++ b/geoblacklight.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'blacklight', '~> 6.3'
   spec.add_dependency 'leaflet-rails', '~> 0.7.3'
-  spec.add_dependency 'font-awesome-rails', '~> 4.1.0.0'
+  spec.add_dependency 'font-awesome-rails'
   spec.add_dependency 'rails_config', '~> 0.4.2'
   spec.add_dependency 'faraday'
   spec.add_dependency 'coderay'


### PR DESCRIPTION
This PR unpins the version for the `font-awesome-rails` gem. The current version is 4.6.3.1