### PR TITLE
Fix common testsuite errors

### DIFF
--- a/geoblacklight.gemspec
+++ b/geoblacklight.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.required_rubygems_version = '>= 2.5.2'
 
   spec.add_dependency 'rails', '~> 5.0'
-  spec.add_dependency 'blacklight', '~> 6.10'
+  spec.add_dependency 'blacklight', '<= 6.11.0'
   spec.add_dependency 'leaflet-rails', '~> 0.7.3'
   spec.add_dependency 'font-awesome-rails'
   spec.add_dependency 'config'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,7 +14,7 @@ require 'selenium-webdriver'
 
 Capybara.register_driver(:headless_chrome) do |app|
   capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
-    chromeOptions: { args: %w(headless disable-gpu) }
+    chromeOptions: { args: %w(headless disable-gpu window-size=1280,1024) }
   )
 
   Capybara::Selenium::Driver.new(app,


### PR DESCRIPTION
Set a window-size for Capybara tests and lock our Blacklight dependency to 6.11.0, which is the last release of BL that doesn’t exhibit the modal asset re-fetching JS bug. #569