### PR TITLE
Restores the default bounding box for the Leaflet viewer on the landing page

### DIFF
--- a/app/assets/javascripts/geoblacklight/modules/home.js
+++ b/app/assets/javascripts/geoblacklight/modules/home.js
@@ -1,8 +1,9 @@
 Blacklight.onLoad(function() {
   $('[data-map="home"]').each(function(i, element) {
 
-    var geoblacklight = new GeoBlacklight.Viewer.Map(this),
-        data = $(this).data();
+    var geoblacklight = new GeoBlacklight.Viewer.Map(this);
+    var data = $(this).data();
+
     geoblacklight.map.addControl(L.control.geosearch({
       baseUrl: data.catalogPath,
       dynamic: false,

--- a/app/assets/javascripts/geoblacklight/viewers/map.js
+++ b/app/assets/javascripts/geoblacklight/viewers/map.js
@@ -1,12 +1,13 @@
 //= require geoblacklight/viewers/viewer
 
 GeoBlacklight.Viewer.Map = GeoBlacklight.Viewer.extend({
+
   options: {
     /**
     * Initial bounds of map
     * @type {L.LatLngBounds}
     */
-    bbox: [[-80, -195], [80, 185]],
+    bbox: [[-82, -144], [77, 161]],
     opacity: 0.75
   },
 

--- a/app/assets/stylesheets/geoblacklight/modules/home.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/home.scss
@@ -1,18 +1,28 @@
-[data-map="home"] {
-  height: 400px;
-}
 
 .geobl-homepage-masthead {
-
   .search-query-form {
     max-width: 100%;
   }
 }
 
-.category-block {
-  min-height: 240px;
+#main-container {
+  .category-block {
+    min-height: 240px;
 
-  .category-icon {
-    font-size: 6em;
+    .category-icon {
+      font-size: 6em;
+    }
+  }
+
+  [data-map="home"] {
+    height: 400px;
+
+    .leaflet-control-container {
+      .search-control {
+        a {
+          color: $white;
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
Resolves #637 by addressing the following:
- Adjusting the initial bounding box for Leaflet on the home landing page
- Restoring the link color for the leaflet search control

<img width="759" alt="geoblacklight_issues_637_screenshot_0" src="https://user-images.githubusercontent.com/1443986/43329000-61217f54-918d-11e8-97e0-dae1091457e7.png">
