### PR TITLE
Adjusts the download and export panel styles for Bootstrap 4

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -64,6 +64,7 @@ RSpec/AnyInstance:
   Exclude:
     - 'spec/models/concerns/geoblacklight/solr_document_spec.rb'
     - 'spec/helpers/geoblacklight_helper_spec.rb'
+    - 'spec/features/download_layer_spec.rb'
 
 # Rubocop bug causes view specs to fail.
 #  https://github.com/nevir/rubocop-rspec/issues/47

--- a/app/assets/javascripts/geoblacklight/downloaders/downloader.js
+++ b/app/assets/javascripts/geoblacklight/downloaders/downloader.js
@@ -10,7 +10,7 @@
       L.Util.setOptions(this, options);
       this.$el = $(el);
       this.options.spinner.hide();
-      $('.exports .panel-heading').append(this.options.spinner);
+      $('.exports .card-header').append(this.options.spinner);
       this.configureHandler();
     },
 

--- a/app/assets/stylesheets/geoblacklight/modules/downloads.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/downloads.scss
@@ -5,18 +5,22 @@
   }
 }
 
+%download-export-links {
+  a {
+    width: 100%;
+    font-weight: 600;
+    background-color: $link-color;
+    color: #ffffff;
+    border-color: darken($link-color, 6.5%);
+    white-space: inherit;
+  }
+}
+
 @mixin download-export {
   &-link {
     &-container {
       text-align: center;
-
-      a {
-        width: 100%;
-        font-weight: 600;
-        background-color: $link-color;
-        color: #ffffff;
-        border-color: darken($link-color, 6.5%);
-      }
+      @extend %download-export-links;
     }
   }
 }
@@ -27,6 +31,16 @@
 
   .download {
     @include download-export;
+  }
+}
+
+.authentication {
+  @include sidebar-children;
+  .card-header {
+    background-color: inherit;
+    border-bottom: inherit;
+
+    @extend %download-export-links;
   }
 }
 
@@ -46,15 +60,16 @@
     padding-left: 0px;
     padding-right: 0px;
     text-align: center;
+    width: 100%;
 
