### PR TITLE
Gracefully handle nil geoblacklight icon values

### DIFF
--- a/app/helpers/geoblacklight_helper.rb
+++ b/app/helpers/geoblacklight_helper.rb
@@ -37,9 +37,10 @@ module GeoblacklightHelper
   end
 
   def geoblacklight_icon(name)
+    icon_name = name ? name.parameterize : 'none'
     content_tag :span,
                 '',
-                class: "geoblacklight-icon geoblacklight-#{name.parameterize}",
+                class: "geoblacklight-icon geoblacklight-#{icon_name}",
                 title: name
   end
 

--- a/spec/helpers/geoblacklight_helper_spec.rb
+++ b/spec/helpers/geoblacklight_helper_spec.rb
@@ -31,6 +31,10 @@ describe GeoblacklightHelper, type: :helper do
         expect(html).to have_css ".geoblacklight-#{value}"
       end
     end
+    it 'handles nil values' do
+      html = Capybara.string(geoblacklight_icon(nil))
+      expect(html).to have_css '.geoblacklight-none'
+    end
   end
 
   describe '#proper_case_format' do


### PR DESCRIPTION
- ~~Makes `layer_geom_type_s` a required field in the GeoBlacklight schema.~~
- ~~Bumps the schema up a minor version to 1.1.~~
- Gracefully handles cases where `layer_geom_type_s` is missing in the document.

Closes #516