### PR TITLE
Restores the styling for the Data Relations sidebar panel

### DIFF
--- a/app/assets/stylesheets/geoblacklight/_geoblacklight.scss
+++ b/app/assets/stylesheets/geoblacklight/_geoblacklight.scss
@@ -27,6 +27,8 @@
 @import 'modules/results';
 @import 'modules/geosearch';
 @import 'modules/search_widgets';
+@import 'modules/sidebar';
 @import 'modules/toolbar';
+@import 'modules/relations';
 @import 'modules/web_services';
 @import 'blacklight_overrides';

--- a/app/assets/stylesheets/geoblacklight/modules/relations.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/relations.scss
@@ -1,0 +1,15 @@
+.relations {
+  @include sidebar-children;
+
+  .list-group {
+    .relations-ancestors {
+      padding-left: 16px;
+      padding-right: 16px;
+    }
+
+    .relations-descendants {
+      padding-left: 16px;
+      padding-right: 16px;
+    }
+  }
+}

--- a/app/assets/stylesheets/geoblacklight/modules/sidebar.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/sidebar.scss
@@ -1,0 +1,35 @@
+// Mixins and shared properties for sidebar elements
+
+@mixin sidebar-children {
+  %list-group-item-children {
+    padding: 10px, 15px;
+  }
+
+  %list-group-item-anchors {
+    text-align: center;
+    width: 1.4em;
+  }
+
+  margin-top: 16px;
+  margin-bottom: 16px;
+
+  .list-group {
+    padding-top: 24px;
+    padding-bottom: 24px;
+    padding-left: 4px;
+    padding-right: 4px;
+
+    .list-group-item {
+      border-color: $white;
+      padding: 8px 32px;
+
+      a {
+        @extend %list-group-item-children;
+
+        .geoblacklight {
+          color: $gray-600;
+        }
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/geoblacklight/modules/toolbar.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/toolbar.scss
@@ -1,22 +1,10 @@
-%list-group-item-children {
-  padding: 10px, 15px;
-}
-
-%list-group-item-anchors {
-  text-align: center;
-  width: 1.4em;
-}
 
 .show-tools {
+  @include sidebar-children;
+
   .list-group {
-    padding-top: 24px;
-    padding-bottom: 24px;
-    padding-left: 4px;
-    padding-right: 4px;
 
     .list-group-item {
-      border-color: $white;
-      padding: 8px 32px;
 
       form {
         @extend %list-group-item-children;
@@ -32,10 +20,8 @@
       }
 
       a {
-        @extend %list-group-item-children;
 
         .geoblacklight {
-          color: $gray-600;
 
           &-citation {
             @extend %list-group-item-anchors;

--- a/app/views/relation/_ancestors.html.erb
+++ b/app/views/relation/_ancestors.html.erb
@@ -1,8 +1,8 @@
-<li>
+<li class="list-group-item relations-ancestors">
   <b><%= t('geoblacklight.relations.ancestor') %></b>
 </li>
 <% @relations.ancestors['docs'].each do |ancestor| %>
-  <li>
+  <li class="list-group-item">
     <%= link_to solr_document_path(ancestor['layer_slug_s']) do %>
       <span class='geoblacklight geoblacklight-relations-ancestor'></span> <%= ancestor['dc_title_s'] %>
     <% end %>

--- a/app/views/relation/_descendants.html.erb
+++ b/app/views/relation/_descendants.html.erb
@@ -1,15 +1,15 @@
-<li>
+<li class="list-group-item relations-descendants">
   <b><%= t('geoblacklight.relations.descendant', count: @relations.descendants['numFound']) %></b>
 </li>
 <% @relations.descendants['docs'][0..2].each do |descendant| %>
-  <li>
+  <li class="list-group-item">
     <%= link_to solr_document_path(descendant['layer_slug_s']) do %>
       <span class='geoblacklight geoblacklight-relations-descendant'></span> <%= descendant['dc_title_s'] %>
     <% end %>
   </li>
 <% end %>
 <% unless (@relations.descendants['numFound'].to_i <= 3) %>
-  <li>
+  <li class="list-group-item">
     <%= link_to search_catalog_path({f: {"#{Settings.FIELDS.SOURCE}" => [@relations.search_id]}}) do %>
       <%= t('geoblacklight.relations.browse_all', count: @relations.descendants['numFound']) %>
     <% end %>

--- a/app/views/relation/index.html.erb
+++ b/app/views/relation/index.html.erb
@@ -1,13 +1,13 @@
 <% unless @relations.empty? %>
-  <div class="panel panel-default show-tools">
-    <div class="panel-heading">
+  <div class="card relations">
+    <div class="card-header">
       <%= t('geoblacklight.relations.title') %>
     </div>
-    <div class="panel-body">
-      <ul class="nav">
-        <%= render 'ancestors' unless @relations.ancestors['numFound'].to_i == 0 %>
-        <%= render 'descendants' unless @relations.descendants['numFound'].to_i == 0 %>
-      </ul>
-    </div>
+
+    <ul class="list-group list-group-flush">
+      <%= render 'ancestors' unless @relations.ancestors['numFound'].to_i == 0 %>
+      <%= render 'descendants' unless @relations.descendants['numFound'].to_i == 0 %>
+    </ul>
+
   </div>
 <% end %>

--- a/spec/features/relations_spec.rb
+++ b/spec/features/relations_spec.rb
@@ -41,7 +41,7 @@ feature 'Display related documents' do
 
   scenario 'Record with relations should render widget in catalog#show', js: true do
     visit solr_document_path('nyu_2451_34635')
-    expect(page).to have_css('div.panel-heading', text: 'Data Relations')
+    expect(page).to have_css('div.card-header', text: 'Data Relations')
   end
 
   scenario 'Record without relations should not render widget in catalog#show', js: true do


### PR DESCRIPTION
Resolves #644 by restoring the styling for the relations ("Data Relations") sidebar panel and refactoring the SCSS for the "Tools" panel:

![geoblacklight_issues_644_screenshot_1](https://user-images.githubusercontent.com/1443986/43405584-2a66ce62-93e8-11e8-8f4b-82e8d586ef32.png)
