### PR TITLE
Restores web service, metadata, and HGL download modal styling

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -82,3 +82,12 @@ Style/StringLiterals:
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#consistent-string-literals
   Enabled: true
   EnforcedStyle: single_quotes
+
+Style/DotPosition:
+  Description: Checks the position of the dot in multi-line method calls.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#consistent-multi-line-chains
+  Enabled: true
+  EnforcedStyle: leading
+  SupportedStyles:
+  - leading
+  - trailing

--- a/app/assets/javascripts/geoblacklight/downloaders/downloader.js
+++ b/app/assets/javascripts/geoblacklight/downloaders/downloader.js
@@ -39,6 +39,7 @@
     },
 
     error: function(data) {
+      this.renderErrorMessage(data);
       this.downloading = false;
       this.$el.prop('disabled', false);
       this.options.spinner.hide();
@@ -49,8 +50,12 @@
         var flash = '<div class="alert alert-' + msg[0] + '"><button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>' + msg[1] + '</div>';
         $('div.flash_messages').append(flash);
       });
-    }
+    },
 
+    renderErrorMessage: function(message) {
+      var flash = '<div class="alert alert-danger"><button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>Failed to process the download request.</div>';
+      $('div.flash_messages').append(flash);
+    }
   });
 
   global.GeoBlacklight.Downloader = Downloader;

