### PR TITLE
make bounding box constraint label configurable

### DIFF
--- a/config/locales/geoblacklight.en.yml
+++ b/config/locales/geoblacklight.en.yml
@@ -1,5 +1,6 @@
 en:
   geoblacklight:
+    bbox_label: 'Bounding Box'
     download:
       download: 'Download'
       success: 'Your file %{title} is ready for download'

--- a/lib/geoblacklight/view_helper_override.rb
+++ b/lib/geoblacklight/view_helper_override.rb
@@ -21,7 +21,7 @@ module Geoblacklight
 
     def render_search_to_s_bbox(params)
       return ''.html_safe if params['bbox'].blank?
-      render_search_to_s_element('Bounding box', render_filter_value(params['bbox']))
+      render_search_to_s_element(t('geoblacklight.bbox_label'), render_filter_value(params['bbox']))
     end
 
     def render_constraints_filters(localized_params = params)
@@ -30,7 +30,8 @@ module Geoblacklight
 
       if localized_params[:bbox]
         path = search_action_path(remove_spatial_filter_group(:bbox, localized_params))
-        content << render_constraint_element('Bounding Box', localized_params[:bbox], remove: path)
+        content << render_constraint_element(t('geoblacklight.bbox_label'),
+                                             localized_params[:bbox], remove: path)
       end
 
       content

--- a/spec/features/saved_searches_spec.rb
+++ b/spec/features/saved_searches_spec.rb
@@ -8,6 +8,6 @@ feature 'saved searches' do
       expect(page.current_url).to match(/bbox=/)
     end
     visit blacklight.search_history_path
-    expect(page).to have_css 'td.query a', text: /Bounding box:/
+    expect(page).to have_css 'td.query a', text: /#{I18n.t('geoblacklight.bbox_label')}:/
   end
 end

--- a/spec/lib/geoblacklight/view_helper_override_spec.rb
+++ b/spec/lib/geoblacklight/view_helper_override_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 describe Geoblacklight::ViewHelperOverride do
   class GeoblacklightControllerTestClass
+    include AbstractController::Translation
     attr_accessor :params
   end
 


### PR DESCRIPTION
This shouldn't be a breaking change and makes it easier to configure a custom label for the bounding box search constraint.