### PR TITLE
 reduce support for Rails >= 4.2 < 5.1 and Blacklight > 6.3 < 6.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,21 +5,21 @@ notifications:
   email: false
 
 rvm:
-  - 2.3.1
+  - 2.3.4
 
 matrix:
   include:
-    - rvm: 2.3.1
-      env: "RAILS_VERSION=4.2.7.1"
-    - rvm: 2.2.5
-      env: "RAILS_VERSION=5.0.0.1"
+    - rvm: 2.3.4
+      env: "RAILS_VERSION=4.2.8"
+    - rvm: 2.3.4
+      env: "RAILS_VERSION=5.0.3"
 
 before_install:
   - gem update --system
   - gem install bundler
 
 env:
- - "RAILS_VERSION=5.0.0.1"
+ - "RAILS_VERSION=5.0.3"
 
 global_env:
   - NOKOGIRI_USE_SYSTEM_LIBRARIES=true

--- a/geoblacklight.gemspec
+++ b/geoblacklight.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_rubygems_version = '>= 2.5.2'
 
-  spec.add_dependency 'rails', '>= 4.2.0', '< 6'
-  spec.add_dependency 'blacklight', '~> 6.3'
+  spec.add_dependency 'rails', '>= 4.2.0', '< 5.1'
+  spec.add_dependency 'blacklight', '~> 6.3', '< 6.10'
   spec.add_dependency 'leaflet-rails', '~> 0.7.3'
   spec.add_dependency 'font-awesome-rails'
   spec.add_dependency 'config'

--- a/spec/test_app_templates/lib/generators/test_app_generator.rb
+++ b/spec/test_app_templates/lib/generators/test_app_generator.rb
@@ -4,7 +4,7 @@ class TestAppGenerator < Rails::Generators::Base
   source_root File.expand_path('../../../../spec/test_app_templates', __FILE__)
 
   def add_gems
-    gem 'blacklight', '~> 6.3'
+    gem 'blacklight'
     gem 'teaspoon'
     gem 'teaspoon-jasmine'
     Bundler.with_clean_env do


### PR DESCRIPTION
This change is an effort to provide a migration path for Rails 4.2 users
as we intend to drop Rails 4.2 in the v1.6.0 release