### PR TITLE
Data relation UI widget

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,7 +25,7 @@ Metrics/AbcSize:
   Max: 23
 
 Metrics/MethodLength:
-  Max: 15
+  Max: 16
 
 # TODO: Add top-level class and module documentation.
 Style/Documentation:

--- a/app/assets/javascripts/geoblacklight/modules/relations.js
+++ b/app/assets/javascripts/geoblacklight/modules/relations.js
@@ -1,0 +1,15 @@
+Blacklight.onLoad(function () {
+    $('[data-relations="true"]').each(function (i, element) {
+        var $elem = $(element);
+        var attributes = $elem.data();
+        var relation_url = attributes['url'] + '/relations';
+        $.ajax({
+            url: relation_url,
+            type: 'GET',
+            dataType: 'html',
+            success: function (data) {
+                $elem.append($(data).hide().fadeIn(200));
+            }
+        })
+    });
+});

--- a/app/assets/stylesheets/geoblacklight/modules/icon-customization.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/icon-customization.scss
@@ -34,6 +34,14 @@
   @extend .fa, .fa-envelope;
 }
 
+.geoblacklight-relations-ancestor {
+  @extend .fa, .fa-pagelines;
+}
+
+.geoblacklight-relations-descendant {
+  @extend .fa, .fa-leaf;
+}
+
 .geoblacklight-web_services {
   @extend .fa, .fa-external-link;
 }

--- a/app/controllers/relation_controller.rb
+++ b/app/controllers/relation_controller.rb
@@ -1,0 +1,17 @@
+class RelationController < ApplicationController
+  include Blacklight::Configurable
+  include Blacklight::SearchHelper
+  copy_blacklight_config_from(CatalogController)
+
+  def relations
+    @relation_response = Geoblacklight::Relation::RelationResponse.new(params[:id], repository)
+    respond_to do |format|
+      format.json do
+        render json: @relation_response.relations
+      end
+      format.html do
+        render 'catalog/relations', layout: false
+      end
+    end
+  end
+end

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -1,4 +1,9 @@
 module BlacklightHelper
   include Blacklight::BlacklightHelperBehavior
   include Geoblacklight::GeoblacklightHelperBehavior
+  include Blacklight::CatalogHelperBehavior
+
+  def render_document_sidebar_partial(document = @document)
+    super(document) + (render 'relations_container', document: document)
+  end
 end

--- a/app/views/catalog/_relations_container.html.erb
+++ b/app/views/catalog/_relations_container.html.erb
@@ -1,0 +1,1 @@
+<%= content_tag(:div, nil, data: {relations: true, url: solr_document_path(document.id)}) %>

--- a/app/views/catalog/relations.html.erb
+++ b/app/views/catalog/relations.html.erb
@@ -1,0 +1,39 @@
+<% unless @relation_response.empty? %>
+    <div class="panel panel-default show-tools">
+      <div class="panel-heading">
+        Data Relations
+      </div>
+      <div class="panel-body">
+        <ul class="nav" data-present="<%= (@relation_response.relations[:descendants]['numFound'] != 0 || @relation_response.relations[:ancestors]['numFound'] != 0) %>">
+          <% unless (@relation_response.relations[:ancestors]['numFound'].to_i == 0) %>
+              <b><%= t('geoblacklight.relations.ancestor') %></b>
+              <% @relation_response.relations[:ancestors]['docs'].each do |ancestor| %>
+                  <li>
+                    <%= link_to solr_document_path(ancestor['layer_slug_s']) do %>
+                        <span class='geoblacklight geoblacklight-relations-ancestor'></span> <%= ancestor['dc_title_s'] %>
+                    <% end %>
+                  </li>
+              <% end %>
+          <% end %>
+          <% unless (@relation_response.relations[:descendants]['numFound'].to_i == 0) %>
+              <b><%= t('geoblacklight.relations.descendant') %>
+                (<%= @relation_response.relations[:descendants]['numFound'] %>)</b>
+              <% @relation_response.relations[:descendants]['docs'][0..2].each do |descendant| %>
+                  <li>
+                    <%= link_to solr_document_path(descendant['layer_slug_s']) do %>
+                        <span class='geoblacklight geoblacklight-relations-descendant'></span> <%= descendant['dc_title_s'] %>
+                    <% end %>
+                  </li>
+              <% end %>
+              <% unless (@relation_response.relations[:descendants]['numFound'].to_i <= 3) %>
+                  <li>
+                    <%= link_to search_catalog_path({f: {"#{Settings.FIELDS.SOURCE}" => [@relation_response.relations[:current_doc]]}}) do %>
+                        <%= "Browse all #{@relation_response.relations[:descendants]['numFound']} records..." %>
+                    <% end %>
+                  </li>
+              <% end %>
+          <% end %>
+        </ul>
+      </div>
+    </div>
+<% end %>