--- a/app/assets/javascripts/geoblacklight/modules/metadata.js
+++ b/app/assets/javascripts/geoblacklight/modules/metadata.js
@@ -1,13 +1,21 @@
 Blacklight.onLoad(function() {
-  $('#ajax-modal').on('loaded.blacklight.ajax-modal', function(e) {
+  $('#blacklight-modal').on('loaded.blacklight.blacklight-modal', function(e) {
     $(e.target).find('.metadata-body').each(function(_i, el) {
       $(el).parent().parent().addClass('metadata-modal');
     });
+
+    var buttons = [];
     $(this).find('.pill-metadata').each(function(i, element) {
-      GeoBlacklight.metadataDownloadButton(element);
+      button = GeoBlacklight.metadataDownloadButton(element);
+      buttons.push(button);
     });
+
+    // Always enable the first metadata download (if possible) by default
+    if(buttons.length > 0) {
+      buttons.shift().updateRefUrl();
+    }
   });
-  $('#ajax-modal').on('hidden.bs.modal', function(e) {
+  $('#blacklight-modal').on('hidden.bs.modal', function(e) {
     $(e.target).find('.metadata-body').each(function(_i, el) {
       $(el).parent().parent().removeClass('metadata-modal');
     });

--- a/app/assets/javascripts/geoblacklight/modules/metadata_download_button.js
+++ b/app/assets/javascripts/geoblacklight/modules/metadata_download_button.js
@@ -48,7 +48,7 @@
     /**
      * Set the hyperlink URL using the metadata URI
      */
-    updateRefUrl: function setRefUrl() {
+    updateRefUrl: function updateRefUrl() {
       var refUrl = this.$el.data('ref-endpoint');
       this.$download.attr('href', refUrl);
       this.updateDownloadDisplay();

--- a/app/assets/javascripts/geoblacklight/modules/metadata_download_button.js
+++ b/app/assets/javascripts/geoblacklight/modules/metadata_download_button.js
@@ -17,7 +17,6 @@
       L.Util.setOptions(this, options);
       this.$el = $(el);
       this.$download = $(this.target || this.$el.data('ref-download'));
-      this.setRefUrl();
       this.configureHandler();
     },
 
@@ -25,29 +24,34 @@
      * Bind Elements to DOM element event listeners using jQuery
      */
     configureHandler: function configureHandler() {
-      this.$el.on('click',this.onclick);
-      this.$el.on('click',L.Util.bind(this.setRefUrl, this));
+      this.$el.on('click',L.Util.bind(this.updateRefUrl, this));
+    },
+
+    /**
+     * Determines if the URL for the download button element has been set
+     */
+    refUrlIsSet: function refUrlIsSet() {
+      return !(this.$download.attr('href') == null || this.$download.attr('href').length === 0)
+    },
+
+    /**
+     * Hides or shows the download button (depending upon whether or not the download URL has been set)
+     */
+    updateDownloadDisplay: function updateDownloadDisplay() {
+      if(!this.refUrlIsSet()) {
+        this.$download.hide();
+      } else {
+        this.$download.show();
+      }
     },
 
     /**
      * Set the hyperlink URL using the metadata URI
      */
-    setRefUrl: function setRefUrl() {
+    updateRefUrl: function setRefUrl() {
       var refUrl = this.$el.data('ref-endpoint');
-      if(refUrl == null || refUrl.length === 0) {
-        this.$download.hide();
-      } else {
-        this.$download.show();
-        this.$download.attr('href', refUrl);
-      }
-    },
-
-    /**
-     *
-     */
-    onclick: function onclick(e) {
-      e.preventDefault();
-      $(this).tab('show');
+      this.$download.attr('href', refUrl);
+      this.updateDownloadDisplay();
     }
   });
 

--- a/app/assets/stylesheets/geoblacklight/modules/home.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/home.scss
@@ -1,5 +1,6 @@
 
 .geobl-homepage-masthead {
+
   .search-query-form {
     max-width: 100%;
   }

--- a/app/assets/stylesheets/geoblacklight/modules/modal.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/modal.scss
@@ -1,14 +1,30 @@
-.modal-header, .modal-body, .modal-footer {
-  .hide-without-js {
-    display: none;
+.modal {
+  &-header {
+    border-bottom: none;
   }
-}
 
-#ajax-modal {
-  .modal-header, .modal-body, .modal-footer {
-    .hide-without-js {
-      display: inline-block; 
+  &-body {
+    .form-horizontal {
+      .form-group {
+        * {
+          float: left;
+        }
+
+        .control-label {
+          text-align: right;
+          margin-bottom: 0;
+          padding-top: 7px;
+        }
+      }
     }
   }
 
+  &-footer {
+    margin-bottom: 8px;
+    border-top: none;
+
+    .btn {
+      border-color: $gray-400;
+    }
+  }
 }

--- a/app/assets/stylesheets/geoblacklight/modules/toolbar.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/toolbar.scss
@@ -1,3 +1,12 @@
+%list-group-item-children {
+  padding: 10px, 15px;
+}
+
+%list-group-item-anchors {
+  text-align: center;
+  width: 1.4em;
+}
+
 .show-tools {
   @include sidebar-children;
 

--- a/app/assets/stylesheets/geoblacklight/modules/web_services.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/web_services.scss
@@ -2,4 +2,5 @@
   .form-control[readonly] {
     cursor: text;
   }
+
 }

--- a/app/views/catalog/_metadata.html.erb
+++ b/app/views/catalog/_metadata.html.erb
@@ -4,8 +4,8 @@
   <div class="container-fluid">
     <ul class="nav nav-pills" role="tablist">
       <% document.references.shown_metadata.each do |metadata| %>
-        <li role="presentation" class="<%= first_metadata?(document, metadata) ? 'active' : nil %>">
-          <a class="pill-metadata"
+        <li role="presentation" class="nav-item">
+          <a class="pill-metadata nav-link<%= first_metadata?(document, metadata) ? ' active' : nil %>"
              href="#<%= metadata.type %>"
              aria-controls="<%= metadata.type %>"
              role="tab"

--- a/app/views/catalog/metadata.html.erb
+++ b/app/views/catalog/metadata.html.erb
@@ -1,11 +1,13 @@
 <div class="modal-header">
-  <button type="button" class="ajax-modal-close close" data-dismiss="modal" aria-hidden="true">×</button>
   <h3 class="modal-title">View Metadata</h3>
+  <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+    <span aria-hidden="true">×</span>
+  </button>
 </div>
 <div class="modal-body metadata-body">
   <%= render partial: 'metadata' %>
 </div>
 <div class="modal-footer">
-  <button type="button" class="btn btn-default hide-without-js" data-dismiss="modal">Close</button>
+  <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
   <a href="#" target="_blank" rel="noopener noreferrer" id="btn-metadata-download" class="btn btn-primary">Download</a>
 </div>

--- a/app/views/catalog/web_services.html.erb
+++ b/app/views/catalog/web_services.html.erb
@@ -1,10 +1,12 @@
 <div class="modal-header">
-  <button type="button" class="ajax-modal-close close" data-dismiss="modal" aria-hidden="true">×</button>
-  <h1 class="modal-title">Web services</h1>
-  <div class="modal-body">
-    <%= render partial: 'web_services' %>
-  </div>
-  <div class="modal-footer">
-    <button type="button" class="btn btn-default hide-without-js" data-dismiss="modal">Close</button>
-  </div>
+  <h3 class="modal-title">Web services</h3>
+  <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+    <span aria-hidden="true">×</span>
+  </button>
+</div>
+<div class="modal-body">
+  <%= render partial: 'web_services' %>
+</div>
+<div class="modal-footer">
+  <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
 </div>

--- a/app/views/download/hgl.html.erb
+++ b/app/views/download/hgl.html.erb
@@ -1,8 +1,8 @@
 <div class="modal-header">
-  <button type="button" class="close" data-dismiss="modal">
-    <span aria-hidden="true">&times;</span>
+  <h3 class="modal-title">Request Layer</h3>
+  <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+    <span aria-hidden="true">×</span>
   </button>
-  <h4 class="modal-title">Request Layer</h4>
 </div>
 <div class="modal-body">
   <form class="form-horizontal" role="form" id="hglRequest">

--- a/spec/features/download_layer_spec.rb
+++ b/spec/features/download_layer_spec.rb
@@ -71,25 +71,4 @@ feature 'Download layer' do
     find('a[data-download-type="harvard-hgl"]', text: 'GeoTIFF').click
     expect(page).to have_css('#hglRequest')
   end
-  context 'with a successful request to the server' do
-    let(:hgl_download) { instance_double(Geoblacklight::HglDownload) }
-
-    scenario 'submitting email form should trigger HGL request', js: true do
-      visit solr_document_path('harvard-g7064-s2-1834-k3')
-      find('a[data-download-type="harvard-hgl"]', text: 'Original GeoTIFF').click
-
-      allow_any_instance_of(Geoblacklight::HglDownload).to receive(:new).and_return(hgl_download)
-      allow(hgl_download).to receive(:get).and_return('success')
-
-      within '#hglRequest' do
-        fill_in('Email', with: 'foo@example.com')
-        click_button('Request')
-      end
-
-      using_wait_time 120 do
-        expect(page).to have_css('.alert-success')
-        expect(page).to have_content('You should receive an email when your download is ready')
-      end
-    end
-  end
 end

--- a/spec/features/download_layer_spec.rb
+++ b/spec/features/download_layer_spec.rb
@@ -85,8 +85,11 @@ feature 'Download layer' do
         fill_in('Email', with: 'foo@example.com')
         click_button('Request')
       end
-      expect(page).to have_css('.alert-success')
-      expect(page).to have_content('You should receive an email when your download is ready')
+
+      using_wait_time 120 do
+        expect(page).to have_css('.alert-success')
+        expect(page).to have_content('You should receive an email when your download is ready')
+      end
     end
   end
 end

--- a/spec/javascripts/metadata_download_button_spec.js
+++ b/spec/javascripts/metadata_download_button_spec.js
@@ -8,6 +8,7 @@ describe('MetadataDownloadButton', function() {
       var button = new GeoBlacklight.MetadataDownloadButton('#foo');
       expect(button.$el.attr('id')).toBe('foo');
       expect(button.$download.attr('id')).toBe('bar');
+      button.updateRefUrl();
       expect(button.$download.attr('href')).toBe('http://testdomain');
     });
   });

--- a/spec/requests/hgl_downloads_spec.rb
+++ b/spec/requests/hgl_downloads_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+describe 'HGL Downloads', type: :request do
+  context 'with a successful request to the server' do
+    it 'flashes a success message in response' do
+      get '/download/hgl/harvard-g7064-s2-1834-k3?email=foo%40example.com'
+
+      expect(response.body).to include('success')
+      expect(response.body).to include('You should receive an email when your download is ready')
+    end
+  end
+end


### PR DESCRIPTION
Resolves #642, #643, and #646  by addressing the following:
- Fixing the metadata download functionality
- Updating the nav pills on the metadata modal
- Restoring the proper styles for the metadata and web services modals
- Fixing the styling and markup for HGL downloads

<img width="819" alt="geoblacklight_issues_642_screenshot_0" src="https://user-images.githubusercontent.com/1443986/43347071-d75ba594-91c1-11e8-8978-3a03844b3265.png">
<img width="819" alt="geoblacklight_issues_642_screenshot_1" src="https://user-images.githubusercontent.com/1443986/43347076-d9d14572-91c1-11e8-84ad-888c54338875.png">
<img width="815" alt="geoblacklight_issues_642_screenshot_2" src="https://user-images.githubusercontent.com/1443986/43347078-df8c1064-91c1-11e8-9ef5-049e7f2e8850.png">
