### PR TITLE
Add bookmarks and search history nav actions to catalog controller template

### DIFF
--- a/lib/generators/geoblacklight/templates/catalog_controller.rb
+++ b/lib/generators/geoblacklight/templates/catalog_controller.rb
@@ -213,6 +213,10 @@ class CatalogController < ApplicationController
     # mean") suggestion is offered.
     config.spell_max = 5
 
+    # Nav actions from Blacklight
+    config.add_nav_action(:bookmark, partial: 'blacklight/nav/bookmark', if: :render_bookmarks_control?)
+    config.add_nav_action(:search_history, partial: 'blacklight/nav/search_history')
+
     # Tools from Blacklight
     config.add_show_tools_partial(:bookmark, partial: 'bookmark_control', if: :render_bookmarks_control?)
     config.add_show_tools_partial(:email, callback: :email_action, validator: :validate_email_params)

--- a/spec/features/home_page_spec.rb
+++ b/spec/features/home_page_spec.rb
@@ -4,6 +4,10 @@ feature 'Home page', js: true do # use js: true for tests which require js, but 
   before do
     visit root_path
   end
+  scenario 'navbar' do
+    expect(page).to have_css '#bookmarks_nav'
+    expect(page).to have_css 'a', text: 'History'
+  end
   scenario 'search bar' do
     expect(page).not_to have_css '#search-navbar'
     within '.jumbotron' do


### PR DESCRIPTION
Fixes issue in BL7 branch where bookmarks and history links are missing from the nav bar.

Closes #638 