### PR TITLE
Fix WMS feature inspection

### DIFF
--- a/app/controllers/wms_controller.rb
+++ b/app/controllers/wms_controller.rb
@@ -1,9 +1,15 @@
 class WmsController < ApplicationController
   def handle
-    response = Geoblacklight::WmsLayer.new(params).feature_info
+    response = Geoblacklight::WmsLayer.new(wms_params).feature_info
 
     respond_to do |format|
       format.json { render json: response }
     end
+  end
+
+  private
+
+  def wms_params
+    params.permit('URL', 'LAYERS', 'BBOX', 'WIDTH', 'HEIGHT', 'QUERY_LAYERS', 'X', 'Y')
   end
 end

--- a/spec/controllers/wms_controller_spec.rb
+++ b/spec/controllers/wms_controller_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+describe Geoblacklight::WmsController, type: :controller do
+  let(:wms_layer) { instance_double('Geoblacklight::WmsLayer') }
+  let(:feature_info) { { values: ['fid', 'layer:example'] } }
+  let(:params) do
+    { format: 'json', 'URL' => 'http://www.example.com/', 'LAYERS' => 'layer:example',
+      'BBOX' => '-74, 40, -68, 43', 'WIDTH' => '500', 'HEIGHT' => '400',
+      'QUERY_LAYERS' => 'layer:example', 'X' => '277', 'Y' => '195' }
+  end
+
+  before do
+    allow(Geoblacklight::WmsLayer).to receive(:new).and_return(wms_layer)
+    allow(wms_layer).to receive(:feature_info).and_return(feature_info)
+  end
+
+  describe '#handle' do
+    it 'returns feature info as json' do
+      get :handle, params: params
+      expect(response.body).to eq(feature_info.to_json)
+    end
+  end
+
+  describe '#wms_params' do
+    let(:wms_params) { controller.instance_eval { wms_params } }
+
+    it 'returns only permitted params' do
+      get :handle, params: params
+      expect(wms_params.to_h).not_to eq(params)
+      params.delete(:format)
+      expect(wms_params.to_h).to eq(params)
+    end
+  end
+end

--- a/spec/lib/geoblacklight/wms_layer_spec.rb
+++ b/spec/lib/geoblacklight/wms_layer_spec.rb
@@ -1,28 +1,63 @@
 require 'spec_helper'
 
 describe Geoblacklight::WmsLayer do
-  let(:params) { { 'URL' => 'http://www.example.com/', 'X' => '277' } }
   let(:wms_layer) { described_class.new(params) }
+  let(:rails_4_params) { { 'URL' => 'http://www.example.com/', 'X' => '277' } }
+  let(:rails_5_params) { instance_double('ActionController::Parameters') }
+
+  before do
+    allow(rails_5_params).to receive(:to_h).and_return('URL' => 'http://www.example.com/', 'X' => '277')
+  end
+
   describe '#initialize' do
+    let(:params) { rails_4_params }
+
     it 'initializes as a WmsLayer object' do
       expect(wms_layer).to be_an described_class
     end
   end
 
   describe '#url' do
-    it 'returns only URL parameter' do
-      expect(wms_layer.url).to eq 'http://www.example.com/'
+    context 'when running on rails 4' do
+      let(:params) { rails_4_params }
+
+      it 'returns the correct URL parameter' do
+        expect(wms_layer.url).to eq('http://www.example.com/')
+      end
+    end
+
+    context 'when running on rails 5' do
+      let(:params) { rails_5_params }
+
+      it 'returns the correct URL parameter' do
+        expect(wms_layer.url).to eq('http://www.example.com/')
+      end
     end
   end
 
   describe '#search_params' do
-    it 'returns all params except URL plus default params' do
-      expect(wms_layer.search_params.length).to eq 8
-      expect(wms_layer.search_params).not_to include 'URL' => 'http://www.example.com'
+    context 'when running on rails 4' do
+      let(:params) { rails_4_params }
+
+      it 'returns all params except URL plus default params' do
+        expect(wms_layer.search_params.length).to eq 8
+        expect(wms_layer.search_params).not_to include 'URL' => 'http://www.example.com/'
+      end
+    end
+
+    context 'when running on rails 5' do
+      let(:params) { rails_5_params }
+
+      it 'returns all params except URL plus default params' do
+        expect(wms_layer.search_params.length).to eq 8
+        expect(wms_layer.search_params).not_to include 'URL' => 'http://www.example.com/'
+      end
     end
   end
 
   describe '#request_response' do
+    let(:params) { rails_4_params }
+
     it 'returns a Faraday object' do
       faraday = double('faraday')
       allow(faraday).to receive(:get)


### PR DESCRIPTION
Fix WMS feature inspection. ~~Rails 5 parameters are objects and need to be converted to hashes using the `to_unsafe_h` method for compatibility.~~ We have to explicitly permit WMS parameters (url, layer, bbox, etc…).