### PR TITLE
Update parseableBbox and add specs to validate map initial view

### DIFF
--- a/app/assets/javascripts/geoblacklight/modules/results.js
+++ b/app/assets/javascripts/geoblacklight/modules/results.js
@@ -11,10 +11,14 @@ Blacklight.onLoad(function() {
   $('[data-map="index"]').each(function() {
     var data = $(this).data(),
     opts = { baseUrl: data.catalogPath },
-    geoblacklight;
-    var bbox = [[-180, -90], [180, 90]];
+    geoblacklight, bbox;
 
-    var parseableBbox = /(-?[0-9]{2})\s(-?[0-9]{3})\s(-?[0-9]{2})\s(-?[0-9]{3})/;
+    var lngRe = '(-?[0-9]{1,2}(\\.[0-9]+)?)';
+    var latRe = '(-?[0-9]{1,3}(\\.[0-9]+)?)';
+
+    var parseableBbox = new RegExp(
+      [lngRe,latRe,lngRe,latRe].join('\\s+')
+    );
 
     if (typeof data.mapBbox === 'string') {
       bbox = L.bboxToBounds(data.mapBbox);
@@ -23,10 +27,14 @@ Blacklight.onLoad(function() {
         var currentBbox = $(this).data().bbox;
         if (parseableBbox.test(currentBbox)) {
           if (typeof bbox === 'undefined') {
-            bbox = L.bboxToBounds($(this).data().bbox);
+            bbox = L.bboxToBounds(currentBbox);
           } else {
-            bbox.extend(L.bboxToBounds($(this).data().bbox));
+            bbox.extend(L.bboxToBounds(currentBbox));
           }
+        } else {
+          // bbox not parseable, use default value.
+          // [[-180, -90], [180, 90]];
+          bbox = L.bboxToBounds("-180 -90 180 90");
         }
       });
     }

--- a/app/assets/javascripts/geoblacklight/viewers/map.js
+++ b/app/assets/javascripts/geoblacklight/viewers/map.js
@@ -9,7 +9,7 @@ GeoBlacklight.Viewer.Map = GeoBlacklight.Viewer.extend({
     bbox: [[-80, -195], [80, 185]],
     opacity: 0.75
   },
-  
+
   overlay: L.layerGroup(),
 
   load: function() {
@@ -17,6 +17,12 @@ GeoBlacklight.Viewer.Map = GeoBlacklight.Viewer.extend({
       this.options.bbox = L.bboxToBounds(this.data.mapBbox);
     }
     this.map = L.map(this.element).fitBounds(this.options.bbox);
+
+    // Add initial bbox to map element for easier testing
+    if (this.map.getBounds().isValid()) {
+      this.element.setAttribute('data-js-map-render-bbox', this.map.getBounds().toBBoxString());
+    }
+
     this.map.addLayer(this.selectBasemap());
     this.map.addLayer(this.overlay);
     if (this.data.map !== 'index') {

--- a/spec/features/search_results_map_spec.rb
+++ b/spec/features/search_results_map_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+
+feature 'search results map', js: true do
+  scenario 'present on a search result page' do
+    visit search_catalog_path(q: 'Minnesota')
+    expect(page).to have_css '#map'
+  end
+  scenario 'present on a search result page' do
+    visit root_path
+    click_link 'Minnesota, United States'
+    results = page.all(:css, 'div.document')
+    expect(results.count).to equal(4)
+  end
+  scenario 'view is scoped to Minnesota' do
+    visit root_path
+    click_link 'Minnesota, United States'
+    expect(page).to have_css '#map'
+    bbox = page.find('#map')['data-js-map-render-bbox']
+
+    # Example bbox for Place > Minnesota, United States:
+    # "-101.90917968749999,38.75408327579141,-83.27636718749999,53.27835301753182"
+    left, bottom, right, top = bbox.split(',')
+    expect(left.to_f).to be_within(2).of(-101)
+    expect(bottom.to_f).to be_within(2).of(38)
+    expect(right.to_f).to be_within(2).of(-83)
+    expect(top.to_f).to be_within(2).of(53)
+  end
+  scenario 'view is scoped to Twin Cities metro area' do
+    visit search_catalog_path(q: 'Minneapolis')
+    expect(page).to have_css '#map'
+    bbox = page.find('#map')['data-js-map-render-bbox']
+
+    # Example bbox for q: Minneapolis
+    # "-94.537353515625,44.004669106432225,-92.208251953125,45.87088761346192"
+    left, bottom, right, top = bbox.split(',')
+    expect(left.to_f).to be_within(1).of(-94)
+    expect(bottom.to_f).to be_within(1).of(44)
+    expect(right.to_f).to be_within(1).of(-92)
+    expect(top.to_f).to be_within(1).of(45)
+  end
+  scenario 'view is scoped to NYC' do
+    visit root_path
+    click_link 'New York, New York, United States'
+    expect(page).to have_css '#map'
+    bbox = page.find('#map')['data-js-map-render-bbox']
+
+    # Example bbox for Place > New York, New York, United States
+    # "-74.26895141601562,40.455307212131494,-73.68667602539061,40.95501133048621"
+    left, bottom, right, top = bbox.split(',')
+    expect(left.to_f).to be_within(2).of(-74)
+    expect(bottom.to_f).to be_within(2).of(40)
+    expect(right.to_f).to be_within(2).of(-73)
+    expect(top.to_f).to be_within(2).of(40)
+  end
+end

--- a/spec/fixtures/solr_documents/umn_metro_result1.json
+++ b/spec/fixtures/solr_documents/umn_metro_result1.json
@@ -1,0 +1,37 @@
+{
+  "geoblacklight_version": "1.0",
+  "layer_geom_type_s": "Mixed",
+  "layer_modified_dt": "2017-01-20T18:38:47Z",
+  "solr_geom": "ENVELOPE(-94.012, -92.732, 45.415, 44.471)",
+  "dct_references_s": "{\"http://schema.org/downloadUrl\":\"ftp://ftp.gisdata.mn.gov/pub/gdrs/data/pub/us_mn_state_metc/plan_frmwrk2030dev_plan_ar2011/shp_plan_frmwrk2030dev_plan_ar2011.zip\",\"http://schema.org/url\":\"https://gisdata.mn.gov/dataset/us-mn-state-metc-plan-frmwrk2030dev-plan-ar2011\",\"http://www.isotc211.org/schemas/2005/gmd/\":\"https://opengeometadata.github.io/edu.umn/4a/d4/13/49035c4bd391a777b99afbf550/iso19139.xml\"}",
+  "dc_rights_s": "Public",
+  "dct_provenance_s": "Minnesota",
+  "dc_subject_sm": [
+    "Planning and Cadastral",
+    "Urban planning and development"
+  ],
+  "dc_format_s": "Shapefile",
+  "dc_description_s": "The 2030 Regional Development Framework Planning Areas - 2011 updates the 2030 Regional Development Framework Planning Areas initially adopted on January 14, 2004 and ammended in 2006. This dataset reflect the agreed upon planning areas between a community and the Metropolitan Council and defined in the communities' 2030 Comprehensive Plan Update and is intended to supplement the 2030 Regional Development Framework - the planning guide for the 7-county Twin Cities metropolitan area of Minneapolis and Saint Paul, Minnesota. Planning area definitions and strategies for the planning areas are available in the 2030 Regional Development Framework document at http://www.metrocouncil.org/Planning/Planning/2030-Regional-Development-Framework.aspx (See Chapter 3). For questions about how decisions were made regarding individual communities' geographic planning areas, please contact the Metropolitan Council Regional Framework Development staff, Dan Marckel, 651-602-1548. See Currentness Reference and Lineage in Data Quality Section of this metadata for more information.",
+  "dct_issued_s": "2014-05-23",
+  "dct_temporal_sm": [
+    "2011"
+  ],
+  "dc_creator_sm": [
+    "Metropolitan Council"
+  ],
+  "dc_identifier_s": "4ad41349-035c-4bd3-91a7-77b99afbf550",
+  "solr_year_i": 2011,
+  "dct_spatial_sm": [
+    "Minnesota, United States",
+    "Minneapolis-St. Paul-Bloomington, United States"
+  ],
+  "dc_publisher_sm": [
+    "Metropolitan Council"
+  ],
+  "layer_id_s": "4ad41349-035c-4bd3-91a7-77b99afbf550",
+  "dc_title_s": "2030 Regional Development Framework Planning Areas: Twin Cities Metro, Minnesota, 2011",
+  "layer_slug_s": "4ad41349-035c-4bd3-91a7-77b99afbf550",
+  "dct_isPartOf_sm": [
+    "Minnesota Geospatial Commons"
+  ]
+}

--- a/spec/fixtures/solr_documents/umn_metro_result2.json
+++ b/spec/fixtures/solr_documents/umn_metro_result2.json
@@ -1,0 +1,35 @@
+{
+  "layer_geom_type_s": "Mixed",
+  "layer_modified_dt": "2017-01-20T18:39:22Z",
+  "solr_geom": "ENVELOPE(-94.012, -92.732, 45.415, 44.471)",
+  "dct_references_s": "{\"http://schema.org/downloadUrl\":\"ftp://ftp.gisdata.mn.gov/pub/gdrs/data/pub/us_mn_state_metc/society_census_trt_comb1990_2000/shp_society_census_trt_comb1990_2000.zip\",\"http://schema.org/url\":\"https://gisdata.mn.gov/dataset/us-mn-state-metc-society-census-trt-comb1990-2000\",\"http://www.isotc211.org/schemas/2005/gmd/\":\"https://opengeometadata.github.io/edu.umn/e9/71/49/88c3074135b7a7a1d521949f5d/iso19139.xml\"}",
+  "dc_rights_s": "Public",
+  "dct_provenance_s": "Minnesota",
+  "dc_subject_sm": [
+    "Society"
+  ],
+  "dc_format_s": "Shapefile",
+  "dc_description_s": "This dataset consists of a correspondence table and shape file of the combined 1990 and 2000 Census tracts. Note: Census tracts from 1990 and 2000 do not match in all areas. This dataset is an attempt to match them. Some combining and splitting of tracts was necessary. See the Lineage in Section 2 of the metadata for more information.",
+  "dct_issued_s": "2003-01-27",
+  "dct_temporal_sm": [
+    "1990-2000"
+  ],
+  "dc_creator_sm": [
+    "Metropolitan Council"
+  ],
+  "dc_identifier_s": "e9714988-c307-4135-b7a7-a1d521949f5d",
+  "solr_year_i": 1990,
+  "dct_spatial_sm": [
+    "Minnesota, United States",
+    "Minneapolis-St. Paul-Bloomington, United States"
+  ],
+  "dc_publisher_sm": [
+    "Metropolitan Council"
+  ],
+  "layer_id_s": "e9714988-c307-4135-b7a7-a1d521949f5d",
+  "dc_title_s": "1990 to 2000 Census Tract Correspondence and Combined Tracts: Twin Cities Metro, Minnesota, 2003",
+  "layer_slug_s": "e9714988-c307-4135-b7a7-a1d521949f5d",
+  "dct_isPartOf_sm": [
+    "Minnesota Geospatial Commons"
+  ]
+}

--- a/spec/fixtures/solr_documents/umn_state_result1.json
+++ b/spec/fixtures/solr_documents/umn_state_result1.json
@@ -1,0 +1,31 @@
+{
+  "layer_geom_type_s": "Mixed",
+  "layer_modified_dt": "2017-01-20T18:38:45Z",
+  "solr_geom": "ENVELOPE(-97.612501, -88.842351, 49.464145, 42.906949)",
+  "dct_references_s": "{\"http://schema.org/downloadUrl\":\"ftp://gdrs.dnr.state.mn.us/gdrs/data/pub/us_mn_state_dnr/tif_base_usgs_scanned_topo_100k_drg.zip\",\"http://schema.org/url\":\"https://gisdata.mn.gov/dataset/base-usgs-scanned-topo-100k-drg\",\"http://www.isotc211.org/schemas/2005/gmd/\":\"https://opengeometadata.github.io/edu.umn/08/32/9e/9637794cea9fa85d9939b6276f/iso19139.xml\"}",
+  "dc_rights_s": "Public",
+  "dct_provenance_s": "Minnesota",
+  "dc_subject_sm": [
+    "Imagery and Base Maps"
+  ],
+  "dc_format_s": "GeoTIFF",
+  "dc_description_s": "A digital raster graphic (DRG) is a scanned image of an U.S. Geological Survey (USGS) standard series topographic map, including all map collar information. The image inside the map neatline is georeferenced to the surface of the earth and fit to the Universal Transverse Mercator projection. The horizontal positional accuracy and datum of the DRG matches the accuracy and datum of the source map. The map is scanned at a minimum resolution of 250 dots per inch. DRG's are created by scanning published paper maps on high-resolution scanners. The raster image is georeferenced and fit to the UTM projection. Colors are standardized to remove scanner limitations and artifacts. The average data set size is about 6 megabytes in Tagged Image File Format (TIFF) with PackBits compression. DRG's can be easily combined with other digital cartographic products such as digital elevation models (DEM) and digital orthophoto quadrangles (DOQ). DRG's are stored as rectified TIFF files in geoTIFF format. GeoTIFF is a relatively new TIFF image storage format that incorporates georeferencing information in the header. This allows software, such as ArcView, ARC/INFO, or EPPL7 to reference the image without an additional header or world file. Within the Minnesota Department of Natural Resources Core GIS data set the DRG's have been processed to be in compliance with departmental data standards (UTM Extended Zone 15, NAD83 datum) and the map collar information has been removed to facilitate the display of the DRG's in a seamless fashion. These DRG's were clipped and transformed to UTM Zone 15 using EPPL7 Raster GIS.",
+  "dct_issued_s": "2010-04-22T06:00:00.000ZZ",
+  "dc_creator_sm": [
+    "U.S. Geological Survey (USGS) and Minnesota Department of Natural Resources (DNR)"
+  ],
+  "dc_identifier_s": "08329e96-3779-4cea-9fa8-5d9939b6276f",
+  "dct_isPartOf_sm": [
+    "Minnesota Geospatial Commons"
+  ],
+  "solr_year_i": 2010,
+  "dct_spatial_sm": [
+    "Minnesota, United States"
+  ],
+  "dc_publisher_sm": [
+    "Minnesota Department of Natural Resources"
+  ],
+  "layer_id_s": "08329e96-3779-4cea-9fa8-5d9939b6276f",
+  "dc_title_s": "1:100k Digital Raster Graphic, Collars Removed: Minnesota, 2010",
+  "layer_slug_s": "08329e96-3779-4cea-9fa8-5d9939b6276f"
+}

--- a/spec/fixtures/solr_documents/umn_state_result2.json
+++ b/spec/fixtures/solr_documents/umn_state_result2.json
@@ -1,0 +1,36 @@
+{
+  "layer_geom_type_s": "Mixed",
+  "layer_modified_dt": "2017-01-20T18:40:36Z",
+  "solr_geom": "ENVELOPE(-97.991522, -87.177541, 49.892443, 42.891013)",
+  "dct_references_s": "{\"http://schema.org/downloadUrl\":\"ftp://ftp.gisdata.mn.gov/pub/gdrs/data/pub/us_mn_state_dnr/base_usgs_scanned_topo_250k_drg/fgdb_base_usgs_scanned_topo_250k_drg.zip\",\"http://schema.org/url\":\"https://gisdata.mn.gov/dataset/base-usgs-scanned-topo-250k-drg\",\"http://www.isotc211.org/schemas/2005/gmd/\":\"https://opengeometadata.github.io/edu.umn/18/63/6f/2f3d0a470e82bf26f9ceb4ea43/iso19139.xml\"}",
+  "dc_rights_s": "Public",
+  "dct_provenance_s": "Minnesota",
+  "dc_subject_sm": [
+    "Imagery and Base Maps",
+    "Imagerybasemapsearthcover",
+    "Drg"
+  ],
+  "dc_format_s": "GeoTIFF",
+  "dc_description_s": "A digital raster graphic (DRG) is a scanned image of an U.S. Geological Survey (USGS) standard series topographic map, including all map collar information. The image inside the map neatline is georeferenced to the surface of the earth and fit to the Universal Transverse Mercator projection. The horizontal positional accuracy and datum of the DRG matches the accuracy and datum of the source map. The map is scanned at a minimum resolution of 250 dots per inch. DRG's are created by scanning published paper maps on high-resolution scanners. The raster image is georeferenced and fit to the UTM projection. Colors are standardized to remove scanner limitations and artifacts. The average data set size is about 6 megabytes in Tagged Image File Format (TIFF) with PackBits compression. DRG's can be easily combined with other digital cartographic products such as digital elevation models (DEM) and digital orthophoto quadrangles (DOQ). DRG's are stored as rectified TIFF files in geoTIFF format. GeoTIFF is a relatively new TIFF image storage format that incorporates georeferencing information in the header. This allows software, such as ArcView, ARC/INFO, or EPPL7 to reference the image without an additional header or world file. Within the Minnesota Department of Natural Resources Core GIS data set the DRG's have been processed to be in compliance with departmental data standards (UTM Extended Zone 15, NAD83 datum) and the map collar information has been removed to facilitate the display of the DRG's in a seamless fashion. These DRG's were clipped and transformed to UTM Zone 15 using EPPL7 Raster GIS.",
+  "dct_issued_s": "1998-01-01",
+  "dct_temporal_sm": [
+    "1998"
+  ],
+  "dc_creator_sm": [
+    "U.S. Geological Survey and Minnesota DNR"
+  ],
+  "dc_identifier_s": "18636f2f-3d0a-470e-82bf-26f9ceb4ea43",
+  "solr_year_i": 1998,
+  "dct_spatial_sm": [
+    "Minnesota, United States"
+  ],
+  "dc_publisher_sm": [
+    "Minnesota Department of Natural Resources"
+  ],
+  "layer_id_s": "18636f2f-3d0a-470e-82bf-26f9ceb4ea43",
+  "dc_title_s": "1:250k Digital Raster Graphic, Collars Removed: Minnesota, 1998",
+  "layer_slug_s": "18636f2f-3d0a-470e-82bf-26f9ceb4ea43",
+  "dct_isPartOf_sm": [
+    "Minnesota Geospatial Commons"
+  ]
+}


### PR DESCRIPTION
Add decimal support to parseableBbox RegExp; Thanks and HT to @nihiliad

The B1G Geoportal bounding box data attributes include decimals, ex:
"-97.991522 42.891013 -87.177541 49.892443".  As such, the 1.4.0
release parseableBbox RegExp pattern could not parse any of our bboxes.

GeoBlacklight.Viewer.Map now adds a data-js-map-render-bbox attribute
upon valid bboxes, so specs can verify search result sets render an
appropriate initial map view bbox.