### PR TITLE
Uses specific version releases for `simplecov`

### DIFF
--- a/geoblacklight.gemspec
+++ b/geoblacklight.gemspec
@@ -44,5 +44,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'database_cleaner', '~> 1.3'
   spec.add_development_dependency 'bixby'
   spec.add_development_dependency 'coveralls'
-  spec.add_development_dependency 'simplecov'
+  spec.add_development_dependency 'simplecov', '~> 0.16'
 end


### PR DESCRIPTION
Previously, attempting regenerate the app. without a fresh clone did not automatically update `simplecov`, throwing an error relating the following:
```
SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(
  [
    SimpleCov::Formatter::HTMLFormatter,
    Coveralls::SimpleCov::Formatter
  ]
)
```

This is fixed by 