### PR TITLE
Improve behavior of solr server rake tasks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -79,7 +79,14 @@ namespace :geoblacklight do
         Rake::Task['geoblacklight:internal:seed'].invoke
 
         within_test_app do
-          system "bundle exec rails s #{args[:rails_server_args]}"
+          puts "\nSolr server running: http://localhost:#{solr.port}/solr/#/blacklight-core"
+          puts "\n^C to stop"
+          puts ' '
+          begin
+            system "bundle exec rails s #{args[:rails_server_args]}"
+          rescue Interrupt
+            puts 'Shutting down...'
+          end
         end
       end
     end

--- a/lib/tasks/geoblacklight.rake
+++ b/lib/tasks/geoblacklight.rake
@@ -7,7 +7,15 @@ namespace :geoblacklight do
   task :server, [:rails_server_args] do |_t, args|
     SolrWrapper.wrap(port: '8983') do |solr|
       solr.with_collection(name: 'blacklight-core', dir: File.join(File.expand_path('../../', File.dirname(__FILE__)), 'solr', 'conf')) do
-        system "bundle exec rails s #{args[:rails_server_args]}"
+          puts "\nSolr server running: http://localhost:#{solr.port}/solr/#/blacklight-core"
+          puts "\n^C to stop"
+          puts ' '
+          begin
+            Rake::Task['geoblacklight:solr:seed'].invoke
+            system "bundle exec rails s #{args[:rails_server_args]}"
+          rescue Interrupt
+            puts 'Shutting down...'
+          end
       end
     end
   end


### PR DESCRIPTION
Improves behavior of solr server rake tasks.

- Runs `solr:seed` as part of  `geoblacklight:server`.
- Solr server shuts down in a friendly way instead of spitting out exception messages.

Closes #485.