### PR TITLE
Deprecates PhantomJS for Headless Chrome

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+dist: trusty
+addons:
+  chrome: stable
 language: ruby
 sudo: false
 
@@ -15,6 +18,7 @@ matrix:
 before_install:
   - gem update --system
   - gem install bundler
+  - google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost &
 
 env:
  - "RAILS_VERSION=5.0.3"

--- a/geoblacklight.gemspec
+++ b/geoblacklight.gemspec
@@ -34,7 +34,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec-rails', '~> 3.1'
   spec.add_development_dependency 'engine_cart', '~> 1.0'
   spec.add_development_dependency 'capybara', '>= 2.5.0'
-  spec.add_development_dependency 'poltergeist'
+  spec.add_development_dependency 'selenium-webdriver'
+  spec.add_development_dependency 'chromedriver-helper'
   spec.add_development_dependency 'factory_girl_rails'
   spec.add_development_dependency 'database_cleaner', '~> 1.3'
 end

--- a/spec/features/layer_inspection_spec.rb
+++ b/spec/features/layer_inspection_spec.rb
@@ -4,7 +4,7 @@ feature 'Layer inspection', js: true do
   scenario 'clicking map should trigger inspection' do
     visit solr_document_path('mit-us-ma-e25zcta5dct-2000')
     expect(page).to have_css('th', text: 'Attribute')
-    find('#map').trigger('click')
+    find('#map').click
     expect(page).not_to have_css('td.default-text')
   end
 end

--- a/spec/features/split_view.html.erb_spec.rb
+++ b/spec/features/split_view.html.erb_spec.rb
@@ -34,14 +34,14 @@ feature 'Index view', js: true do
     # Needed to find an svg element on the page
     visit search_catalog_path(f: { Settings.FIELDS.PROVENANCE => ['Stanford'] })
     expect(Nokogiri::HTML.parse(page.body).css('path').length).to eq 0
-    find('.documentHeader', match: :first).trigger(:mouseover)
+    find('.documentHeader', match: :first).hover
     expect(Nokogiri::HTML.parse(page.body).css('path').length).to eq 1
   end
 
   scenario 'click on a record area to expand collapse' do
     within('.documentHeader', match: :first) do
       expect(page).not_to have_css('.collapse')
-      find('.status-icons').trigger('click')
+      find('.status-icons').click
       expect(page).to have_css('.collapse', visible: true)
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,16 +10,19 @@ EngineCart.load_application!
 require 'rails-controller-testing' if Rails::VERSION::MAJOR >= 5
 require 'rspec/rails'
 require 'capybara/rspec'
-require 'capybara/poltergeist'
-Capybara.javascript_driver = :poltergeist
+require 'selenium-webdriver'
 
-Capybara.register_driver :poltergeist do |app|
-  options = {}
+Capybara.register_driver(:headless_chrome) do |app|
+  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
+    chromeOptions: { args: %w(headless disable-gpu) }
+  )
 
-  options[:timeout] = RUBY_PLATFORM == 'java' ? 120 : 15
-
-  Capybara::Poltergeist::Driver.new(app, options)
+  Capybara::Selenium::Driver.new(app,
+                                 browser: :chrome,
+                                 desired_capabilities: capabilities)
 end
+
+Capybara.javascript_driver = :headless_chrome
 
 Capybara.default_wait_time = 15
 


### PR DESCRIPTION
Resolves #558 by addressing the following:
- Updating RSpec functional test suites to use Headless Chrome on Selenium as a test driver
- Modifying the test suites for the Index View and Layer interaction for the Selenium