--- a/config/locales/geoblacklight.en.yml
+++ b/config/locales/geoblacklight.en.yml
@@ -32,3 +32,6 @@ en:
       dynamic_map_layer: 'ArcGIS Dynamic Map Layer'
       image_map_layer: 'ArcGIS Image Map Layer'
       data_dictionary: 'Documentation'
+    relations:
+      ancestor: 'Source Datasets'
+      descendant: 'Derived Datasets'

--- a/lib/generators/geoblacklight/install_generator.rb
+++ b/lib/generators/geoblacklight/install_generator.rb
@@ -20,18 +20,17 @@ module Geoblacklight
           resources :solr_documents, only: [:show], path: '/catalog', controller: 'catalog' do
             concerns :gbl_exportable
           end
-
           concern :gbl_wms, Geoblacklight::Routes::Wms.new
           namespace :wms do
             concerns :gbl_wms
           end
-
           concern :gbl_downloadable, Geoblacklight::Routes::Downloadable.new
           namespace :download do
             concerns :gbl_downloadable
           end
-
           resources :download, only: [:show]
+
+          get '/catalog/:id/relations' => 'relation#relations', as: :relations
       EOF
     end
 

--- a/lib/generators/geoblacklight/templates/settings.yml
+++ b/lib/generators/geoblacklight/templates/settings.yml
@@ -28,6 +28,7 @@ FIELDS:
   :PART_OF: 'dct_isPartOf_sm'
   :TEMPORAL: 'dct_temporal_sm'
   :TITLE: 'dc_title_s'
+  :SOURCE: 'dc_source_sm'
 
 # Institution deployed at
 INSTITUTION: 'Stanford'

--- a/lib/geoblacklight.rb
+++ b/lib/geoblacklight.rb
@@ -22,6 +22,9 @@ module Geoblacklight
   require 'geoblacklight/reference'
   require 'geoblacklight/references'
   require 'geoblacklight/routes'
+  require 'geoblacklight/relation/descendants'
+  require 'geoblacklight/relation/ancestors'
+  require 'geoblacklight/relation/relation_response'
 
   def self.inject!
     CatalogController.send(:include, Geoblacklight::ControllerOverride)

--- a/lib/geoblacklight/relation/ancestors.rb
+++ b/lib/geoblacklight/relation/ancestors.rb
@@ -1,0 +1,27 @@
+module Geoblacklight
+  module Relation
+    class Ancestors
+      def initialize(id, repository)
+        @search_id = id
+        @repository = repository
+      end
+
+      def create_search_params
+        { fq: ["{!join from=#{Settings.FIELDS.SOURCE} to=layer_slug_s}layer_slug_s:#{@search_id}"],
+          fl: [Settings.FIELDS.TITLE, 'layer_slug_s'] }
+      end
+
+      def execute_query
+        @repository.connection.send_and_receive(
+          @repository.blacklight_config.solr_path,
+          params: create_search_params
+        )
+      end
+
+      def results
+        response = execute_query
+        response['response']
+      end
+    end
+  end
+end

--- a/lib/geoblacklight/relation/descendants.rb
+++ b/lib/geoblacklight/relation/descendants.rb
@@ -1,0 +1,27 @@
+module Geoblacklight
+  module Relation
+    class Descendants
+      def initialize(id, repository)
+        @search_id = id
+        @repository = repository
+      end
+
+      def create_search_params
+        { fq: "#{Settings.FIELDS.SOURCE}:#{@search_id}",
+          fl: [Settings.FIELDS.TITLE, 'layer_slug_s'] }
+      end
+
+      def execute_query
+        @repository.connection.send_and_receive(
+          @repository.blacklight_config.solr_path,
+          params: create_search_params
+        )
+      end
+
+      def results
+        response = execute_query
+        response['response']
+      end
+    end
+  end
+end

--- a/lib/geoblacklight/relation/relation_response.rb
+++ b/lib/geoblacklight/relation/relation_response.rb
@@ -1,0 +1,20 @@
+module Geoblacklight
+  module Relation
+    class RelationResponse
+      attr_reader :relations
+      def initialize(id, repository)
+        @search_id = id
+        @repository = repository
+        @relations = {
+          ancestors: Geoblacklight::Relation::Ancestors.new(@search_id, @repository).results,
+          descendants: Geoblacklight::Relation::Descendants.new(@search_id, @repository).results,
+          current_doc: id
+        }
+      end
+
+      def empty?
+        !(@relations[:ancestors]['numFound'] > 0 || @relations[:descendants]['numFound'] > 0)
+      end
+    end
+  end
+end

