### PR TITLE
Ensures that the ordering of metadata formats in the config. is preserved in the ordering of metadata References for a Document

### DIFF
--- a/lib/geoblacklight/references.rb
+++ b/lib/geoblacklight/references.rb
@@ -12,7 +12,10 @@ module Geoblacklight
     # Return only those metadata references which are exposed within the configuration
     # @return [Geoblacklight::Reference]
     def shown_metadata_refs
-      @refs.select { |ref| Settings.METADATA_SHOWN.include?(ref.type.to_s) }
+      metadata = @refs.select { |ref| Settings.METADATA_SHOWN.include?(ref.type.to_s) }
+      metadata.sort do |u, v|
+        Settings.METADATA_SHOWN.index(u.type.to_s) <=> Settings.METADATA_SHOWN.index(v.type.to_s)
+      end
     end
 
     ##

--- a/spec/features/download_layer_spec.rb
+++ b/spec/features/download_layer_spec.rb
@@ -86,7 +86,7 @@ feature 'Download layer' do
       fill_in('Email', with: 'foo@example.com')
       click_button('Request')
     end
-    using_wait_time 95 do
+    using_wait_time 120 do
       expect(page).to have_css('.alert-success')
       expect(page).to have_content('You should receive an email when your download is ready')
     end

--- a/spec/features/split_view.html.erb_spec.rb
+++ b/spec/features/split_view.html.erb_spec.rb
@@ -25,10 +25,12 @@ feature 'Index view', js: true do
       expect(page).to have_css('div.panel.facet_limit', text: 'Format')
     end
     click_link 'Institution'
-    expect(page).to have_css('a.facet_select', text: 'Columbia', visible: true)
-    expect(page).to have_css('a.facet_select', text: 'MIT', visible: true)
-    expect(page).to have_css('a.facet_select', text: 'Stanford', visible: true)
-    expect(page).to have_css('a.more_facets_link', text: 'more Institution »', visible: true)
+    using_wait_time 120 do
+      expect(page).to have_css('a.facet_select', text: 'Columbia', visible: true)
+      expect(page).to have_css('a.facet_select', text: 'MIT', visible: true)
+      expect(page).to have_css('a.facet_select', text: 'Stanford', visible: true)
+      expect(page).to have_css('a.more_facets_link', text: /more\sInstitution\s»/, visible: true)
+    end
   end
 
   scenario 'hover on record should produce bounding box on map' do

--- a/spec/lib/geoblacklight/references_spec.rb
+++ b/spec/lib/geoblacklight/references_spec.rb
@@ -115,6 +115,19 @@ describe Geoblacklight::References do
   describe 'shown_metadata_refs' do
     it 'is a set of metadata references exposed by the configuration' do
       expect(complex_shapefile.shown_metadata_refs.count).to eq 2
+      expect(complex_shapefile.shown_metadata_refs.first.type.to_s).to eq 'mods'
+      expect(complex_shapefile.shown_metadata_refs.last.type.to_s).to eq 'iso19139'
+    end
+    context 'with an overridden order for the formats' do
+      let(:settings_klass) { class_double('Settings').as_stubbed_const }
+      before do
+        allow(settings_klass).to receive(:METADATA_SHOWN).and_return %w(iso19139 mods)
+        allow(settings_klass).to receive(:FIELDS).and_return OpenStruct.new(FILE_FORMAT: 'dc_format_s')
+      end
+      it 'is ordered by the configuration' do
+        expect(complex_shapefile.shown_metadata_refs.first.type.to_s).to eq 'iso19139'
+        expect(complex_shapefile.shown_metadata_refs.last.type.to_s).to eq 'mods'
+      end
     end
   end
   describe 'shown_metadata' do


### PR DESCRIPTION
Resolves #592 