### PR TITLE
allow search results html to render

### DIFF
--- a/app/presenters/geoblacklight/document_presenter.rb
+++ b/app/presenters/geoblacklight/document_presenter.rb
@@ -2,6 +2,7 @@ module Geoblacklight
   ##
   # Adds custom functionality for Geoblacklight document presentation
   class DocumentPresenter < Blacklight::IndexPresenter
+    include ActionView::Helpers::OutputSafetyHelper
     ##
     # Presents configured index fields in search results. Passes values through
     # configured helper_method. Multivalued fields separated by presenter
@@ -16,7 +17,7 @@ module Geoblacklight
           fields_values << val
         end
       end
-      fields_values.join(' ')
+      safe_join(fields_values, ' ')
     end
   end
 end


### PR DESCRIPTION
This change allows html (ie links to searches, or characters like double quotes) to render in the search results view.
Example (expand the search result): https://earthworks.stanford.edu/?utf8=%E2%9C%93&q=+100+Years+of+Estuarine+Marsh+Trends