### PR TITLE
allow search bar fields to fit in homepage jumbotron

### DIFF
--- a/app/views/catalog/_home_text.html.erb
+++ b/app/views/catalog/_home_text.html.erb
@@ -2,8 +2,10 @@
   <div class='home-search-area'>
     <%= content_tag :h2, t('geoblacklight.home.headline') %>
     <%= content_tag :h3, t('geoblacklight.home.search_heading') %>
-    <div class='col-md-6 col-md-offset-3'>
-      <%= render_search_form_no_navbar %>
+    <div class='row'>
+      <div class='col-md-6 col-md-offset-3'>
+        <%= render_search_form_no_navbar %>
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
If a Geoblacklight application gets configured for multiple search fields the search form doesn't fit in the homepage gray jumbotron banner.
Current:
<img width="1440" alt="jumbotron_before" src="https://cloud.githubusercontent.com/assets/4650153/22772401/6fc97ea2-ee6a-11e6-9e3f-c6ca90c52a1a.png">
Proposed change:
<img width="1439" alt="jumbotron_after" src="https://cloud.githubusercontent.com/assets/4650153/22772405/7330a6ce-ee6a-11e6-9fd8-905175498922.png">
