### PR TITLE
allow blank search to retrieve full results set

### DIFF
--- a/app/views/catalog/_search_form_no_navbar.html.erb
+++ b/app/views/catalog/_search_form_no_navbar.html.erb
@@ -1,10 +1,12 @@
 <%= form_tag search_action_url, :method => :get, :class => 'search-query-form clearfix' do %>
 <%= render_hash_as_hidden_fields(search_state.params_for_search().except(:q, :search_field, :qt, :page, :utf8)) %>
 
-<% unless search_fields.empty? %>
+<% if search_fields.length > 1 %>
 <label for="search_field" class="sr-only"><%= t('blacklight.search.form.search_field.label') %></label>
 <%= select_tag(:search_field, options_for_select(search_fields, h(params[:search_field])), :title => t('blacklight.search.form.search_field.title'), :class=>"search_field form-control") %>
 <span class="sr-only"><%= t('blacklight.search.form.search_field.post_label') %></span>
+<% elsif search_fields.length == 1 %>
+  <%= hidden_field_tag :search_field, search_fields.first.last %>
 <% end %>
 <div class="input-group search-input-group">
   <label for="q" class="sr-only"><%= t('blacklight.search.form.search.label') %></label>

--- a/lib/generators/geoblacklight/templates/catalog_controller.rb
+++ b/lib/generators/geoblacklight/templates/catalog_controller.rb
@@ -145,7 +145,7 @@ class CatalogController < ApplicationController
     # solr request handler? The one set in config[:default_solr_parameters][:qt],
     # since we aren't specifying it otherwise.
 
-    # config.add_search_field 'text', :label => 'All Fields'
+    config.add_search_field 'all_fields', :label => 'All Fields'
     # config.add_search_field 'dc_title_ti', :label => 'Title'
     # config.add_search_field 'dc_description_ti', :label => 'Description'
 

--- a/spec/features/empty_search_spec.rb
+++ b/spec/features/empty_search_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+feature 'Empty search' do
+  before do
+    visit root_path
+  end
+  scenario 'Entering empty search returns results page' do
+    click_button 'search'
+    expect(page).to have_css '#documents'
+  end
+end


### PR DESCRIPTION
Closes #526. Makes the homepage search form fields behave more consistently with search results page search form: https://github.com/projectblacklight/blacklight/blob/c5b170a0a404fd97df32f80dbc47fa58d3c9c152/app/views/catalog/_search_form.html.erb

By configuring a single search field in the catalog_controller, Blacklight will submit a url `search_field` parameter, which causes the `has_search_parameters?` to return true in https://github.com/geoblacklight/geoblacklight/blob/3603575c85b81b4070d56f3011dd9b55873a2697/app/views/catalog/index.html.erb#L1 (and render the search results).