### PR TITLE
restricts how the metadata modal gets styled so that global modals ar…

### DIFF
--- a/app/assets/javascripts/geoblacklight/modules/metadata.js
+++ b/app/assets/javascripts/geoblacklight/modules/metadata.js
@@ -1,7 +1,15 @@
 Blacklight.onLoad(function() {
-  $('#ajax-modal').on('loaded.blacklight.ajax-modal', function() {
+  $('#ajax-modal').on('loaded.blacklight.ajax-modal', function(e) {
+    $(e.target).find('.metadata-body').each(function(_i, el) {
+      $(el).parent().parent().addClass('metadata-modal');
+    });
     $(this).find('.pill-metadata').each(function(i, element) {
       GeoBlacklight.metadataDownloadButton(element);
+    });
+  });
+  $('#ajax-modal').on('hidden.bs.modal', function(e) {
+    $(e.target).find('.metadata-body').each(function(_i, el) {
+      $(el).parent().parent().removeClass('metadata-modal');
     });
   });
 });

--- a/app/assets/stylesheets/geoblacklight/modules/metadata.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/metadata.scss
@@ -1,18 +1,11 @@
 /**
  * Rules for the geospatial metadata Bootstrap Modal dialog
  */
-.modal-dialog {
-  width: 1148px;
+.modal-dialog.metadata-modal {
+  width: 90%;
 }
 
-.modal-header {
-  .modal-title {
-    font-weight: 400;
-    font-size: 20px;
-  }
-}
-
-.modal-body {
+.metadata-body.modal-body {
   overflow-y: scroll;
   height: calc(100vh - 190px);
 

--- a/app/views/catalog/metadata.html.erb
+++ b/app/views/catalog/metadata.html.erb
@@ -2,7 +2,7 @@
   <button type="button" class="ajax-modal-close close" data-dismiss="modal" aria-hidden="true">×</button>
   <h3 class="modal-title">View Metadata</h3>
 </div>
-<div class="modal-body">
+<div class="modal-body metadata-body">
   <%= render partial: 'metadata' %>
 </div>
 <div class="modal-footer">


### PR DESCRIPTION
…e not changed

Closes #580 

![modal](https://user-images.githubusercontent.com/1656824/35354597-b178f994-0107-11e8-827f-3acaf610fc10.gif)

I realize the javascript is a bit hacky, open to suggestions.