### PR TITLE
Improve strictness of schema validation

### DIFF
--- a/schema/geoblacklight-schema.json
+++ b/schema/geoblacklight-schema.json
@@ -3,20 +3,20 @@
   "description": "Schema for GeoBlacklight. See https://github.com/geoblacklight/geoblacklight/wiki/Schema for more details.",
   "id": "http://geoblacklight.org/v1.0/schema",
   "title": "GeoBlacklight Schema",
-  "required": [
-    "dc_title_s",
-    "dc_description_s",
-    "dc_rights_s",
-    "dct_provenance_s",
-    "layer_slug_s",
-    "solr_geom"
-  ],
   "type": "array",
   "properties": {
     "layer": {
       "title": "layer",
       "description": "A GIS data layer. See [this example](https://github.com/OpenGeoMetadata/edu.stanford.purl/blob/master/bb/099/zb/1450/geoblacklight.json) metadata layer.",
       "type": "object",
+      "required": [
+        "dc_title_s",
+        "dc_identifier_s",
+        "dc_rights_s",
+        "dct_provenance_s",
+        "layer_slug_s",
+        "solr_geom"
+      ],
       "properties": {
         "uuid": {
           "type": "string",
@@ -35,7 +35,7 @@
         },
         "dc_description_s": {
           "type": "string",
-          "description": "Description for the layer.",
+          "description": "Description for the layer. *Optional*",
           "example": "My Description"
         },
         "dc_rights_s": {
@@ -53,7 +53,8 @@
         },
         "dct_references_s": {
           "type": "string",
-          "description": "External resources that are available for the layer. The value is a JSON hash where each key is a URI for the protocol or format, and the value is the URL to the external resource. See `dct_references_s` [detailed documentation](http://geoblacklight.org/tutorial/2015/02/09/geoblacklight-overview.html)",
+          "description": "External resources that are available for the layer. The value is a JSON hash where each key is a URI for the protocol or format, and the value is the URL to the external resource. See `dct_references_s` [detailed documentation](http://geoblacklight.org/tutorial/2015/02/09/geoblacklight-overview.html). *Optional*",
+          "pattern": "\\{.*\\}",
           "example": "{ ... }"
         },
         "georss_box_s": {
@@ -63,7 +64,7 @@
         },
         "layer_id_s": {
           "type": "string",
-          "description": "The complete identifier for the layer via WMS/WFS/WCS protocol.",
+          "description": "The complete identifier for the layer via WMS/WFS/WCS protocol. *Optional*",
           "example": "druid:vr593vj7147"
         },
         "layer_geom_type_s": {
@@ -74,18 +75,20 @@
             "Polygon",
             "Raster",
             "Scanned Map",
+            "Image",
             "Mixed"
           ],
-          "description": "Geometry type for layer data, using controlled vocabulary."
+          "description": "Geometry type for layer data, using controlled vocabulary. *Optional*"
         },
         "layer_modified_dt": {
           "type": "string",
           "format": "date-time",
-          "description": "Last modification date for the metadata record, using XML Schema dateTime format (YYYY-MM-DDThh:mm:ssZ)."
+          "description": "Last modification date for the metadata record, using XML Schema dateTime format (YYYY-MM-DDThh:mm:ssZ). *Optional*"
         },
         "layer_slug_s": {
           "type": "string",
           "description": "Identifies a layer in human-readable keywords. Note this value is visible to the user, and used for Permalinks. The value should be alpha-numeric characters separated by dashes, and is typically of the form `institution-keyword1-keyword2`. It should also be globally unique across all institutions in *your* GeoBlacklight index. See https://github.com/geoblacklight/geoblacklight/wiki/Schema for more detailed documentation.",
+          "pattern": "^[-a-zA-Z0-9]+$",
           "example": "stanford-andhra-pradesh-village-boundaries"
         },
         "solr_geom": {
@@ -109,12 +112,8 @@
         },
         "dc_format_s": {
           "type": "string",
-          "enum": [
-            "Shapefile",
-            "GeoTIFF",
-            "ArcGRID"
-          ],
-          "description": "File format for the layer, using a controlled vocabulary. *Optional*"
+          "description": "File format for the layer, ideally using a controlled vocabulary. *Optional*",
+          "example": "Shapefile, GeoTIFF, ArcGRID"
         },
         "dc_language_s": {
           "type": "string",
@@ -196,7 +195,9 @@
         "geoblacklight_version": {
           "type": "string",
           "description": "The version of the GeoBlacklight Schema to which this metadata record conforms.",
-          "example": "1.0"
+          "enum": [
+            "1.0"
+          ]
         }
       }
     }

--- a/schema/geoblacklight-schema.md
+++ b/schema/geoblacklight-schema.md
@@ -8,8 +8,8 @@ A GIS data layer. See [this example](https://github.com/OpenGeoMetadata/edu.stan
 | Name | Type | Description | Example |
 | ------- | ------- | ------- | ------- |
 | **dc_creator_sm** | *array* | Author(s) of the layer. *Optional* | `"George Washington, Thomas Jefferson"` |
-| **dc_description_s** | *string* | Description for the layer. | `"My Description"` |
-| **dc_format_s** | *string* | File format for the layer, using a controlled vocabulary. *Optional*<br/> **one of:**`"Shapefile"` or `"GeoTIFF"` or `"ArcGRID"` | `"Shapefile"` |
+| **dc_description_s** | *string* | Description for the layer. *Optional* | `"My Description"` |
+| **dc_format_s** | *string* | File format for the layer, ideally using a controlled vocabulary. *Optional* | `"Shapefile, GeoTIFF, ArcGRID"` |
 | **dc_identifier_s** | *string* | Unique identifier for layer as a URI. It should be globally unique across all institutions, assumed not to be end-user visible, and is usually of the form `http://institution/id`. See https://github.com/geoblacklight/geoblacklight/wiki/Schema for more detailed documentation. | `"http://purl.stanford.edu/vr593vj7147"` |
 | **dc_language_s** | *string* | Language for the layer. *Optional*. Note that future versions of the schema may make this a multi-valued field. | `"English"` |
 | **dc_publisher_s** | *string* | Publisher of the layer. *Optional* | `"ML InfoMap"` |
@@ -22,16 +22,18 @@ A GIS data layer. See [this example](https://github.com/OpenGeoMetadata/edu.stan
 | **dct_isPartOf_sm** | *array* | Holding entity for the layer, such as the title of a collection. *Optional* | `"Village Maps of India"` |
 | **dct_issued_dt** | *date-time* | Issued date for the layer, using XML Schema dateTime format (YYYY-MM-DDThh:mm:ssZ). *Optional* | `"2015-01-01T12:00:00Z"` |
 | **dct_provenance_s** | *string* | Institution who holds the layer. | `"Stanford"` |
-| **dct_references_s** | *string* | External resources that are available for the layer. The value is a JSON hash where each key is a URI for the protocol or format, and the value is the URL to the external resource. See `dct_references_s` [detailed documentation](http://geoblacklight.org/tutorial/2015/02/09/geoblacklight-overview.html) | `"{ ... }"` |
+| **dct_references_s** | *string* | External resources that are available for the layer. The value is a JSON hash where each key is a URI for the protocol or format, and the value is the URL to the external resource. See `dct_references_s` [detailed documentation](http://geoblacklight.org/tutorial/2015/02/09/geoblacklight-overview.html). *Optional*<br/> **pattern:** `\{.*\}` | `"{ ... }"` |
 | **dct_spatial_sm** | *array* | Spatial coverage and place names for the layer, preferrably in a controlled vocabulary. *Optional* | `"Paris, San Francisco"` |
 | **dct_temporal_sm** | *array* | Temporal coverage for the layer, typically years or dates. Note that this field is not in a specific date format. *Optional* | `"1989, circa 2010, 2007-2009"` |
-| **geoblacklight_version** | *string* | The version of the GeoBlacklight Schema to which this metadata record conforms. | `"1.0"` |
+| **geoblacklight_version** | *string* | The version of the GeoBlacklight Schema to which this metadata record conforms.<br/> **one of:**`"1.0"` | `"1.0"` |
 | **georss_box_s** | *string* | *DEPRECATED* (use `solr_geom`): Bounding box for the layer, as maximum values for S W N E. | `"12.6 -119.4 19.9 84.8"` |
 | **georss_point_s** | *string* | *DEPRECATED* (use `georss_box_s`): Point representation for layer as y, x - i.e., centroid | `"12.6 -119.4"` |
-| **layer_geom_type_s** | *string* | Geometry type for layer data, using controlled vocabulary.<br/> **one of:**`"Point"` or `"Line"` or `"Polygon"` or `"Raster"` or `"Scanned Map"` or `"Mixed"` | `"Point"` |
-| **layer_id_s** | *string* | The complete identifier for the layer via WMS/WFS/WCS protocol. | `"druid:vr593vj7147"` |
-| **layer_modified_dt** | *date-time* | Last modification date for the metadata record, using XML Schema dateTime format (YYYY-MM-DDThh:mm:ssZ). | `"2015-01-01T12:00:00Z"` |
-| **layer_slug_s** | *string* | Identifies a layer in human-readable keywords. Note this value is visible to the user, and used for Permalinks. The value should be alpha-numeric characters separated by dashes, and is typically of the form `institution-keyword1-keyword2`. It should also be globally unique across all institutions in *your* GeoBlacklight index. See https://github.com/geoblacklight/geoblacklight/wiki/Schema for more detailed documentation. | `"stanford-andhra-pradesh-village-boundaries"` |
+| **layer_geom_type_s** | *string* | Geometry type for layer data, using controlled vocabulary.<br/> **one of:**`"Point"` or `"Line"` or `"Polygon"` or `"Raster"` or `"Scanned Map"` or `"Image"` or `"Mixed"` | `"Point"` |
+| **layer_id_s** | *string* | The complete identifier for the layer via WMS/WFS/WCS protocol. *Optional* | `"druid:vr593vj7147"` |
+| **layer_modified_dt** | *date-time* | Last modification date for the metadata record, using XML Schema dateTime format (YYYY-MM-DDThh:mm:ssZ). *Optional* | `"2015-01-01T12:00:00Z"` |
+| **layer_slug_s** | *string* | Identifies a layer in human-readable keywords. Note this value is visible to the user, and used for Permalinks. The value should be alpha-numeric characters separated by dashes, and is typically of the form `institution-keyword1-keyword2`. It should also be globally unique across all institutions in *your* GeoBlacklight index. See https://github.com/geoblacklight/geoblacklight/wiki/Schema for more detailed documentation.<br/> **pattern:** `^[-a-zA-Z0-9]+$` | `"stanford-andhra-pradesh-village-boundaries"` |
 | **solr_geom** | *string* | Bounding box of the layer as a ENVELOPE WKT (from the CQL standard) using coordinates in (West, East, North, South) order. Note that this field is indexed as a Solr spatial (RPT) field.<br/> **pattern:** `ENVELOPE(.*,.*,.*,.*)` | `"ENVELOPE(76.76, 84.76, 19.91, 12.62)"` |
 | **solr_year_i** | *integer* | *DEPRECATED* (only used by the Blacklight range plugin, not core GeoBlacklight, and generally you want a multi-valued field here): *Derived from* `dct_temporal_sm`. Year for which layer is valid and only a single value. Note that this field is indexed as a Solr numeric field. | `"1989"` |
 | **uuid** | *string* | *DEPRECATED* (use `dc_identifier_s`): Unique identifier for layer that is globally unique. | `"http://purl.stanford.edu/vr593vj7147"` |
+
+


### PR DESCRIPTION
This PR improves the enum and pattern matching validation. It also makes `dc_format_s` a free-text field to support more file formats. This PR is connected to https://github.com/geoblacklight/geoblacklight-schema/issues/84