### PR TITLE
Refactor simplecov and coveralls

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,10 +4,6 @@ source 'https://rubygems.org'
 gemspec
 
 group :development, :test do
-  gem 'coveralls', require: false
-  # Peg simplecov to < 0.8 until this is resolved:
-  # https://github.com/colszowka/simplecov/issues/281
-  gem 'simplecov', '~> 0.7.1', require: false
   # See https://github.com/rails/rails/issues/32955
   gem 'thor', '>= 0.19.0'
 end

--- a/geoblacklight.gemspec
+++ b/geoblacklight.gemspec
@@ -43,4 +43,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'factory_bot_rails'
   spec.add_development_dependency 'database_cleaner', '~> 1.3'
   spec.add_development_dependency 'bixby'
+  spec.add_development_dependency 'coveralls'
+  spec.add_development_dependency 'simplecov'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,24 @@
 ENV['RAILS_ENV'] ||= 'test'
 
+require 'simplecov'
+require 'coveralls'
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(
+  [
+    SimpleCov::Formatter::HTMLFormatter,
+    Coveralls::SimpleCov::Formatter
+  ]
+)
+SimpleCov.start 'rails' do
+  add_filter 'lib/generators/geoblacklight/install_generator.rb'
+  add_filter 'lib/geoblacklight/version.rb'
+  add_filter 'lib/generators/geoblacklight/templates'
+  add_filter '/spec'
+end
+
 require 'factory_bot'
 require 'database_cleaner'
+
 require 'engine_cart'
-require 'coveralls'
-Coveralls.wear!('rails')
 EngineCart.load_application!
 
 require 'rails-controller-testing' if Rails::VERSION::MAJOR >= 5
@@ -23,16 +37,7 @@ Capybara.register_driver(:headless_chrome) do |app|
 end
 
 Capybara.javascript_driver = :headless_chrome
-
 Capybara.default_max_wait_time = 15
-
-if ENV['COVERAGE'] || ENV['CI']
-  require 'simplecov'
-  SimpleCov.formatter = Coveralls::SimpleCov::Formatter
-  SimpleCov.start do
-    add_filter '/spec/'
-  end
-end
 
 require 'geoblacklight'
 


### PR DESCRIPTION
Closes #686 

- Sends coverage data to coveralls when using circle ci.
- Generates coverage documentation on every run of the specs.