### PR TITLE
Adds index map functionality

### DIFF
--- a/app/assets/javascripts/geoblacklight/geoblacklight.js
+++ b/app/assets/javascripts/geoblacklight/geoblacklight.js
@@ -1,5 +1,6 @@
 //= require leaflet
 //= require native.history
+//= require_tree ./templates
 
 !function(global) {
   'use strict';

--- a/app/assets/javascripts/geoblacklight/modules/util.js
+++ b/app/assets/javascripts/geoblacklight/modules/util.js
@@ -5,5 +5,26 @@ GeoBlacklight.Util = {
   linkify: function(str) {
     var urlRegEx = /((([A-Za-z]{3,9}:(?:\/\/)?)(?:[\-;:&=\+\$,\w]+@)?[A-Za-z0-9\.\-]+|(?:www\.|[\-;:&=\+\$,\w]+@)[A-Za-z0-9\.\-]+)((?:\/[\+~%\/\.\w\-]*)?\??(?:[\-\+=&;%@\.\w]*)#?(?:[\.\!\/\\\w]*))?)/g;
     return str.toString().replace(urlRegEx, '<a href=\'$1\'>$1</a>');
+  },
+  /**
+   * Calls the index map template
+   * @param {Object} data - GeoJSON feature properties object
+   * @param {requestCallback} cb
+   */
+  indexMapTemplate: function(data, cb) {
+    var thumbDeferred = $.Deferred();
+    $.when(thumbDeferred).done(function() {
+      cb(HandlebarsTemplates["index_map_info"](data));
+    });
+    if (data.iiifUrl) {
+      var manifest = $.getJSON(data.iiifUrl, function(manifestResponse) {
+        if (manifestResponse.thumbnail['@id'] !== null) {
+          data.thumbnailUrl = manifestResponse.thumbnail['@id'];
+          thumbDeferred.resolve();
+        }
+      });
+    } else {
+      thumbDeferred.resolve();
+    }
   }
 };

--- a/app/assets/javascripts/geoblacklight/templates/index_map_info.hbs
+++ b/app/assets/javascripts/geoblacklight/templates/index_map_info.hbs
@@ -1,0 +1,38 @@
+<div class="index-map-info">
+  {{#if title}}
+    <h3>{{title}}</h3>
+  {{/if}}
+  <div class="">
+    {{#if thumbnailUrl}}
+      {{#if websiteUrl}}
+        <a href="{{websiteUrl}}">
+          <img src="{{thumbnailUrl}}" class="img-responsive">
+        </a>
+      {{else}}
+        <img src="{{thumbnailUrl}}">
+      {{/if}}
+    {{/if}}
+    <dl>
+      {{#if websiteUrl}}
+        <dt>Website</dt>
+        <dd><a href="{{websiteUrl}}">{{websiteUrl}}</a></dd>
+      {{/if}}
+      {{#if downloadUrl}}
+        <dt>Download</dt>
+        <dd><a href="{{downloadUrl}}">{{downloadUrl}}</a></dd>
+      {{/if}}
+      {{#if recordIdentifier}}
+        <dt>Record Identifier</dt>
+        <dd>{{recordIdentifier}}</dd>
+      {{/if}}
+      {{#if label}}
+        <dt>Label</dt>
+        <dd>{{label}}</dd>
+      {{/if}}
+      {{#if note}}
+        <dt>Note</dt>
+        <dd>{{note}}</dd>
+      {{/if}}
+    </dl>
+  </div>
+</div>

--- a/app/assets/javascripts/geoblacklight/viewers/index_map.js
+++ b/app/assets/javascripts/geoblacklight/viewers/index_map.js
@@ -20,27 +20,29 @@ GeoBlacklight.Viewer.IndexMap = GeoBlacklight.Viewer.Map.extend({
         {
           style: function(feature) {
             var style = {
-              weight: 1,
-              color: '#1eb300',
+              weight: 1
             }
-            var title = feature.properties.Title
-            if (title === null) {
-              style.color = '#b3001e'
+            // Style the colors based on availability
+            if (feature.properties.available) {
+              style.color = '#1eb300';
+            } else {
+              style.color = '#b3001e';
             }
             return style;
           },
           onEachFeature: function(feature, layer) {
-            layer.bindLabel(feature.properties.Sheet_Num, {
-              direction: 'auto', permanent: true
-            });
-            if (feature.properties.Title !== null) {
+            // Add a hover label for the label property
+            if (feature.properties.label !== null) {
+              layer.bindLabel(feature.properties.label, {
+                direction: 'auto', permanent: true
+              });
+            }
+            // If it is available add clickable info
+            if (feature.properties.available !== null) {
               layer.on('click', function(e) {
-                console.log(e)
-                var html = '';
-                $.each(feature.properties, function(key, val) {
-                  html += key + ': ' + val + '\n';
+                GeoBlacklight.Util.indexMapTemplate(feature.properties, function(html) {
+                  $('.viewer-information').html(html);
                 });
-                $('.viewer-information').html(html);
               });
             }
           }

--- a/app/assets/javascripts/geoblacklight/viewers/index_map.js
+++ b/app/assets/javascripts/geoblacklight/viewers/index_map.js
@@ -1,0 +1,51 @@
+//= require geoblacklight/viewers/map
+
+GeoBlacklight.Viewer.IndexMap = GeoBlacklight.Viewer.Map.extend({
+  load: function() {
+    this.map = L.map(this.element).fitBounds(this.options.bbox);
+    this.map.addLayer(this.selectBasemap());
+    
+    if (this.data.available) {
+      this.addPreviewLayer();
+    } else {
+      this.addBoundsOverlay(this.options.bbox);
+    }
+  },
+
+  addPreviewLayer: function() {
+    var _this = this;
+    var geoJSONLayer;
+    $.getJSON(this.data.url, function(data) {
+      geoJSONLayer = L.geoJson(data,
+        {
+          style: function(feature) {
+            var style = {
+              weight: 1,
+              color: '#1eb300',
+            }
+            var title = feature.properties.Title
+            if (title === null) {
+              style.color = '#b3001e'
+            }
+            return style;
+          },
+          onEachFeature: function(feature, layer) {
+            layer.bindLabel(feature.properties.Sheet_Num, {
+              direction: 'auto', permanent: true
+            });
+            if (feature.properties.Title !== null) {
+              layer.on('click', function(e) {
+                console.log(e)
+                var html = '';
+                $.each(feature.properties, function(key, val) {
+                  html += key + ': ' + val + '\n';
+                });
+                $('.viewer-information').html(html);
+              });
+            }
+          }
+        }).addTo(_this.map);
+        _this.map.fitBounds(geoJSONLayer.getBounds());
+    });
+  }
+});

--- a/app/views/catalog/_show_default.html.erb
+++ b/app/views/catalog/_show_default.html.erb
@@ -5,4 +5,5 @@
 <div class='row'>
   <%= render 'show_default_viewer_container' %>
   <%= render 'show_default_attribute_table' %>
+  <%= render 'show_default_viewer_information' %>
 </div>

--- a/app/views/catalog/_show_default_viewer_information.html.erb
+++ b/app/views/catalog/_show_default_viewer_information.html.erb
@@ -1,0 +1,2 @@
+<div class='viewer-information col-md-4'>
+</div>

--- a/geoblacklight.gemspec
+++ b/geoblacklight.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'deprecation'
   spec.add_dependency 'geo_combine', '>= 0.3'
   spec.add_dependency 'mime-types'
+  spec.add_dependency 'handlebars_assets'
 
   spec.add_development_dependency 'solr_wrapper'
   spec.add_development_dependency 'rails-controller-testing'

--- a/lib/generators/geoblacklight/templates/geoblacklight.js
+++ b/lib/generators/geoblacklight/templates/geoblacklight.js
@@ -1,3 +1,4 @@
+//= require handlebars.runtime
 //= require geoblacklight/geoblacklight
 //= require geoblacklight/basemaps
 //= require geoblacklight/controls

--- a/lib/generators/geoblacklight/templates/geoblacklight.js
+++ b/lib/generators/geoblacklight/templates/geoblacklight.js
@@ -7,3 +7,4 @@
 //= require leaflet-iiif
 //= require esri-leaflet
 //= require readmore.min
+//= require leaflet-label-src

--- a/lib/generators/geoblacklight/templates/geoblacklight.scss
+++ b/lib/generators/geoblacklight/templates/geoblacklight.scss
@@ -1,3 +1,4 @@
 /*
 *= require geoblacklight/application
+*= require leaflet-label
 */

--- a/lib/geoblacklight/constants.rb
+++ b/lib/geoblacklight/constants.rb
@@ -20,7 +20,8 @@ module Geoblacklight
       tiled_map_layer: 'urn:x-esri:serviceType:ArcGIS#TiledMapLayer',
       dynamic_map_layer: 'urn:x-esri:serviceType:ArcGIS#DynamicMapLayer',
       image_map_layer: 'urn:x-esri:serviceType:ArcGIS#ImageMapLayer',
-      data_dictionary: 'http://lccn.loc.gov/sh85035852'
+      data_dictionary: 'http://lccn.loc.gov/sh85035852',
+      index_map: 'https://openindexmaps.org'
     }.freeze
   end
 end

--- a/lib/geoblacklight/engine.rb
+++ b/lib/geoblacklight/engine.rb
@@ -8,6 +8,7 @@ require 'faraday_middleware'
 require 'nokogiri'
 require 'geoblacklight-icons'
 require 'mime/types'
+require 'handlebars_assets'
 
 module Geoblacklight
   class Engine < ::Rails::Engine

--- a/lib/geoblacklight/item_viewer.rb
+++ b/lib/geoblacklight/item_viewer.rb
@@ -38,8 +38,12 @@ module Geoblacklight
       @references.image_map_layer
     end
 
+    def index_map
+      @references.index_map
+    end
+
     def viewer_preference
-      [wms, iiif, tiled_map_layer, dynamic_map_layer,
+      [index_map, wms, iiif, tiled_map_layer, dynamic_map_layer,
        image_map_layer, feature_layer].compact.map(&:to_hash).first
     end
   end

--- a/spec/features/index_map_spec.rb
+++ b/spec/features/index_map_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+feature 'Index map' do
+  scenario 'displays index map viewer', js: true do
+    visit solr_document_path('stanford-fb897vt9938')
+    # Wait until SVG elements are added
+    expect(page).to have_css '.leaflet-overlay-pane svg'
+    page.first('svg g path').click
+    within '.index-map-info' do
+      expect(page).to have_css 'h3', text: 'Dabao Kinbōzu -- ダバオ近傍圖'
+      expect(page).to have_css 'a img[src="https://stacks.stanford.edu/image/iiif/zh828kt2136%2Fzh828kt2136_00_0001/full/!400,400/0/default.jpg"]'
+      within 'dl' do
+        expect(page).to have_css 'dt', text: 'Website'
+        expect(page).to have_css 'dd a', text: 'http://purl.stanford.edu/zh828kt2136'
+        expect(page).to have_css 'dt', text: 'Download'
+        expect(page).to have_css 'dd a', text: 'https://embed.stanford.edu/iframe?url=https://purl.stanford.edu/zh828kt2136&hide_title=true#'
+        expect(page).to have_css 'dt', text: 'Record Identifier'
+        expect(page).to have_css 'dd', text: '10532136'
+        expect(page).to have_css 'dt', text: 'Label'
+        expect(page).to have_css 'dd', text: 'SHEET 8'
+      end
+    end
+  end
+end

--- a/spec/features/split_view.html.erb_spec.rb
+++ b/spec/features/split_view.html.erb_spec.rb
@@ -9,7 +9,7 @@ feature 'Index view', js: true do
   scenario 'should have documents and map on page' do
     visit search_catalog_path(f: { Settings.FIELDS.PROVENANCE => ['Stanford'] })
     expect(page).to have_css('#documents')
-    expect(page).to have_css('.document', count: 3)
+    expect(page).to have_css('.document', count: 4)
     expect(page).to have_css('#map')
   end
 

--- a/spec/fixtures/solr_documents/index-map-stanford.json
+++ b/spec/fixtures/solr_documents/index-map-stanford.json
@@ -1,0 +1,40 @@
+{
+  "uuid": "http://purl.stanford.edu/fb897vt9938",
+  "dc_identifier_s": "http://purl.stanford.edu/fb897vt9938",
+  "dc_title_s": "Dabao Kinbōzu, Maps Index",
+  "dc_description_s": "This polygon GeoJSON file is an index to 1:50000 scale maps of Davao (Philippines), titled 'Dabao Kinbōzu -- ダバオ近傍圖/Dabao Kinbōzu.’ This map series was originally produced by the Japanese Land Survey Department of the General Staff Headquarters in 1944. Stanford University Libraries holds a large collection of Japanese military and imperial maps, referred to as gaihōzu, or \"maps of outer lands.\" These maps were produced starting in the early Meiji (1868-1912) era and the end of World War II by the Land Survey Department of the General Staff Headquarters, the former Japanese Army. The Library is in the process of scanning and making available all of the maps in the collection. To create this index, footprints were generated using the fishnet tool, and metadata were supplied for the digitized paper maps by Stanford University Libraries. After the footprints were created, the GeoJSON was trimmed and labeled according to the sources.This layer provides an index map that can be used to locate individual scanned map sheets.",
+  "dc_rights_s": "Public",
+  "dct_provenance_s": "Stanford",
+  "dct_references_s": "{\"http://schema.org/url\":\"http://purl.stanford.edu/fb897vt9938\",\"http://schema.org/downloadUrl\":\"https://gist.githubusercontent.com/mejackreed/4a44f1f7cc4fbb926068738e903a9e96/raw/fedfb0e599d647920f084627b7dca8f88a358757/stanford-fb897vt9938.geojson\",\"http://www.loc.gov/mods/v3\":\"http://purl.stanford.edu/fb897vt9938.mods\",\"http://www.isotc211.org/schemas/2005/gmd/\":\"http://opengeometadata.stanford.edu/metadata/edu.stanford.purl/druid:fb897vt9938/iso19139.xml\",\"http://www.w3.org/1999/xhtml\":\"http://opengeometadata.stanford.edu/metadata/edu.stanford.purl/druid:fb897vt9938/default.html\",\"https://openindexmaps.org\": \"https://gist.githubusercontent.com/mejackreed/4a44f1f7cc4fbb926068738e903a9e96/raw/fedfb0e599d647920f084627b7dca8f88a358757/stanford-fb897vt9938.geojson\"}",
+  "layer_id_s": "druid:fb897vt9938",
+  "layer_slug_s": "stanford-fb897vt9938",
+  "layer_geom_type_s": "Polygon",
+  "layer_modified_dt": "2016-10-20T21:07:24Z",
+  "dc_format_s": "GeoJSON",
+  "dc_language_s": "English",
+  "dc_type_s": "Dataset",
+  "dc_publisher_s": "Stanford Digital Repository",
+  "dc_creator_sm": [
+    "Stanford Geospatial Center"
+  ],
+  "dc_subject_sm": [
+    "Military maps",
+    "Topographic maps",
+    "Index maps",
+    "Grids (Cartography)",
+    "Boundaries",
+    "Military"
+  ],
+  "dct_issued_s": "2016",
+  "dct_temporal_sm": [
+    "1944"
+  ],
+  "dct_spatial_sm": [
+    "Davao (Philippines)"
+  ],
+  "georss_box_s": "6.6666 125 7.3333 126",
+  "georss_polygon_s": "6.6666 125 7.3333 125 7.3333 126 6.6666 126 6.6666 125",
+  "solr_geom": "ENVELOPE(125, 126, 7.3333, 6.6666)",
+  "solr_year_i": 1944,
+  "stanford_rights_metadata_s": "<?xml version=\"1.0\"?>\n<rightsMetadata>\n  <access type=\"discover\">\n    <machine>\n      <world/>\n    </machine>\n  </access>\n  <access type=\"read\">\n    <machine>\n      <world/>\n    </machine>\n  </access>\n  <use>\n    <human type=\"useAndReproduction\">This item is in the public domain.  There are no restrictions on use.</human>\n    <human type=\"creativeCommons\"/>\n    <machine type=\"creativeCommons\"/>\n  </use>\n  <copyright>\n    <human>This work is in the Public Domain, meaning that it is not subject to copyright.</human>\n  </copyright>\n</rightsMetadata>\n"
+}

--- a/spec/lib/geoblacklight/item_viewer_spec.rb
+++ b/spec/lib/geoblacklight/item_viewer_spec.rb
@@ -49,5 +49,15 @@ describe Geoblacklight::ItemViewer do
         expect(item_viewer.viewer_preference).to eq tiled_map_layer: 'http://www.example.com/MapServer'
       end
     end
+    context 'index map' do
+      let(:document_attributes) do
+        {
+          references_field => {
+            'https://openindexmaps.org' => 'http://www.example.com/index_map'
+          }.to_json
+        }
+      end
+      it { expect(item_viewer.viewer_preference).to eq index_map: 'http://www.example.com/index_map' }
+    end
   end
 end

--- a/vendor/assets/javascripts/leaflet-label-src.js
+++ b/vendor/assets/javascripts/leaflet-label-src.js
@@ -1,0 +1,564 @@
+/*
+	Leaflet.label, a plugin that adds labels to markers and vectors for Leaflet powered maps.
+	(c) 2012-2013, Jacob Toye, Smartrak
+
+	https://github.com/Leaflet/Leaflet.label
+	http://leafletjs.com
+	https://github.com/jacobtoye
+*/
+(function (factory, window) {
+
+	// define an AMD module that relies on 'leaflet'
+	if (typeof define === 'function' && define.amd) {
+		define(['leaflet'], factory);
+
+	// define a Common JS module that relies on 'leaflet'
+	} else if (typeof exports === 'object') {
+		module.exports = factory(require('leaflet'));
+	}
+
+	// attach your plugin to the global 'L' variable
+	if (typeof window !== 'undefined' && window.L) {
+		window.LeafletLabel = factory(L);
+	}
+}(function (L) {
+L.labelVersion = '0.2.4';
+
+
+var LeafletLabel = L.Class.extend({
+
+	includes: L.Mixin.Events,
+
+	options: {
+		className: '',
+		clickable: false,
+		direction: 'right',
+		noHide: false,
+		offset: [12, -15], // 6 (width of the label triangle) + 6 (padding)
+		opacity: 1,
+		zoomAnimation: true
+	},
+
+	initialize: function (options, source) {
+		L.setOptions(this, options);
+
+		this._source = source;
+		this._animated = L.Browser.any3d && this.options.zoomAnimation;
+		this._isOpen = false;
+	},
+
+	onAdd: function (map) {
+		this._map = map;
+
+		this._pane = this.options.pane ? map._panes[this.options.pane] :
+			this._source instanceof L.Marker ? map._panes.markerPane : map._panes.popupPane;
+
+		if (!this._container) {
+			this._initLayout();
+		}
+
+		this._pane.appendChild(this._container);
+
+		this._initInteraction();
+
+		this._update();
+
+		this.setOpacity(this.options.opacity);
+
+		map
+			.on('moveend', this._onMoveEnd, this)
+			.on('viewreset', this._onViewReset, this);
+
+		if (this._animated) {
+			map.on('zoomanim', this._zoomAnimation, this);
+		}
+
+		if (L.Browser.touch && !this.options.noHide) {
+			L.DomEvent.on(this._container, 'click', this.close, this);
+			map.on('click', this.close, this);
+		}
+	},
+
+	onRemove: function (map) {
+		this._pane.removeChild(this._container);
+
+		map.off({
+			zoomanim: this._zoomAnimation,
+			moveend: this._onMoveEnd,
+			viewreset: this._onViewReset
+		}, this);
+
+		this._removeInteraction();
+
+		this._map = null;
+	},
+
+	setLatLng: function (latlng) {
+		this._latlng = L.latLng(latlng);
+		if (this._map) {
+			this._updatePosition();
+		}
+		return this;
+	},
+
+	setContent: function (content) {
+		// Backup previous content and store new content
+		this._previousContent = this._content;
+		this._content = content;
+
+		this._updateContent();
+
+		return this;
+	},
+
+	close: function () {
+		var map = this._map;
+
+		if (map) {
+			if (L.Browser.touch && !this.options.noHide) {
+				L.DomEvent.off(this._container, 'click', this.close);
+				map.off('click', this.close, this);
+			}
+
+			map.removeLayer(this);
+		}
+	},
+
+	updateZIndex: function (zIndex) {
+		this._zIndex = zIndex;
+
+		if (this._container && this._zIndex) {
+			this._container.style.zIndex = zIndex;
+		}
+	},
+
+	setOpacity: function (opacity) {
+		this.options.opacity = opacity;
+
+		if (this._container) {
+			L.DomUtil.setOpacity(this._container, opacity);
+		}
+	},
+
+	_initLayout: function () {
+		this._container = L.DomUtil.create('div', 'leaflet-label ' + this.options.className + ' leaflet-zoom-animated');
+		this.updateZIndex(this._zIndex);
+	},
+
+	_update: function () {
+		if (!this._map) { return; }
+
+		this._container.style.visibility = 'hidden';
+
+		this._updateContent();
+		this._updatePosition();
+
+		this._container.style.visibility = '';
+	},
+
+	_updateContent: function () {
+		if (!this._content || !this._map || this._prevContent === this._content) {
+			return;
+		}
+
+		if (typeof this._content === 'string') {
+			this._container.innerHTML = this._content;
+
+			this._prevContent = this._content;
+
+			this._labelWidth = this._container.offsetWidth;
+		}
+	},
+
+	_updatePosition: function () {
+		var pos = this._map.latLngToLayerPoint(this._latlng);
+
+		this._setPosition(pos);
+	},
+
+	_setPosition: function (pos) {
+		var map = this._map,
+			container = this._container,
+			centerPoint = map.latLngToContainerPoint(map.getCenter()),
+			labelPoint = map.layerPointToContainerPoint(pos),
+			direction = this.options.direction,
+			labelWidth = this._labelWidth,
+			offset = L.point(this.options.offset);
+
+		// position to the right (right or auto & needs to)
+		if (direction === 'right' || direction === 'auto' && labelPoint.x < centerPoint.x) {
+			L.DomUtil.addClass(container, 'leaflet-label-right');
+			L.DomUtil.removeClass(container, 'leaflet-label-left');
+
+			pos = pos.add(offset);
+		} else { // position to the left
+			L.DomUtil.addClass(container, 'leaflet-label-left');
+			L.DomUtil.removeClass(container, 'leaflet-label-right');
+
+			pos = pos.add(L.point(-offset.x - labelWidth, offset.y));
+		}
+
+		L.DomUtil.setPosition(container, pos);
+	},
+
+	_zoomAnimation: function (opt) {
+		var pos = this._map._latLngToNewLayerPoint(this._latlng, opt.zoom, opt.center).round();
+
+		this._setPosition(pos);
+	},
+
+	_onMoveEnd: function () {
+		if (!this._animated || this.options.direction === 'auto') {
+			this._updatePosition();
+		}
+	},
+
+	_onViewReset: function (e) {
+		/* if map resets hard, we must update the label */
+		if (e && e.hard) {
+			this._update();
+		}
+	},
+
+	_initInteraction: function () {
+		if (!this.options.clickable) { return; }
+
+		var container = this._container,
+			events = ['dblclick', 'mousedown', 'mouseover', 'mouseout', 'contextmenu'];
+
+		L.DomUtil.addClass(container, 'leaflet-clickable');
+		L.DomEvent.on(container, 'click', this._onMouseClick, this);
+
+		for (var i = 0; i < events.length; i++) {
+			L.DomEvent.on(container, events[i], this._fireMouseEvent, this);
+		}
+	},
+
+	_removeInteraction: function () {
+		if (!this.options.clickable) { return; }
+
+		var container = this._container,
+			events = ['dblclick', 'mousedown', 'mouseover', 'mouseout', 'contextmenu'];
+
+		L.DomUtil.removeClass(container, 'leaflet-clickable');
+		L.DomEvent.off(container, 'click', this._onMouseClick, this);
+
+		for (var i = 0; i < events.length; i++) {
+			L.DomEvent.off(container, events[i], this._fireMouseEvent, this);
+		}
+	},
+
+	_onMouseClick: function (e) {
+		if (this.hasEventListeners(e.type)) {
+			L.DomEvent.stopPropagation(e);
+		}
+
+		this.fire(e.type, {
+			originalEvent: e
+		});
+	},
+
+	_fireMouseEvent: function (e) {
+		this.fire(e.type, {
+			originalEvent: e
+		});
+
+		// TODO proper custom event propagation
+		// this line will always be called if marker is in a FeatureGroup
+		if (e.type === 'contextmenu' && this.hasEventListeners(e.type)) {
+			L.DomEvent.preventDefault(e);
+		}
+		if (e.type !== 'mousedown') {
+			L.DomEvent.stopPropagation(e);
+		} else {
+			L.DomEvent.preventDefault(e);
+		}
+	}
+});
+
+
+/*global LeafletLabel */
+
+// This object is a mixin for L.Marker and L.CircleMarker. We declare it here as both need to include the contents.
+L.BaseMarkerMethods = {
+	showLabel: function () {
+		if (this.label && this._map) {
+			this.label.setLatLng(this._latlng);
+			this._map.showLabel(this.label);
+		}
+
+		return this;
+	},
+
+	hideLabel: function () {
+		if (this.label) {
+			this.label.close();
+		}
+		return this;
+	},
+
+	setLabelNoHide: function (noHide) {
+		if (this._labelNoHide === noHide) {
+			return;
+		}
+
+		this._labelNoHide = noHide;
+
+		if (noHide) {
+			this._removeLabelRevealHandlers();
+			this.showLabel();
+		} else {
+			this._addLabelRevealHandlers();
+			this.hideLabel();
+		}
+	},
+
+	bindLabel: function (content, options) {
+		var labelAnchor = this.options.icon ? this.options.icon.options.labelAnchor : this.options.labelAnchor,
+			anchor = L.point(labelAnchor) || L.point(0, 0);
+
+		anchor = anchor.add(LeafletLabel.prototype.options.offset);
+
+		if (options && options.offset) {
+			anchor = anchor.add(options.offset);
+		}
+
+		options = L.Util.extend({offset: anchor}, options);
+
+		this._labelNoHide = options.noHide;
+
+		if (!this.label) {
+			if (!this._labelNoHide) {
+				this._addLabelRevealHandlers();
+			}
+
+			this
+				.on('remove', this.hideLabel, this)
+				.on('move', this._moveLabel, this)
+				.on('add', this._onMarkerAdd, this);
+
+			this._hasLabelHandlers = true;
+		}
+
+		this.label = new LeafletLabel(options, this)
+			.setContent(content);
+
+		return this;
+	},
+
+	unbindLabel: function () {
+		if (this.label) {
+			this.hideLabel();
+
+			this.label = null;
+
+			if (this._hasLabelHandlers) {
+				if (!this._labelNoHide) {
+					this._removeLabelRevealHandlers();
+				}
+
+				this
+					.off('remove', this.hideLabel, this)
+					.off('move', this._moveLabel, this)
+					.off('add', this._onMarkerAdd, this);
+			}
+
+			this._hasLabelHandlers = false;
+		}
+		return this;
+	},
+
+	updateLabelContent: function (content) {
+		if (this.label) {
+			this.label.setContent(content);
+		}
+	},
+
+	getLabel: function () {
+		return this.label;
+	},
+
+	_onMarkerAdd: function () {
+		if (this._labelNoHide) {
+			this.showLabel();
+		}
+	},
+
+	_addLabelRevealHandlers: function () {
+		this
+			.on('mouseover', this.showLabel, this)
+			.on('mouseout', this.hideLabel, this);
+
+		if (L.Browser.touch) {
+			this.on('click', this.showLabel, this);
+		}
+	},
+
+	_removeLabelRevealHandlers: function () {
+		this
+			.off('mouseover', this.showLabel, this)
+			.off('mouseout', this.hideLabel, this);
+
+		if (L.Browser.touch) {
+			this.off('click', this.showLabel, this);
+		}
+	},
+
+	_moveLabel: function (e) {
+		this.label.setLatLng(e.latlng);
+	}
+};
+
+
+// Add in an option to icon that is used to set where the label anchor is
+L.Icon.Default.mergeOptions({
+	labelAnchor: new L.Point(9, -20)
+});
+
+// Have to do this since Leaflet is loaded before this plugin and initializes
+// L.Marker.options.icon therefore missing our mixin above.
+L.Marker.mergeOptions({
+	icon: new L.Icon.Default()
+});
+
+L.Marker.include(L.BaseMarkerMethods);
+L.Marker.include({
+	_originalUpdateZIndex: L.Marker.prototype._updateZIndex,
+
+	_updateZIndex: function (offset) {
+		var zIndex = this._zIndex + offset;
+
+		this._originalUpdateZIndex(offset);
+
+		if (this.label) {
+			this.label.updateZIndex(zIndex);
+		}
+	},
+
+	_originalSetOpacity: L.Marker.prototype.setOpacity,
+
+	setOpacity: function (opacity, labelHasSemiTransparency) {
+		this.options.labelHasSemiTransparency = labelHasSemiTransparency;
+
+		this._originalSetOpacity(opacity);
+	},
+
+	_originalUpdateOpacity: L.Marker.prototype._updateOpacity,
+
+	_updateOpacity: function () {
+		var absoluteOpacity = this.options.opacity === 0 ? 0 : 1;
+
+		this._originalUpdateOpacity();
+
+		if (this.label) {
+			this.label.setOpacity(this.options.labelHasSemiTransparency ? this.options.opacity : absoluteOpacity);
+		}
+	},
+
+	_originalSetLatLng: L.Marker.prototype.setLatLng,
+
+	setLatLng: function (latlng) {
+		if (this.label && !this._labelNoHide) {
+			this.hideLabel();
+		}
+
+		return this._originalSetLatLng(latlng);
+	}
+});
+
+// Add in an option to icon that is used to set where the label anchor is
+L.CircleMarker.mergeOptions({
+	labelAnchor: new L.Point(0, 0)
+});
+
+
+L.CircleMarker.include(L.BaseMarkerMethods);
+
+/*global LeafletLabel */
+
+L.Path.include({
+	bindLabel: function (content, options) {
+		if (!this.label || this.label.options !== options) {
+			this.label = new LeafletLabel(options, this);
+		}
+
+		this.label.setContent(content);
+
+		if (!this._showLabelAdded) {
+			this
+				.on('mouseover', this._showLabel, this)
+				.on('mousemove', this._moveLabel, this)
+				.on('mouseout remove', this._hideLabel, this);
+
+			if (L.Browser.touch) {
+				this.on('click', this._showLabel, this);
+			}
+			this._showLabelAdded = true;
+		}
+
+		return this;
+	},
+
+	unbindLabel: function () {
+		if (this.label) {
+			this._hideLabel();
+			this.label = null;
+			this._showLabelAdded = false;
+			this
+				.off('mouseover', this._showLabel, this)
+				.off('mousemove', this._moveLabel, this)
+				.off('mouseout remove', this._hideLabel, this);
+		}
+		return this;
+	},
+
+	updateLabelContent: function (content) {
+		if (this.label) {
+			this.label.setContent(content);
+		}
+	},
+
+	_showLabel: function (e) {
+		this.label.setLatLng(e.latlng);
+		this._map.showLabel(this.label);
+	},
+
+	_moveLabel: function (e) {
+		this.label.setLatLng(e.latlng);
+	},
+
+	_hideLabel: function () {
+		this.label.close();
+	}
+});
+
+
+L.Map.include({
+	showLabel: function (label) {
+		return this.addLayer(label);
+	}
+});
+
+L.FeatureGroup.include({
+	// TODO: remove this when AOP is supported in Leaflet, need this as we cannot put code in removeLayer()
+	clearLayers: function () {
+		this.unbindLabel();
+		this.eachLayer(this.removeLayer, this);
+		return this;
+	},
+
+	bindLabel: function (content, options) {
+		return this.invoke('bindLabel', content, options);
+	},
+
+	unbindLabel: function () {
+		return this.invoke('unbindLabel');
+	},
+
+	updateLabelContent: function (content) {
+		this.invoke('updateLabelContent', content);
+	}
+});
+
+	return LeafletLabel;
+}, window));

--- a/vendor/assets/stylesheets/leaflet-label.css
+++ b/vendor/assets/stylesheets/leaflet-label.css
@@ -1,0 +1,54 @@
+.leaflet-label {
+	background: rgb(235, 235, 235);
+	background: rgba(235, 235, 235, 0.81);
+	background-clip: padding-box;
+	border-color: #777;
+	border-color: rgba(0,0,0,0.25);
+	border-radius: 4px;
+	border-style: solid;
+	border-width: 4px;
+	color: #111;
+	display: block;
+	font: 12px/20px "Helvetica Neue", Arial, Helvetica, sans-serif;
+	font-weight: bold;
+	padding: 1px 6px;
+	position: absolute;
+	-webkit-user-select: none;
+	   -moz-user-select: none;
+	    -ms-user-select: none;
+	        user-select: none;
+	pointer-events: none;
+	white-space: nowrap;
+	z-index: 6;
+}
+
+.leaflet-label.leaflet-clickable {
+	cursor: pointer;
+	pointer-events: auto;
+}
+
+.leaflet-label:before,
+.leaflet-label:after {
+	border-top: 6px solid transparent;
+	border-bottom: 6px solid transparent;
+	content: none;
+	position: absolute;
+	top: 5px;
+}
+
+.leaflet-label:before {
+	border-right: 6px solid black;
+	border-right-color: inherit;
+	left: -10px;
+}
+
+.leaflet-label:after {
+	border-left: 6px solid black;
+	border-left-color: inherit;
+	right: -10px;
+}
+
+.leaflet-label-right:before,
+.leaflet-label-left:after {
+	content: "";
+}


### PR DESCRIPTION
Closes #406 
Closes #459 

This pull request adds a custom javascript viewer for index maps referenced in a layer's `dct_references_s` field. The index map viewed is displayed using expected fields from https://github.com/OpenIndexMaps/openindexmaps.github.io/blob/master/index.md and must be an accessible GeoJSON file with `Polygon` features.

![imupdate](https://user-images.githubusercontent.com/1656824/35015094-301758a6-fad0-11e7-9795-2fc138a89716.gif)

_Note:_ This pull request adds two dependencies:
 - Leaflet-label (removable when we upgrade to Leaflet >= v1.0 See https://github.com/geoblacklight/geoblacklight/pull/553)
 - Handlebars & handlebars assets - allows us to write clientside templates. Could be used to enhance feature inspection, metadata view, or attribute definitions

_Note:_ I did have a concern about the handlebars_assets templates precompiling in production. In my test GeoBlacklight app, I precompiled assets and ran in `RAILS_ENV=production` and things seem to work just fine.