### PR TITLE
Add rake task to run Solr only

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -93,6 +93,34 @@ namespace :geoblacklight do
       end
     end
   end
+
+  desc 'Run Solr and seed with sample data'
+  task :solr do
+    if File.exist? EngineCart.destination
+      within_test_app do
+        system 'bundle update'
+      end
+    else
+      Rake::Task['engine_cart:generate'].invoke
+    end
+
+    SolrWrapper.wrap(port: '8983') do |solr|
+      solr.with_collection(name: 'blacklight-core', dir: File.join(File.expand_path('.', File.dirname(__FILE__)), 'solr', 'conf')) do
+        Rake::Task['geoblacklight:internal:seed'].invoke
+
+        within_test_app do
+          puts "\nSolr server running: http://localhost:#{solr.port}/solr/#/blacklight-core"
+          puts "\n^C to stop"
+          puts ' '
+          begin
+            sleep
+          rescue Interrupt
+            puts 'Shutting down...'
+          end
+        end
+      end
+    end
+  end
 end
 
 task default: [:ci]


### PR DESCRIPTION
Allows developers to run solr and rails server(using `rake engine_cart:server`) in seperate terminal windows. Makes development of engine easier, as developer has to only restart the server process after making changes.

Closes #658 