-    @include media-breakpoint-up(lg) {
+    @include media-breakpoint-up(xl) {
       text-align: left;
     }
 
     &-label {
       padding: 6px 12px;
 
-      @include media-breakpoint-up(lg) {
+      @include media-breakpoint-up(xl) {
         display: inline-block;
       }
     }
@@ -62,13 +77,13 @@
     &-link {
       &-container {
 
-        @include media-breakpoint-up(lg) {
+        @include media-breakpoint-up(xl) {
           display: inline-block;
           float: right;
         }
 
         a {
-          @include media-breakpoint-up(lg) {
+          @include media-breakpoint-up(xl) {
             width: inherit;
           }
         }

--- a/app/assets/stylesheets/geoblacklight/modules/downloads.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/downloads.scss
@@ -8,7 +8,6 @@
 @mixin download-export {
   &-link {
     &-container {
-      padding: 4px 15px;
       text-align: center;
 
       a {
@@ -23,6 +22,7 @@
 }
 
 .downloads {
+  @include sidebar-children;
   @extend %downloads-exports;
 
   .download {
@@ -31,16 +31,12 @@
 }
 
 .exports {
+  @include sidebar-children;
   @extend %downloads-exports;
 
-  .panel-heading {
-    h2 {
-      display: inline;
-    }
-
+  .card-header {
     .fa-spinner {
-      padding-left: 8px;
-      padding-right: 8px;
+      float: right;
     }
   }
 
@@ -56,7 +52,7 @@
     }
 
     &-label {
-      padding: 10px 12px;
+      padding: 6px 12px;
 
       @include media-breakpoint-up(lg) {
         display: inline-block;

--- a/app/assets/stylesheets/geoblacklight/modules/sidebar.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/sidebar.scss
@@ -31,7 +31,7 @@
 
     .list-group-item {
       border-color: $white;
-      padding: 8px 32px;
+      padding: 8px 16px;
 
       a {
         @extend %list-group-item-children;

--- a/app/assets/stylesheets/geoblacklight/modules/sidebar.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/sidebar.scss
@@ -13,6 +13,16 @@
   margin-top: 16px;
   margin-bottom: 16px;
 
+  .card-header {
+    h2 {
+      display: inline-block;
+      padding-top: 8px;
+      padding-bottom: 8px;
+      margin-bottom: 0px;
+      font-size: 1rem;
+    }
+  }
+
   .list-group {
     padding-top: 24px;
     padding-bottom: 24px;

--- a/app/helpers/geoblacklight_helper.rb
+++ b/app/helpers/geoblacklight_helper.rb
@@ -42,7 +42,7 @@ module GeoblacklightHelper
       download_hgl_path(id: document),
       class: ['btn', 'btn-default', 'download', 'download-original'],
       data: {
-        ajax_modal: 'trigger',
+        blacklight_modal: 'trigger',
         download: 'trigger',
         download_type: 'harvard-hgl',
         download_id: document.id

--- a/app/views/catalog/_show_downloads.html.erb
+++ b/app/views/catalog/_show_downloads.html.erb
@@ -2,9 +2,9 @@
 
 <% if document_downloadable? %>
   <% if document.direct_download.present? || document.hgl_download.present? || document.iiif_download.present? %>
-    <div class="panel panel-default downloads">
-      <div class="panel-heading">
-        <h2 class="mb-0 h6"><%= t('geoblacklight.download.download').pluralize %></h2>
+    <div class="card downloads">
+      <div class="card-header">
+        <h2><%= t('geoblacklight.download.download').pluralize %></h2>
       </div>
 
       <ul class="list-group list-group-flush">
@@ -14,9 +14,10 @@
   <% end %>
 
   <% if document.download_types.present? %>
-    <div class="panel panel-default exports">
-      <div class="panel-heading">
-        <h2 class="mb-0 h6"><%= t('geoblacklight.download.export_formats') %></h2>
+    <div class="card exports">
+      <div class="card-header">
+
+        <h2><%= t('geoblacklight.download.export_formats') %></h2>
       </div>
 
       <ul class="list-group list-group-flush">

--- a/app/views/catalog/_show_downloads.html.erb
+++ b/app/views/catalog/_show_downloads.html.erb
@@ -26,7 +26,9 @@
     </div>
   <% end %>
 <% elsif document.restricted? && document.same_institution? %>
-  <div class='panel-body'>
-    <%= link_to t('geoblacklight.tools.login_to_view'), new_user_session_path(referrer: request.original_url) %>
+  <div class="card authentication">
+    <div class="card-header">
+      <%= link_to t('geoblacklight.tools.login_to_view'), new_user_session_path(referrer: request.original_url), class: ['btn', 'btn-default'] %>
+    </div>
   </div>
 <% end %>

--- a/app/views/catalog/_show_tools.html.erb
+++ b/app/views/catalog/_show_tools.html.erb
@@ -9,7 +9,7 @@
 <% if show_doc_actions? %>
   <div class="card show-tools">
     <div class="card-header">
-      <%= t('blacklight.tools.title') %>
+      <h2><%= t('blacklight.tools.title') %></h2>
     </div>
 
     <ul class="list-group list-group-flush">

--- a/config/locales/geoblacklight.en.yml
+++ b/config/locales/geoblacklight.en.yml
@@ -10,7 +10,7 @@ en:
       error_with_url: 'Sorry, the requested file could not be downloaded, try downloading it directly from: %{link}'
       export_formats: 'Export Formats'
       export_link: 'Export'
-      export_shapefile_link: 'EPSG:4326 Shapefile'
+      export_shapefile_link: 'Shapefile'
       export_kmz_link: 'KMZ'
       export_geojson_link: 'GeoJSON'
     home:

--- a/config/locales/geoblacklight.en.yml
+++ b/config/locales/geoblacklight.en.yml
@@ -19,7 +19,7 @@ en:
       category_heading: 'Find by...'
       map_heading: 'Find by location'
     tools:
-      login_to_view: 'Login to view'
+      login_to_view: 'Login to View and Download'
       open_carto: 'Open in Carto'
     formats:
       arcgrid: 'ArcGRID'

--- a/spec/features/download_layer_spec.rb
+++ b/spec/features/download_layer_spec.rb
@@ -3,12 +3,10 @@ require 'spec_helper'
 feature 'Download layer' do
   let(:shapefile_download) { instance_double(Geoblacklight::ShapefileDownload) }
   let(:kmz_download) { instance_double(Geoblacklight::KmzDownload) }
-  let(:hgl_download) { instance_double(Geoblacklight::HglDownload) }
 
   before do
     allow(Geoblacklight::ShapefileDownload).to receive(:new).and_return(shapefile_download)
     allow(Geoblacklight::KmzDownload).to receive(:new).and_return(kmz_download)
-    allow(Geoblacklight::HglDownload).to receive(:new).and_return(hgl_download)
   end
 
   scenario 'clicking initial shapefile download button should trigger download', js: true do
@@ -73,15 +71,20 @@ feature 'Download layer' do
     find('a[data-download-type="harvard-hgl"]', text: 'GeoTIFF').click
     expect(page).to have_css('#hglRequest')
   end
-  scenario 'submitting email form should trigger HGL request', js: true do
-    expect(hgl_download).to receive(:get).and_return('success')
-    visit solr_document_path('harvard-g7064-s2-1834-k3')
-    find('a[data-download-type="harvard-hgl"]', text: 'GeoTIFF').click
-    within '#hglRequest' do
-      fill_in('Email', with: 'foo@example.com')
-      click_button('Request')
-    end
-    using_wait_time 120 do
+  context 'with a successful request to the server' do
+    let(:hgl_download) { instance_double(Geoblacklight::HglDownload) }
+
+    scenario 'submitting email form should trigger HGL request', js: true do
+      visit solr_document_path('harvard-g7064-s2-1834-k3')
+      find('a[data-download-type="harvard-hgl"]', text: 'Original GeoTIFF').click
+
+      allow_any_instance_of(Geoblacklight::HglDownload).to receive(:new).and_return(hgl_download)
+      allow(hgl_download).to receive(:get).and_return('success')
+
+      within '#hglRequest' do
+        fill_in('Email', with: 'foo@example.com')
+        click_button('Request')
+      end
       expect(page).to have_css('.alert-success')
       expect(page).to have_content('You should receive an email when your download is ready')
     end

--- a/spec/features/download_layer_spec.rb
+++ b/spec/features/download_layer_spec.rb
@@ -49,7 +49,7 @@ feature 'Download layer' do
   end
   scenario 'restricted layer should not have download available to non logged in user' do
     visit solr_document_path('stanford-cg357zz0321')
-    expect(page).to have_css 'a', text: 'Login to view'
+    expect(page).to have_css 'a', text: 'Login to View and Download'
     expect(page).not_to have_css 'button', text: 'Download Shapefile'
   end
   scenario 'restricted layer should have download available to logged in user' do

--- a/spec/helpers/geoblacklight_helper_spec.rb
+++ b/spec/helpers/geoblacklight_helper_spec.rb
@@ -84,7 +84,7 @@ describe GeoblacklightHelper, type: :helper do
     end
 
     it 'generates a link to the HGL route' do
-      expect(download_link_hgl(text, document)).to eq '<a class="btn btn-default download download-original" data-ajax-modal="trigger" data-download="trigger" data-download-type="harvard-hgl" data-download-id="test-id" href="/download/hgl/test-id">Test Link Text</a>'
+      expect(download_link_hgl(text, document)).to eq '<a class="btn btn-default download download-original" data-blacklight-modal="trigger" data-download="trigger" data-download-type="harvard-hgl" data-download-id="test-id" href="/download/hgl/test-id">Test Link Text</a>'
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,7 +24,7 @@ end
 
 Capybara.javascript_driver = :headless_chrome
 
-Capybara.default_max_wait_time = 15
+Capybara.default_max_wait_time = 120
 
 if ENV['COVERAGE'] || ENV['CI']
   require 'simplecov'

--- a/spec/views/catalog/_show_downloads.html.erb_spec.rb
+++ b/spec/views/catalog/_show_downloads.html.erb_spec.rb
@@ -34,7 +34,7 @@ describe 'catalog/_show_downloads.html.erb', type: :view do
       it 'renders login link' do
         assign :document, document
         render
-        expect(rendered).to have_css '.panel-body a'
+        expect(rendered).to have_css '.card-header a'
       end
     end
   end


### PR DESCRIPTION
<img width="276" alt="geoblacklight_pull_622_screenshot_1" src="https://user-images.githubusercontent.com/1443986/43427399-54be3062-9427-11e8-8799-3effc6772881.png">

For smartphones/tablets/portrait viewport width:
<img width="557" alt="geoblacklight_pull_622_screenshot_2" src="https://user-images.githubusercontent.com/1443986/43427400-5669e42e-9427-11e8-8544-4cc1f131a2a8.png">