--- a/spec/features/relations_spec.rb
+++ b/spec/features/relations_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+
+feature 'Display related documents' do
+  let(:expected_json_resp) do
+    {
+      'ancestors' =>
+        {
+          'numFound' => 0,
+          'start' => 0,
+          'docs' => []
+        },
+      'descendants' =>
+            {
+              'numFound' => 1,
+              'start' => 0,
+              'docs' =>
+                    [
+                      {
+                        'dc_title_s' => '2015 New York City Subway Complexes and Ridership',
+                        'layer_slug_s' => 'nyu_2451_34502'
+                      }
+                    ]
+            },
+      'current_doc' => 'nyu_2451_34635'
+    }
+  end
+  scenario 'Record with dc_source_sm value(s) should have parent(s)' do
+    visit relations_path('nyu_2451_34502')
+    expect(page).to have_css('ul b', text: 'Source Datasets')
+  end
+
+  scenario 'Record that is pointed to by others should have children' do
+    visit relations_path('nyu_2451_34635')
+    expect(page).to have_css('ul b', text: 'Derived Datasets')
+  end
+
+  scenario 'Relations should respond to json' do
+    visit relations_path('nyu_2451_34635', format: 'json')
+    expect(page.body).to eq(expected_json_resp.to_json)
+  end
+
+  scenario 'Record with relations should render widget in catalog#show', js: true do
+    visit solr_document_path('nyu_2451_34635')
+    expect(page).to have_css('div.panel-heading', text: 'Data Relations')
+  end
+
+  scenario 'Record without relations should not render widget in catalog#show', js: true do
+    visit solr_document_path('harvard-g7064-s2-1834-k3')
+    expect(page).to have_no_css('div.panel-heading', text: 'Data Relations')
+  end
+end

--- a/spec/fixtures/solr_documents/baruch_ancestor1.json
+++ b/spec/fixtures/solr_documents/baruch_ancestor1.json
@@ -1,0 +1,46 @@
+{
+  "dc_identifier_s": "http://hdl.handle.net/2451/34635",
+  "dc_title_s": "2016 NYC Geodatabase, Open Source Version (jan2016)",
+  "dc_description_s": "The NYC Geodatabase (nyc_gdb) is a resource designed for basic geographic analysis and thematic mapping within the five boroughs of New York City. It contains geographic features and data compiled from several public sources. Subsets of large features like water, greenspace, and public facilities were created and Census geographies like tracts, ZCTAs, and PUMAs were geoprocessed to create land-based boundaries. Census data from the 2010 Census, American Community Survey (ACS), and ZIP Code Business Patterns are stored in tables that can be easily related to geographic features. Transit and public facility point data were gathered from several city agencies and transformed into spatial data that can be used for reference or analysis for measuring distance, drawing buffers, or counting features within areas. The data is provided in SQLite format.",
+  "dc_rights_s": "Public",
+  "dct_provenance_s": "Baruch CUNY",
+  "dct_references_s": "{\"http://schema.org/url\":\"http://hdl.handle.net/2451/34635\",\"http://schema.org/downloadUrl\":\"https://archive.nyu.edu/retrieve/74854/nyu_2451_34635.zip\",\"http://lccn.loc.gov/sh85035852\":\"https://archive.nyu.edu/retrieve/74855/nyu_2451_34635_doc.zip\"}",
+  "layer_id_s": "sdr:nyu_2451_34635",
+  "layer_slug_s": "nyu_2451_34635",
+  "layer_geom_type_s": "Mixed",
+  "layer_modified_dt": "2016-5-2T18:21:7Z",
+  "dc_format_s": "SQLite Database",
+  "dc_language_s": "English",
+  "dc_type_s": "Dataset",
+  "dc_publisher_s": [
+    "Newman Library (Bernard M. Baruch College)"
+  ],
+  "dc_creator_sm": "GIS Lab, Newman Library, Baruch CUNY",
+  "dc_subject_sm": [
+    "Boroughs",
+    "Boundaries",
+    "Counties"
+  ],
+  "dct_isPartOf_sm": "NYC Geodatabase (version jan2016)",
+  "dct_issued_s": "1/15/2016",
+  "dct_temporal_sm": [
+    "2010",
+    "2016"
+  ],
+  "dct_spatial_sm": [
+    "New York, New York, United States",
+    "Bronx County, New York, United States",
+    "Kings County, New York, United States",
+    "New York County, New York, United States",
+    "Queens County, New York, United States",
+    "Richmond County, New York, United States",
+    "Borough of Bronx, New York, United States",
+    "Borough of Brooklyn, New York, United States",
+    "Borough of Manhattan, New York, United States",
+    "Borough of Queens, New York, United States",
+    "Borough of Staten Island, New York, United States"
+  ],
+  "solr_geom": "ENVELOPE(-74.255895, -73.700272, 40.9152819999998, 40.4959289999998)",
+  "solr_year_i": 2016,
+  "geoblacklight_version": "1.0"
+}

