### PR TITLE
makes the bq boost value for bbox within matches configurable

### DIFF
--- a/app/models/concerns/geoblacklight/spatial_search_behavior.rb
+++ b/app/models/concerns/geoblacklight/spatial_search_behavior.rb
@@ -15,7 +15,7 @@ module Geoblacklight
     def add_spatial_params(solr_params)
       if blacklight_params[:bbox]
         solr_params[:bq] ||= []
-        solr_params[:bq] = ["#{Settings.FIELDS.GEOMETRY}:\"IsWithin(#{envelope_bounds})\"^10"]
+        solr_params[:bq] << "#{Settings.FIELDS.GEOMETRY}:\"IsWithin(#{envelope_bounds})\"#{boost}"
         solr_params[:fq] ||= []
         solr_params[:fq] << "#{Settings.FIELDS.GEOMETRY}:\"Intersects(#{envelope_bounds})\""
       end
@@ -29,6 +29,12 @@ module Geoblacklight
     # @return [String]
     def envelope_bounds
       bounding_box.to_envelope
+    end
+
+    ## Allow bq boost to be configured, default 10 for backwards compatibility
+    # @return [String]
+    def boost
+      "^#{Settings.BBOX_WITHIN_BOOST || '10'}"
     end
 
     ##

--- a/lib/generators/geoblacklight/templates/settings.yml
+++ b/lib/generators/geoblacklight/templates/settings.yml
@@ -10,7 +10,10 @@ CARTO_ONECLICK_LINK: 'http://oneclick.cartodb.com/'
 # DEPRECATED Main Solr geometry field used for spatial search and bounding box. Should be type 'rpt'
 GEOMETRY_FIELD: 'solr_geom'
 
-#Solr field mappings
+# The bq boost value for spatial search matches within a bounding box
+BBOX_WITHIN_BOOST: '10'
+
+# Solr field mappings
 FIELDS:
   :FILE_FORMAT: 'dc_format_s'
   :GEOMETRY: 'solr_geom'

--- a/spec/models/concerns/geoblacklight/spatial_search_behavior_spec.rb
+++ b/spec/models/concerns/geoblacklight/spatial_search_behavior_spec.rb
@@ -27,6 +27,18 @@ describe Geoblacklight::SpatialSearchBehavior do
       subject.with(params)
       expect(subject.add_spatial_params(solr_params)[:fq].to_s).to include('Intersects')
     end
+    it 'applies boost based on configured Settings.BBOX_WITHIN_BOOST' do
+      allow(Settings).to receive(:BBOX_WITHIN_BOOST).and_return 99
+      params = { bbox: '-180 -80 120 80' }
+      subject.with(params)
+      expect(subject.add_spatial_params(solr_params)[:bq].to_s).to include('^99')
+    end
+    it 'applies default boost of 10 when Settings.BBOX_WITHIN_BOOST not configured' do
+      allow(Settings).to receive(:BBOX_WITHIN_BOOST).and_return nil
+      params = { bbox: '-180 -80 120 80' }
+      subject.with(params)
+      expect(subject.add_spatial_params(solr_params)[:bq].to_s).to include('^10')
+    end
   end
   describe '#envelope_bounds' do
     it 'calls to_envelope on the bounding box' do


### PR DESCRIPTION
@mejackreed - what are your thoughts on this? Making the bq boost configurable prevents the need for local overrides, like in [EarthWorks](https://github.com/sul-dlss/earthworks/blob/00b4eb1c5ead601095d6363ba4822fe8bae1c326/app/models/search_builder.rb#L11).