### PR TITLE
Make sure mime-types gem is required

### DIFF
--- a/geoblacklight.gemspec
+++ b/geoblacklight.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'geoblacklight-icons', '>= 0.2'
   spec.add_dependency 'deprecation'
   spec.add_dependency 'geo_combine', '>= 0.3'
+  spec.add_dependency 'mime-types'
 
   spec.add_development_dependency 'solr_wrapper'
   spec.add_development_dependency 'rails-controller-testing'

--- a/lib/geoblacklight/engine.rb
+++ b/lib/geoblacklight/engine.rb
@@ -7,6 +7,7 @@ require 'faraday'
 require 'faraday_middleware'
 require 'nokogiri'
 require 'geoblacklight-icons'
+require 'mime/types'
 
 module Geoblacklight
   class Engine < ::Rails::Engine


### PR DESCRIPTION
We use the third party mime-types gem in lib/geoblacklight/download.rb
but never explicitly include it or declare it as a dependency. It most
cases, it seems to still work probably because it gets included by
another gem somewhere. We shouldn't rely on this, though.