### PR TITLE
675 scss from px to rems

### DIFF
--- a/app/assets/stylesheets/geoblacklight/_styles.scss
+++ b/app/assets/stylesheets/geoblacklight/_styles.scss
@@ -1,4 +1,4 @@
 #table-container{
   overflow:scroll;
-  max-height: 450px;
+  max-height: 28rem;
 }

--- a/app/assets/stylesheets/geoblacklight/modules/downloads.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/downloads.scss
@@ -57,8 +57,8 @@
   .export {
     @include download-export;
 
-    padding-left: 0px;
-    padding-right: 0px;
+    padding-left: 0rem;
+    padding-right: 0rem;
     text-align: center;
     width: 100%;
 
@@ -67,7 +67,7 @@
     }
 
     &-label {
-      padding: 6px 12px;
+      padding: 0.5rem 0.75rem;
 
       @include media-breakpoint-up(xl) {
         display: inline-block;

--- a/app/assets/stylesheets/geoblacklight/modules/facets.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/facets.scss
@@ -1,5 +1,5 @@
 .facet-label .geoblacklight-icon {
   display: inline;
-  padding-left: 10px;
-  padding-right: 15px;
+  padding-left: 0.625rem;
+  padding-right: 1rem;
 }

--- a/app/assets/stylesheets/geoblacklight/modules/geosearch.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/geosearch.scss
@@ -1,7 +1,7 @@
 .search-control {
   background-color: #FFF;
-  border-radius: 4px;
-  box-shadow: 0 1px 5px rgba(0,0,0,0.65);
+  border-radius: 0.25rem;
+  box-shadow: 0 0.0625rem 0.25rem rgba(0,0,0,0.65);
 }
 
 .search-control a {
@@ -9,21 +9,21 @@
 }
 
 .search-control label {
-  margin: 6px 12px;
-  font-size: 14px;
+  margin: 0.5rem 0.75rem;
+  font-size: 0.875rem;
   display: block;
-  padding-left: 15px;
-  text-indent: -15px;
+  padding-left: 1rem;
+  text-indent: -1rem;
   font-weight: normal;
   cursor: pointer;
 }
 
 .search-control input[type="checkbox"] {
-  width: 13px;
-  height: 13px;
+  width: 1rem;
+  height: 1rem;
   padding: 0;
   margin: 0;
   vertical-align: middle;
   position: relative;
-  top: -1px;
+  top: -0.0625rem;
 }

--- a/app/assets/stylesheets/geoblacklight/modules/home.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/home.scss
@@ -8,15 +8,15 @@
 
 #main-container {
   .category-block {
-    min-height: 240px;
+    min-height: 15rem;
 
     .category-icon {
-      font-size: 6em;
+      font-size: 6rem;
     }
   }
 
   [data-map="home"] {
-    height: 400px;
+    height: 25rem;
 
     .leaflet-control-container {
       .search-control {

--- a/app/assets/stylesheets/geoblacklight/modules/icon-customization.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/icon-customization.scss
@@ -2,7 +2,7 @@
 
 .geoblacklight-icon {
   color: $gray-600;
-  font-size: 1.2em;
+  font-size: 1.2rem;
 }
 
 .geoblacklight-stanford {
@@ -15,7 +15,7 @@
 
 .geoblacklight-restricted {
   @extend .fa, .fa-lock, .text-muted;
-  width: 17px;
+  width: 1rem;
 }
 
 .geoblacklight-citation {

--- a/app/assets/stylesheets/geoblacklight/modules/item.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/item.scss
@@ -4,7 +4,7 @@
       @media (min-width: map-get($grid-breakpoints, "md")) {
         dt {
           float: left;
-          width: 160px;
+          width: 10rem;
           clear: left;
           text-align: right;
           overflow: hidden;
@@ -13,7 +13,7 @@
         }
 
         dd {
-          margin-left: 180px;
+          margin-left: 11.25rem;
         }
       }
     }
@@ -21,7 +21,7 @@
 
   #viewer-container {
     [data-map="item"] {
-      height: 440px;
+      height: 27.5rem;
     }
 
     [data-inspect="true"][data-available="true"] {

--- a/app/assets/stylesheets/geoblacklight/modules/layer_opacity.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/layer_opacity.scss
@@ -13,7 +13,7 @@
   .opacity-handle {
     background-color: #fff;
     border-radius: 0.25rem;
-    border: 0.0625rem solid #eee;
+    border: 1px solid #eee;
     cursor: ns-resize;
     font-size: 0.625rem;
     height: 2rem;

--- a/app/assets/stylesheets/geoblacklight/modules/layer_opacity.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/layer_opacity.scss
@@ -1,79 +1,79 @@
 .leaflet-control.opacity-control {
   background-color: #a9acb1;
-  border-radius: 15px;
+  border-radius: 1rem;
   color: black;
-  font: bold 18px 'Lucida Console', Monaco, monospace;
+  font: bold 1.125rem 'Lucida Console', Monaco, monospace;
   display: block;
-  height: 200px;
-  left: 11px;
+  height: 12.5rem;
+  left: 0.5rem;
   position: relative;
-  top: 15px;
-  width: 5px;
-  
+  top: 1rem;
+  width: 0.25rem;
+
   .opacity-handle {
     background-color: #fff;
-    border-radius: 4px;
-    border: 1px solid #eee;
+    border-radius: 0.25rem;
+    border: 0.0625rem solid #eee;
     cursor: ns-resize;
-    font-size: 10px;
-    height: 26px;
-    left: -11px;
-    line-height: 26px;
+    font-size: 0.625rem;
+    height: 2rem;
+    left: -0.6875rem;
+    line-height: 1.5rem;
     position: absolute;
     text-align: center;
     top: 0;
-    width: 26px;
+    width: 1.625rem;
     @include map-control-shadow;
-    
+
     &:hover {
       background-color: #f4f4f4;
     }
   }
-  
+
   .opacity-arrow-up {
     color: #aaa;
     position: absolute;
-    top: -11px;
+    top: -1.5rem;
     text-align: center;
     width: 100%;
-    
+
     &:before {
       content: '=';
-    } 
+    }
   }
-  
+
   .opacity-arrow-down {
-    bottom: -10px;
+    bottom: -1.5rem;
     color: #aaa;
     position: absolute;
     text-align: center;
     width: 100%;
-    
+
     &:before {
       content: '=';
-    }  
+    }
   }
 
   .opacity-bottom {
     background-color: #017afd;
-    border-radius: 15px;
+    border-radius: 1rem;
     display: block;
-    height: 137px;
-    left: 0px;
+    height: 8.5rem;
+    left: 0rem;
     position: relative;
-    top: 63px;
-    width: 5px;  
+    top: 4rem;
+    width: 0.5rem;
   }
-  
+
   // Area underneath slider to prevent unintentioned map clicks
   .opacity-area {
-    padding: 14px;
+    padding: 1rem;
     cursor: default;
-    height: 200px;
-    left: -11px;
+    height: 12.5rem;
+    left: -1.5rem;
     position: absolute;
-    top: 0px;
-    width: 20px;
+    top: 0rem;
+    width: 1.5rem;
   }
 }
 

--- a/app/assets/stylesheets/geoblacklight/modules/metadata.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/metadata.scss
@@ -7,7 +7,7 @@
 
 .metadata-body.modal-body {
   overflow-y: scroll;
-  height: calc(100vh - 190px);
+  height: calc(100vh - 12rem);
 
   .metadata-view {
     .nav-pills {

--- a/app/assets/stylesheets/geoblacklight/modules/metadata_content.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/metadata_content.scss
@@ -3,29 +3,29 @@
  *
  */
 #metadata-container {
-  height: calc(100vh - 260px);
+  height: calc(100vh - 16rem);
 
   ul {
     margin-top: 0;
-    margin-bottom: 10px;
+    margin-bottom: 0.5rem;
     display: inline-block;
     border: 1px solid black;
     background-color: #f5f5f5;
-    padding-right: 40px;
+    padding-right: 2.5rem;
 
     li {
-      margin-top: 6px;
-      margin-bottom: 6px;
+      margin-top: 0.5rem;
+      margin-bottom: 0.5rem;
       list-style-type: decimal;
     }
   }
 
   div dl {
-    padding-right: 8px;
-    padding-left: 8px;
+    padding-right: 0.5rem;
+    padding-left: 0.5rem;
 
     dt {
-      margin-top: 12px;
+      margin-top: 0.5rem;
     }
   }
 
@@ -33,7 +33,7 @@
   * Highest level heading in the attribute tree
   */
   div > dl > dt {
-    font-size: 22px;
+    font-size: 1.375rem;
   }
 
   iframe {

--- a/app/assets/stylesheets/geoblacklight/modules/metadata_markup.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/metadata_markup.scss
@@ -4,6 +4,6 @@
  */
 #metadata-markup-container {
   .alert {
-    margin-top: 20px;
+    margin-top: 1.5rem;
   }
 }

--- a/app/assets/stylesheets/geoblacklight/modules/mixins.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/mixins.scss
@@ -1,5 +1,5 @@
 // Leaflet control box-shadow
 @mixin map-control-shadow {
-  
-  box-shadow: 0 1px 5px rgba(0,0,0,0.65);
+
+  box-shadow: 0 0.0625rem 0.5rem rgba(0,0,0,0.65);
 }

--- a/app/assets/stylesheets/geoblacklight/modules/modal.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/modal.scss
@@ -13,14 +13,14 @@
         .control-label {
           text-align: right;
           margin-bottom: 0;
-          padding-top: 7px;
+          padding-top: 0.5rem;
         }
       }
     }
   }
 
   &-footer {
-    margin-bottom: 8px;
+    margin-bottom: 0.5rem;
     border-top: none;
 
     .btn {

--- a/app/assets/stylesheets/geoblacklight/modules/relations.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/relations.scss
@@ -3,13 +3,13 @@
 
   .list-group {
     .relations-ancestors {
-      padding-left: 16px;
-      padding-right: 16px;
+      padding-left: 1rem;
+      padding-right: 1rem;
     }
 
     .relations-descendants {
-      padding-left: 16px;
-      padding-right: 16px;
+      padding-left: 1rem;
+      padding-right: 1rem;
     }
   }
 }

--- a/app/assets/stylesheets/geoblacklight/modules/results.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/results.scss
@@ -1,10 +1,10 @@
 [data-map="index"] {
-  height: 480px;
+  height: 30rem;
 }
 
 .more-info-area {
   order:3;
-  max-height: 100px;
+  max-height: 6rem;
   overflow:hidden;
 }
 
@@ -37,7 +37,7 @@
 .caret-toggle {
   @extend .fa, .fa-caret-right;
   cursor: pointer;
-  width: 10px;
+  width: 0.625rem;
 
   &.open {
     @extend .fa, .fa-caret-down;

--- a/app/assets/stylesheets/geoblacklight/modules/sidebar.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/sidebar.scss
@@ -2,23 +2,23 @@
 
 @mixin sidebar-children {
   %list-group-item-children {
-    padding: 10px, 15px;
+    padding: 0.5rem, 1rem;
   }
 
   %list-group-item-anchors {
     text-align: center;
-    width: 1.4em;
+    width: 1.4rem;
   }
 
-  margin-top: 16px;
-  margin-bottom: 16px;
+  margin-top: 1rem;
+  margin-bottom: 1rem;
 
   .card-header {
     h2 {
       display: inline-block;
-      padding-top: 8px;
-      padding-bottom: 8px;
-      margin-bottom: 0px;
+      padding-top: 0.5rem;
+      padding-bottom: 0.5rem;
+      margin-bottom: 0rem;
       font-size: 1rem;
     }
   }

--- a/app/assets/stylesheets/geoblacklight/modules/toolbar.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/toolbar.scss
@@ -1,10 +1,10 @@
 %list-group-item-children {
-  padding: 10px, 15px;
+  padding: 0.5rem, 1rem;
 }
 
 %list-group-item-anchors {
   text-align: center;
-  width: 1.4em;
+  width: 1.4rem;
 }
 
 .show-tools {
@@ -18,8 +18,8 @@
         @extend %list-group-item-children;
 
         .checkbox {
-          margin-left: 4px;
-          margin-right: 4px;
+          margin-left: 0.25rem;
+          margin-right: 0.25rem;
 
           label {
             margin-bottom: inherit;
@@ -68,8 +68,8 @@
     }
 
     .downloads {
-      margin-left: 4px;
-      margin-right: 4px;
+      margin-left: 0.25rem;
+      margin-right: 0.25rem;
     }
   }
 }


### PR DESCRIPTION
Following Bootstrap's lead, migrate SCSS files from px to rem. Assuming standard browser 1rem = 16px base.

Vertical spacers (margins/paddings) shifted to 1 or half rem increments (ex. 6px to 0.5rem) to standardize vertical rhythm. Horizontal spacers converted directly from px to rem (ex. 12px to 0.75rem), except where within 1px to base (ex. 15px to 1rem). Hard-coded heights shifted to 16px/per rem closest fit (ex. 450px/16px = 28.125, so 28rem). Odd px counts converted to nearest divisible by 4, cuz' 16 base (ex. 5px to 0.25rem).

This is the initial conversion commit. Some polishing commits to follow.