--- a/spec/fixtures/solr_documents/baruch_ancestor2.json
+++ b/spec/fixtures/solr_documents/baruch_ancestor2.json
@@ -1,0 +1,46 @@
+{
+  "dc_identifier_s": "http://hdl.handle.net/2451/34636",
+  "dc_title_s": "2016 NYC Geodatabase, ArcGIS Version (jan2016)",
+  "dc_description_s": "The NYC Geodatabase (nyc_gdb) is a resource designed for basic geographic analysis and thematic mapping within the five boroughs of New York City. It contains geographic features and data compiled from several public sources. Subsets of large features like water, greenspace, and public facilities were created and Census geographies like tracts, ZCTAs, and PUMAs were geoprocessed to create land-based boundaries. Census data from the 2010 Census, American Community Survey (ACS), and ZIP Code Business Patterns are stored in tables that can be easily related to geographic features. Transit and public facility point data were gathered from several city agencies and transformed into spatial data that can be used for reference or analysis for measuring distance, drawing buffers, or counting features within areas. The data is provided in ESRI Geodatabase format.",
+  "dc_rights_s": "Public",
+  "dct_provenance_s": "Baruch CUNY",
+  "dct_references_s": "{\"http://schema.org/url\":\"http://hdl.handle.net/2451/34636\",\"http://schema.org/downloadUrl\":\"https://archive.nyu.edu/retrieve/74856/nyu_2451_34636.zip\",\"http://lccn.loc.gov/sh85035852\":\"https://archive.nyu.edu/retrieve/74857/nyu_2451_34636_doc.zip\"}",
+  "layer_id_s": "sdr:nyu_2451_34636",
+  "layer_slug_s": "nyu_2451_34636",
+  "layer_geom_type_s": "Mixed",
+  "layer_modified_dt": "2016-5-2T18:21:7Z",
+  "dc_format_s": "ESRI Geodatabase",
+  "dc_language_s": "English",
+  "dc_type_s": "Dataset",
+  "dc_publisher_s": [
+    "Newman Library (Bernard M. Baruch College)"
+  ],
+  "dc_creator_sm": "GIS Lab, Newman Library, Baruch CUNY",
+  "dc_subject_sm": [
+    "Boroughs",
+    "Boundaries",
+    "Counties"
+  ],
+  "dct_isPartOf_sm": "NYC Geodatabase (version jan2016)",
+  "dct_issued_s": "1/15/2016",
+  "dct_temporal_sm": [
+    "2010",
+    "2016"
+  ],
+  "dct_spatial_sm": [
+    "New York, New York, United States",
+    "Bronx County, New York, United States",
+    "Kings County, New York, United States",
+    "New York County, New York, United States",
+    "Queens County, New York, United States",
+    "Richmond County, New York, United States",
+    "Borough of Bronx, New York, United States",
+    "Borough of Brooklyn, New York, United States",
+    "Borough of Manhattan, New York, United States",
+    "Borough of Queens, New York, United States",
+    "Borough of Staten Island, New York, United States"
+  ],
+  "solr_geom": "ENVELOPE(-74.255895, -73.700272, 40.9152819999998, 40.4959289999998)",
+  "solr_year_i": 2016,
+  "geoblacklight_version": "1.0"
+}


### PR DESCRIPTION
Just picking this up from the end of the sprint... definitely not ready to merge, but thought it would be easier to discuss as a PR.

This implements some simple parent/child relation tracking in GeoBlacklight. It is a refactor from the version that I'm currently using for the NYU deployment. It creates two routes which return a corresponding record's 'ancestors' and 'descendants', where those are determined by Solr queries that look for a value(s) stored in another record's `dc_source_sm` field. Descendants need to point to their ancestor(s), but not vice versa.

The routes are:
```
localhost:3000/catalog/fake-record-001/ancestors.json
localhost:3000/catalog/fake-record-001/descendants.json
```
... and what is returned looks something like this:
```json
{
  "url": "http://localhost:3000/",
  "response": {
    "numFound": 2,
    "start": 0,
    "docs": [
      {
        "dc_title_s": "2016 NYC Geodatabase, ArcGIS Version (jan2016)",
        "layer_slug_s": "nyu_2451_34636"
      },
      {
        "dc_title_s": "2016 NYC Geodatabase, Open Source Version (jan2016)",
        "layer_slug_s": "nyu_2451_34635"
      }
    ]
  }
}
```

I also wrote a bit of JS to inject the results, returned to the browser via XHR, into a record view. That code is probably the messiest part of this right now.

Would love to hear any comments or recommendations about how to improve it. I realize everyone is probably busy on other projects currently, so no hurry!