### PR TITLE
Rubygems update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ matrix:
       env: "RAILS_VERSION=5.0.0"
 
 before_install:
+  - gem update --system
   - gem install bundler
 
 env:

--- a/geoblacklight.gemspec
+++ b/geoblacklight.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
+  spec.required_rubygems_version = '>= 2.5.2'
 
   spec.add_dependency 'rails', '>= 4.2.0', '< 6'
   spec.add_dependency 'blacklight', '~> 6.3'


### PR DESCRIPTION
Fixes an issue with installing the geoblacklight with an older version of rubygems.

- Requires a version of ruby gems greater than or equal to 2.5.2.
- Forces Travis to update rubygems to latest version.