### PR TITLE
Peg thor version >= 19.0 to fix issue with test app generation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,9 @@ group :development, :test do
   gem 'coveralls', require: false
   gem 'rubocop', '0.38.0', require: false
   gem 'rubocop-rspec', '1.4.0', require: false
+
+  # See https://github.com/rails/rails/issues/32955
+  gem 'thor', '>= 0.19.0'
 end
 
 # BEGIN ENGINE_CART BLOCK


### PR DESCRIPTION
- Prevents installation of thor 18.0, fixing a known issue with the rails app generator.
- Backwards compatible to Rails 3.2 if necessary.

Closes #625 