### PR TITLE
Restores the metadata formatting on item show views

### DIFF
--- a/app/assets/stylesheets/geoblacklight/modules/item.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/item.scss
@@ -1,16 +1,36 @@
-[data-map="item"] {  
-  height: 440px;
-}
+#document {
+  .geoblacklight-view-panel {
+    .dl-horizontal {
+      @media (min-width: map-get($grid-breakpoints, "md")) {
+        dt {
+          float: left;
+          width: 160px;
+          clear: left;
+          text-align: right;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+        }
 
-[data-inspect="true"][data-available="true"] {
-  cursor: crosshair;
-
-  // set cursor for feature layer svg elements
-  .leaflet-clickable {
-    cursor: crosshair;
+        dd {
+          margin-left: 180px;
+        }
+      }
+    }
   }
-}
 
-.download-element {
-  padding-bottom: 10px;
+  #viewer-container {
+    [data-map="item"] {
+      height: 440px;
+    }
+
+    [data-inspect="true"][data-available="true"] {
+      cursor: crosshair;
+
+      // set cursor for feature layer svg elements
+      .leaflet-clickable {
+        cursor: crosshair;
+      }
+    }
+  }
 }

--- a/lib/generators/geoblacklight/templates/catalog_controller.rb
+++ b/lib/generators/geoblacklight/templates/catalog_controller.rb
@@ -127,10 +127,10 @@ class CatalogController < ApplicationController
     config.add_show_field Settings.FIELDS.DESCRIPTION, label: 'Description', itemprop: 'description', helper_method: :render_value_as_truncate_abstract
     config.add_show_field Settings.FIELDS.PUBLISHER, label: 'Publisher', itemprop: 'publisher'
     config.add_show_field Settings.FIELDS.PART_OF, label: 'Collection', itemprop: 'isPartOf'
-    config.add_show_field Settings.FIELDS.SPATIAL_COVERAGE, label: 'Place(s)', itemprop: 'spatial', link_to_search: true
-    config.add_show_field Settings.FIELDS.SUBJECT, label: 'Subject(s)', itemprop: 'keywords', link_to_search: true
+    config.add_show_field Settings.FIELDS.SPATIAL_COVERAGE, label: 'Place(s)', itemprop: 'spatial', link_to_facet: true
+    config.add_show_field Settings.FIELDS.SUBJECT, label: 'Subject(s)', itemprop: 'keywords', link_to_facet: true
     config.add_show_field Settings.FIELDS.TEMPORAL, label: 'Year', itemprop: 'temporal'
-    config.add_show_field Settings.FIELDS.PROVENANCE, label: 'Held by', link_to_search: true
+    config.add_show_field Settings.FIELDS.PROVENANCE, label: 'Held by', link_to_facet: true
 
     # "fielded" search configuration. Used by pulldown among other places.
     # For supported keys in hash, see rdoc for Blacklight::SearchFields

--- a/spec/views/catalog/_upper_metadata.html.erb_spec.rb
+++ b/spec/views/catalog/_upper_metadata.html.erb_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+describe 'catalog/_upper_metadata.html.erb', type: :view do
+  let(:document) { instance_double(SolrDocument) }
+  let(:presenter) { instance_double(Blacklight::ShowPresenter) }
+  let(:blacklight_config) do
+    Blacklight::Configuration.new.configure do |config|
+      config.add_show_field Settings.FIELDS.CREATOR, label: 'Author(s)', itemprop: 'author'
+      config.add_show_field Settings.FIELDS.DESCRIPTION, label: 'Description', itemprop: 'description', helper_method: :render_value_as_truncate_abstract
+      config.add_show_field Settings.FIELDS.PUBLISHER, label: 'Publisher', itemprop: 'publisher'
+      config.add_show_field Settings.FIELDS.PART_OF, label: 'Collection', itemprop: 'isPartOf'
+      config.add_show_field Settings.FIELDS.SPATIAL_COVERAGE, label: 'Place(s)', itemprop: 'spatial', link_to_facet: true
+      config.add_show_field Settings.FIELDS.SUBJECT, label: 'Subject(s)', itemprop: 'keywords', link_to_facet: true
+      config.add_show_field Settings.FIELDS.TEMPORAL, label: 'Year', itemprop: 'temporal'
+      config.add_show_field Settings.FIELDS.PROVENANCE, label: 'Held by', link_to_facet: true
+    end
+  end
+
+  before do
+    allow(document).to receive(:references)
+
+    assign(:document, document)
+    allow(presenter).to receive(:field_value)
+    allow(view).to receive(:show_presenter).and_return(presenter)
+    # https://github.com/projectblacklight/blacklight/blob/v7.0.0.rc1/app/helpers/blacklight/configuration_helper_behavior.rb#L31
+    allow(view).to receive(:document_show_fields).and_return(blacklight_config.show_fields)
+    allow(view).to receive(:should_render_show_field?).and_return(true)
+  end
+
+  it 'renders the field values for the default GeoBlacklight show fields' do
+    render
+
+    expect(presenter).to have_received(:field_value).with('dc_creator_sm')
+    expect(presenter).to have_received(:field_value).with('dc_description_s')
+    expect(presenter).to have_received(:field_value).with('dc_publisher_s')
+    expect(presenter).to have_received(:field_value).with('dct_isPartOf_sm')
+    expect(presenter).to have_received(:field_value).with('dct_spatial_sm')
+    expect(presenter).to have_received(:field_value).with('dc_subject_sm')
+    expect(presenter).to have_received(:field_value).with('dct_temporal_sm')
+    expect(presenter).to have_received(:field_value).with('dct_provenance_s')
+  end
+end


### PR DESCRIPTION
Resolves #640 addressing the following:
- Restoring the styling to the metadata section on the item show page
- Replacing link_to_search (which has been deprecated) with link_to_facet for the CatalogController

Smartphone/tablet portrait viewport width:
![geoblacklight_issues_640_screenshot_1](https://user-images.githubusercontent.com/1443986/43290711-f823c7fe-90fc-11e8-9f53-88ecaad43155.png)

Landscape/desktop viewport width:
![geoblacklight_issues_640_screenshot_0](https://user-images.githubusercontent.com/1443986/43290713-fa49a3e6-90fc-11e8-91b8-339962b067d1.png)
