### PR TITLE
Set the proper application name

### DIFF
--- a/lib/generators/geoblacklight/install_generator.rb
+++ b/lib/generators/geoblacklight/install_generator.rb
@@ -89,6 +89,10 @@ module Geoblacklight
       gsub_file('app/assets/javascripts/application.js', %r{\/\/= require turbolinks}, '')
     end
 
+    def update_application_name
+      gsub_file('config/locales/blacklight.en.yml', 'Blacklight', 'GeoBlacklight')
+    end
+
     def bundle_install
       Bundler.with_clean_env do
         run 'bundle install'


### PR DESCRIPTION
Sets the default application name to `GeoBlacklight`. Also added a note in the BL7 upgrade document to make sure that application name is set correctly. 

Closes #609