### PR TITLE
Add support for overriding styles inherited from Blacklight proper

### DIFF
--- a/app/assets/stylesheets/geoblacklight/_blacklight_overrides.scss
+++ b/app/assets/stylesheets/geoblacklight/_blacklight_overrides.scss
@@ -1,0 +1,19 @@
+/**
+  Stylesheet for overriding styles inherited from Blacklight proper
+**/
+
+// Begin - Addresses GBL issue #634
+// Emulates font-size for SVG icons and aligns to baseline
+.blacklight-icons {
+  display: inline-flex;
+  height: $font-size-base;
+  width: $font-size-base;
+}
+
+.blacklight-icons svg {
+  height: 1rem;
+  width: 1rem;
+  top: .125rem;
+  position: relative;
+}
+// End - Addresses GBL issue #634

--- a/app/assets/stylesheets/geoblacklight/_geoblacklight.scss
+++ b/app/assets/stylesheets/geoblacklight/_geoblacklight.scss
@@ -29,3 +29,4 @@
 @import 'modules/search_widgets';
 @import 'modules/toolbar';
 @import 'modules/web_services';
+@import 'blacklight_overrides';


### PR DESCRIPTION
Fixes #634 and includes a dedicated _blacklight_overrides.scss file to override styles inherited from Blacklight proper. This will be useful during major release upgrades and for temporarily overriding styles bugs inherited upstream.