### PR TITLE
Pin the geoblacklight gem version in template.rb

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -1,5 +1,5 @@
-gem 'blacklight'
-gem 'geoblacklight'
+gem 'blacklight', '>= 6.3'
+gem 'geoblacklight', '>= 1.1.0'
 
 run 'bundle install'
 


### PR DESCRIPTION
Pin the geoblacklight gem version in the template file. There have been some issues with users running the `rails new` command with older versions of the gem installed.