### PR TITLE
Add HTML metadata display

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -94,12 +94,3 @@ Style/StringLiterals:
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#consistent-string-literals
   Enabled: true
   EnforcedStyle: single_quotes
-
-Style/DotPosition:
-  Description: Checks the position of the dot in multi-line method calls.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#consistent-multi-line-chains
-  Enabled: true
-  EnforcedStyle: leading
-  SupportedStyles:
-  - leading
-  - trailing

--- a/app/assets/stylesheets/geoblacklight/modules/metadata_content.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/metadata_content.scss
@@ -3,7 +3,7 @@
  *
  */
 #metadata-container {
-  height: 1024px;
+  height: calc(100vh - 260px);
 
   ul {
     margin-top: 0;
@@ -34,5 +34,10 @@
   */
   div > dl > dt {
     font-size: 22px;
+  }
+
+  iframe {
+    height: 100%;
+    width: 100%;
   }
 }

--- a/config/locales/geoblacklight.en.yml
+++ b/config/locales/geoblacklight.en.yml
@@ -37,6 +37,7 @@ en:
       iso19139: 'ISO 19139'
       mods: 'MODS'
       fgdc: 'FGDC'
+      html: 'HTML'
       feature_layer: 'ArcGIS Feature Layer'
       tiled_map_layer: 'ArcGIS Tiled Map Layer'
       dynamic_map_layer: 'ArcGIS Dynamic Map Layer'

--- a/lib/generators/geoblacklight/templates/settings.yml
+++ b/lib/generators/geoblacklight/templates/settings.yml
@@ -41,6 +41,7 @@ METADATA_SHOWN:
   - 'mods'
   - 'fgdc'
   - 'iso19139'
+  - 'html'
 
 # (For external Download) timeout and open_timeout parameters for Faraday
 TIMEOUT_DOWNLOAD: 16

--- a/lib/geoblacklight.rb
+++ b/lib/geoblacklight.rb
@@ -21,6 +21,7 @@ module Geoblacklight
   require 'geoblacklight/metadata'
   require 'geoblacklight/metadata/base'
   require 'geoblacklight/metadata/fgdc'
+  require 'geoblacklight/metadata/html'
   require 'geoblacklight/metadata/iso19139'
   require 'geoblacklight/metadata_transformer'
   require 'geoblacklight/metadata_transformer/base'

--- a/lib/geoblacklight/metadata/html.rb
+++ b/lib/geoblacklight/metadata/html.rb
@@ -1,0 +1,13 @@
+module Geoblacklight
+  module Metadata
+    class Html < Base
+      def transform
+        ActionController::Base.helpers.content_tag(:iframe,
+                                                   '',
+                                                   src: @reference.endpoint,
+                                                   scrolling: 'yes',
+                                                   frameborder: 0)
+      end
+    end
+  end
+end

--- a/spec/fixtures/solr_documents/cornell_html_metadata.json
+++ b/spec/fixtures/solr_documents/cornell_html_metadata.json
@@ -1,0 +1,42 @@
+{
+  "geoblacklight_version": "1.0",
+  "dc_identifier_s": "https://cugir.library.cornell.edu/catalog/cugir-007741",
+  "dc_title_s": "Air Monitoring Stations, Adirondack Park, 2000",
+  "dc_description_s": "  This dataset shows the location of each ambient air quality monitoring station currently being operated by the Bureau of Air Quality Surveillance (BAQS), Division of Air Resources, New York State Department of Environmental Conservation.",
+  "dc_rights_s": "Public",
+  "dct_provenance_s": "Cornell",
+  "dct_references_s": "{\"http://schema.org/downloadUrl\":\"https://s3.amazonaws.com/cugir-data/00/77/41/cugir-007741.zip\",\"http://www.opengis.net/cat/csw/csdgm\":\"https://s3.amazonaws.com/cugir-data/00/77/41/fgdc.xml\",\"http://www.w3.org/1999/xhtml\":\"https://s3.amazonaws.com/cugir-data/00/77/41/fgdc.html\",\"http://www.opengis.net/def/serviceType/ogc/wfs\":\"https://cugir.library.cornell.edu/geoserver/cugir/wfs\",\"http://www.opengis.net/def/serviceType/ogc/wms\":\"https://cugir.library.cornell.edu/geoserver/cugir/wms\"}",
+  "cugir_addl_downloads_s": "{}",
+  "layer_id_s": "cugir007741",
+  "layer_slug_s": "cugir-007741",
+  "dc_type_s": "Dataset",
+  "dc_format_s": "Shapefile",
+  "cugir_filesize_s": "0.07 MB",
+  "layer_geom_type_s": "Point",
+  "layer_modified_dt": "2017-10-05T00:00:00Z",
+  "dc_creator_sm": [
+    "New York State Department of Energy Conservation Bureau of Air Quality Surveillance"
+  ],
+  "dc_publisher_sm": [
+    "Geographic Data Presentation Form: Map"
+  ],
+  "dc_subject_sm": [
+    "environment",
+    "Air quality monitoring stations",
+    "Air quality management",
+    "Air--Pollution--Measurement",
+    "New York State--Dept Energy Conservation"
+  ],
+  "cugir_category_sm": [
+    "environment",
+    "climate"
+  ],
+  "dct_spatial_sm": [
+    "New York"
+  ],
+  "dct_issued_s": "2000-06-00",
+  "dct_temporal_sm": [
+    "-Pres"
+  ],
+  "solr_geom": "ENVELOPE(-74.989258, -73.858335, 44.67778, 43.452994)"
+}

--- a/spec/lib/geoblacklight/metadata/html_spec.rb
+++ b/spec/lib/geoblacklight/metadata/html_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe Geoblacklight::Metadata::Html do
+  let(:url) { 'https://s3.amazonaws.com/cugir-data/00/77/41/fgdc.html' }
+  let(:metadata) do
+    described_class.new(
+      Geoblacklight::Reference.new(
+        ['http://www.w3.org/1999/xhtml', url]
+      )
+    )
+  end
+
+  describe '#transform' do
+    it 'renders an iframe with the html endpoint' do
+      expect(metadata.transform).to include('iframe', url)
+    end
+  end
+end

--- a/spec/lib/geoblacklight/metadata_spec.rb
+++ b/spec/lib/geoblacklight/metadata_spec.rb
@@ -21,6 +21,15 @@ describe Geoblacklight::Metadata do
       end
     end
 
+    context 'with an html metadata reference' do
+      before do
+        allow(reference).to receive(:type).and_return('html')
+      end
+      it 'constructs an Geoblacklight::Metadata::Html instance' do
+        expect(described_class.instance(reference)).to be_a Geoblacklight::Metadata::Html
+      end
+    end
+
     context 'with another metadata reference' do
       before do
         allow(reference).to receive(:type).and_return('unsupported')


### PR DESCRIPTION
Displays HTML metadata endpoints in an iframe in the metadata modal.
Closes #624 

![screenshot 2018-07-25 12 50 41](https://user-images.githubusercontent.com/784196/43218219-619fbd18-9009-11e8-8872-9fd81c71f70c.png)
