### PR TITLE
Remove table-responsive class to fix issue with attribute column width

### DIFF
--- a/app/views/catalog/_show_default_attribute_table.html.erb
+++ b/app/views/catalog/_show_default_attribute_table.html.erb
@@ -1,6 +1,6 @@
 <% if show_attribute_table? %>
   <div id='table-container' class='col-md-4'>
-    <table id="attribute-table" class="table table-hover table-condensed table-responsive table-striped table-bordered">
+    <table id="attribute-table" class="table table-hover table-condensed table-striped table-bordered">
       <thead>
         <tr>
           <th>Attribute</th>


### PR DESCRIPTION
Fixes issue with improperly sized feature inspection table by removing the `table-responsive` class. The table is not responsive, so it isn't needed.

Closes #645 