### PR TITLE
Handle geospatial metadata as XML (without HTML transforms)

### DIFF
--- a/app/assets/javascripts/geoblacklight/modules/metadata_download_button.js
+++ b/app/assets/javascripts/geoblacklight/modules/metadata_download_button.js
@@ -1,4 +1,4 @@
-//= require bootstrap/dropdown
+//= require bootstrap/tab
 
 !(function(global) {
 

--- a/app/assets/stylesheets/geoblacklight/_geoblacklight.scss
+++ b/app/assets/stylesheets/geoblacklight/_geoblacklight.scss
@@ -22,6 +22,7 @@
 @import 'modules/metadata';
 @import 'modules/metadata_content';
 @import 'modules/metadata_missing';
+@import 'modules/metadata_markup';
 @import 'modules/results';
 @import 'modules/geosearch';
 @import 'modules/search_widgets';

--- a/app/assets/stylesheets/geoblacklight/modules/metadata_markup.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/metadata_markup.scss
@@ -1,0 +1,9 @@
+/*
+ * Rules for untransformed geospatial metadata markup
+ *
+ */
+#metadata-markup-container {
+  .alert {
+    margin-top: 20px;
+  }
+}

--- a/app/helpers/geoblacklight_helper.rb
+++ b/app/helpers/geoblacklight_helper.rb
@@ -161,8 +161,11 @@ module GeoblacklightHelper
   # @return [String]
   def render_transformed_metadata(metadata)
     render partial: 'catalog/metadata/content', locals: { content: metadata.transform.html_safe }
-  rescue Geoblacklight::MetadataTransformer::ParseError => e
-    Geoblacklight.logger.warn e.message
+  rescue Geoblacklight::MetadataTransformer::TransformError => transform_err
+    Geoblacklight.logger.warn transform_err.message
+    render partial: 'catalog/metadata/markup', locals: { content: metadata.to_xml }
+  rescue => err
+    Geoblacklight.logger.warn err.message
     render partial: 'catalog/metadata/missing'
   end
 

--- a/app/views/catalog/_metadata.html.erb
+++ b/app/views/catalog/_metadata.html.erb
@@ -1,7 +1,6 @@
 <% document ||= @document %>
 
 <div class='metadata-view'>
-
   <div class="container-fluid">
     <ul class="nav nav-pills" role="tablist">
       <% document.references.shown_metadata.each do |metadata| %>

--- a/app/views/catalog/metadata/_markup.html.erb
+++ b/app/views/catalog/metadata/_markup.html.erb
@@ -1,0 +1,8 @@
+<div id="metadata-markup-container" class="container-fluid">
+  <div class="alert alert-warning" role="alert">
+    <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
+    <span class="sr-only">Error:</span>
+    <span>The metadata for this item cannot be transformed.</span>
+  </div>
+  <%= CodeRay.scan(content, :xml).div.html_safe %>
+</div>

--- a/geoblacklight.gemspec
+++ b/geoblacklight.gemspec
@@ -25,6 +25,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'font-awesome-rails'
   spec.add_dependency 'config'
   spec.add_dependency 'faraday'
+  spec.add_dependency 'faraday_middleware'
+  spec.add_dependency 'coderay'
   spec.add_dependency 'geoblacklight-icons', '>= 0.2'
   spec.add_dependency 'deprecation'
   spec.add_dependency 'geo_combine', '>= 0.3'

--- a/lib/generators/geoblacklight/templates/settings.yml
+++ b/lib/generators/geoblacklight/templates/settings.yml
@@ -38,6 +38,7 @@ INSTITUTION: 'Stanford'
 
 # Metadata shown in tool panel
 METADATA_SHOWN:
+  - 'mods'
   - 'fgdc'
   - 'iso19139'
 

--- a/lib/geoblacklight/engine.rb
+++ b/lib/geoblacklight/engine.rb
@@ -1,8 +1,10 @@
 require 'blacklight'
 require 'leaflet-rails'
 require 'font-awesome-rails'
+require 'coderay'
 require 'config'
 require 'faraday'
+require 'faraday_middleware'
 require 'nokogiri'
 require 'geoblacklight-icons'
 

--- a/lib/geoblacklight/metadata/base.rb
+++ b/lib/geoblacklight/metadata/base.rb
@@ -7,6 +7,7 @@ module Geoblacklight
       delegate :type, to: :reference
       delegate :to_html, to: :metadata
       delegate :transform, to: :transformer
+      delegate :to_xml, to: :document
 
       ##
       # Instantiates a Geoblacklight::Metadata object used for retrieving and
@@ -44,8 +45,11 @@ module Geoblacklight
       # @return [String, nil] metadata string or nil if there is a
       # connection error
       def retrieve_metadata
-        conn = Faraday.new(url: @reference.endpoint)
-        response = conn.get
+        connection = Faraday.new(url: @reference.endpoint) do |conn|
+          conn.use FaradayMiddleware::FollowRedirects
+          conn.adapter Faraday.default_adapter
+        end
+        response = connection.get
         return response.body unless response.nil? || response.status == 404
         Geoblacklight.logger.error "Could not reach #{@reference.endpoint}"
         ''

--- a/lib/geoblacklight/metadata_transformer/base.rb
+++ b/lib/geoblacklight/metadata_transformer/base.rb
@@ -18,7 +18,7 @@ module Geoblacklight
       # @return [String] the transformed metadata in the HTML
       def transform
         cleaned_metadata.to_html
-      rescue StandardError => e
+      rescue => e
         raise TransformError, e.message
       end
 
@@ -29,8 +29,13 @@ module Geoblacklight
       # @return [Nokogiri::XML::Document] the Nokogiri XML Document for the cleaned HTML
       def cleaned_metadata
         transformed_doc = Nokogiri::XML(@metadata.to_html)
-        transformed_elem = transformed_doc.xpath('//body').children
-        transformed_elem || Nokogiri::XML
+        if transformed_doc.xpath('//body').children.empty?
+          fail TransformError,\
+               'Failed to extract the <body> child elements from the transformed metadata'
+        end
+        transformed_doc.xpath('//body').children
+      rescue => e
+        raise TransformError, e.message
       end
 
       ##

--- a/spec/features/metadata_panel_spec.rb
+++ b/spec/features/metadata_panel_spec.rb
@@ -2,15 +2,26 @@ require 'spec_helper'
 
 feature 'Metadata tools' do
   feature 'when metadata references are available', js: :true do
-    scenario 'shows up in tools' do
+    scenario 'shows up as HTML' do
+      visit solr_document_path 'columbia-columbia-landinfo-global-aet'
+      expect(page).to have_css 'li.metadata a', text: 'Metadata'
+      click_link 'Metadata'
+      using_wait_time 15 do
+        within '.metadata-view' do
+          expect(page).to have_css '.pill-metadata', text: 'FGDC'
+          expect(page).to have_css 'dt', text: 'Identification Information'
+          expect(page).to have_css 'dt', text: 'Metadata Reference Information'
+        end
+      end
+    end
+    scenario 'shows up as XML' do
       visit solr_document_path 'stanford-cg357zz0321'
       expect(page).to have_css 'li.metadata a', text: 'Metadata'
       click_link 'Metadata'
       using_wait_time 15 do
         within '.metadata-view' do
-          expect(page).to have_css '.pill-metadata', text: 'ISO 19139'
-          expect(page).to have_css 'dt', text: 'Identification Information'
-          expect(page).to have_css 'dt', text: 'Metadata Reference Information'
+          expect(page).to have_css '.pill-metadata', text: 'MODS'
+          expect(page).to have_css '.CodeRay'
         end
       end
     end

--- a/spec/helpers/geoblacklight_helper_spec.rb
+++ b/spec/helpers/geoblacklight_helper_spec.rb
@@ -170,6 +170,18 @@ describe GeoblacklightHelper, type: :helper do
       end
     end
 
+    context 'with valid XML data without an HTML transform' do
+      before do
+        allow(metadata).to receive(:transform).and_raise(Geoblacklight::MetadataTransformer::TransformError)
+        allow(metadata).to receive(:to_xml).and_return('<data></data>')
+      end
+
+      it 'renders the partial with metadata content' do
+        expect(helper).to receive(:render).with(partial: 'catalog/metadata/markup', locals: { content: '<data></data>' })
+        helper.render_transformed_metadata(metadata)
+      end
+    end
+
     context 'without XML data' do
       before do
         allow(metadata).to receive(:transform).and_raise(Geoblacklight::MetadataTransformer::ParseError)

--- a/spec/lib/geoblacklight/metadata_transformer/base_spec.rb
+++ b/spec/lib/geoblacklight/metadata_transformer/base_spec.rb
@@ -6,4 +6,30 @@ describe Geoblacklight::MetadataTransformer::Base do
       expect { described_class.new(nil) }.to raise_error Geoblacklight::MetadataTransformer::EmptyMetadataError
     end
   end
+
+  context 'with metadata types without XSL Stylesheets' do
+    let(:metadata) { instance_double(GeoCombine::Metadata) }
+    subject { described_class.new(metadata) }
+    describe '#transform' do
+      before do
+        allow(metadata).to receive(:to_html).and_raise(NoMethodError, 'undefined method `to_html\'')
+      end
+      it 'raises a transform error' do
+        expect { subject.transform }.to raise_error Geoblacklight::MetadataTransformer::TransformError, /undefined method `to_html'/
+      end
+    end
+  end
+
+  context 'with metadata types with XSL Stylesheets but invalid HTML' do
+    let(:metadata) { instance_double(GeoCombine::Metadata) }
+    subject { described_class.new(metadata) }
+    describe '#transform' do
+      before do
+        allow(metadata).to receive(:to_html).and_return('<invalid-html></invalid-html>')
+      end
+      it 'raises a transform error' do
+        expect { subject.transform }.to raise_error Geoblacklight::MetadataTransformer::TransformError, 'Failed to extract the <body> child elements from the transformed metadata'
+      end
+    end
+  end
 end

--- a/spec/lib/geoblacklight/references_spec.rb
+++ b/spec/lib/geoblacklight/references_spec.rb
@@ -114,12 +114,12 @@ describe Geoblacklight::References do
   end
   describe 'shown_metadata_refs' do
     it 'is a set of metadata references exposed by the configuration' do
-      expect(complex_shapefile.shown_metadata_refs.count).to eq 1
+      expect(complex_shapefile.shown_metadata_refs.count).to eq 2
     end
   end
   describe 'shown_metadata' do
     it 'is a set of metadata resources exposed by the configuration' do
-      expect(complex_shapefile.shown_metadata.count).to eq 1
+      expect(complex_shapefile.shown_metadata.count).to eq 2
       expect(complex_shapefile.shown_metadata.first).to be_a Geoblacklight::Metadata::Base
     end
   end


### PR DESCRIPTION
Resolves #566 by addressing the following:
- Handling cases in which metadata can be rendered as 
XML (using CodeRay)
- Ensures that metadata retrieved using the HTTP can be offered by endpoints issuing redirect responses
- Reintroducing core support for the MODS as a metadata type

Please find the attached screenshot for the interface updates:
![geoblacklight_issues_566_screenshot](https://user-images.githubusercontent.com/1443986/29625675-68879f8c-87fa-11e7-9dcf-a45e2f8cd9a1.png)
