### PR TITLE
Remove solr_wrapper from geoblacklight generator

### DIFF
--- a/lib/generators/geoblacklight/install_generator.rb
+++ b/lib/generators/geoblacklight/install_generator.rb
@@ -6,10 +6,6 @@ module Geoblacklight
 
     desc 'Install Geoblacklight'
 
-    def add_solr_wrapper
-      generate 'blacklight:solr5'
-    end
-
     def mount_geoblacklight_engine
       route "mount Geoblacklight::Engine => 'geoblacklight'"
     end

--- a/template.rb
+++ b/template.rb
@@ -4,6 +4,6 @@ gem 'geoblacklight', '>= 1.3'
 run 'bundle install'
 
 generate 'blacklight:install', '--devise'
-generate 'geoblacklight:install', '--solrwrapper', '-f'
+generate 'geoblacklight:install', '-f'
 
 rake 'db:migrate'


### PR DESCRIPTION
solr_wrapper is a dependency of Blacklight and gets installed as part of the Blacklight install generator. Removes redundant/unused install generator code for GeoBlacklight generator and template.