### PR TITLE
639 search results formatting

### DIFF
--- a/app/assets/stylesheets/geoblacklight/_blacklight_overrides.scss
+++ b/app/assets/stylesheets/geoblacklight/_blacklight_overrides.scss
@@ -17,3 +17,18 @@
   position: relative;
 }
 // End - Addresses GBL issue #634
+
+// Begin - Addresses GBL issue #639
+.facet-limit {
+  margin-bottom:0;
+}
+
+.facets-collapse .card+.card {
+  margin-top: 0.5rem;
+}
+
+.documents-list .document {
+  margin-top:0.5rem;
+  padding-top:0.5rem;
+}
+// End - Addresses GBL issue #639

--- a/app/assets/stylesheets/geoblacklight/modules/results.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/results.scss
@@ -5,6 +5,7 @@
 .more-info-area {
   order:3;
   max-height: 100px;
+  overflow:hidden;
 }
 
 .text-span{
@@ -21,7 +22,7 @@
 
 .status-icons {
   order: 2;
-  margin-right: 10px;
+  margin-left: 0.5rem;
 }
 
 .index_title {
@@ -30,6 +31,7 @@
   @extend .hide-overflow;
   @extend h5;
   font-size:1rem;
+  width:80%;
 }
 
 .caret-toggle {

--- a/app/assets/stylesheets/geoblacklight/modules/results.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/results.scss
@@ -3,6 +3,7 @@
 }
 
 .more-info-area {
+  order:3;
   max-height: 100px;
 }
 
@@ -19,14 +20,16 @@
 }
 
 .status-icons {
-  float: right;
+  order: 2;
   margin-right: 10px;
 }
 
 .index_title {
+  order: 1;
   @extend .text-span;
   @extend .hide-overflow;
   @extend h5;
+  font-size:1rem;
 }
 
 .caret-toggle {

--- a/app/views/catalog/_document_split.html.erb
+++ b/app/views/catalog/_document_split.html.erb
@@ -1,5 +1,5 @@
 <div class='row'>
-  <div id="documents" class="docView col-md-6">
+  <div id="documents" class="documents-list col-md-6">
     <%= render documents, :as => :document %>
   </div>
   <%= content_tag :div, '', id: 'map', class: 'col-md-6', data: { map: 'index', 'catalog-path'=> search_catalog_path , 'map-bbox' => params[:bbox], basemap: geoblacklight_basemap, leaflet_options: leaflet_options } %>

--- a/lib/generators/geoblacklight/templates/catalog_controller.rb
+++ b/lib/generators/geoblacklight/templates/catalog_controller.rb
@@ -214,6 +214,8 @@ class CatalogController < ApplicationController
     config.spell_max = 5
 
     # Tools from Blacklight
+    config.add_results_collection_tool(:sort_widget)
+    config.add_results_collection_tool(:per_page_widget)
     config.add_show_tools_partial(:bookmark, partial: 'bookmark_control', if: :render_bookmarks_control?)
     config.add_show_tools_partial(:email, callback: :email_action, validator: :validate_email_params)
 

--- a/spec/features/split_view.html.erb_spec.rb
+++ b/spec/features/split_view.html.erb_spec.rb
@@ -13,6 +13,12 @@ feature 'Index view', js: true do
     expect(page).to have_css('#map')
   end
 
+  scenario 'should have sort and per_page on page' do
+    visit search_catalog_path(f: { Settings.FIELDS.PROVENANCE => ['Stanford'] })
+    expect(page).to have_css('#sort-dropdown')
+    expect(page).to have_css('#per_page-dropdown')
+  end
+
   scenario 'should have facets listed correctly' do
     within '#facet-panel-collapse' do
       expect(page).to have_css('div.card.facet-limit', text: 'Institution')


### PR DESCRIPTION
Fixes #639 / Re-adds the sort and per_page widgets. Reorders .document child elements via flexbox's order rule. Tightens BL7 default spacing for facets and .document results, returning these GBL elements to a half-rem for spacing instead of a full rem.