### PR TITLE
[WIP] Add support for additional schema.org props

### DIFF
--- a/app/views/catalog/_index_split_default.html.erb
+++ b/app/views/catalog/_index_split_default.html.erb
@@ -9,7 +9,7 @@
     <span class="document-counter">
       <%= t('blacklight.search.documents.counter', :counter => counter) if counter %>
     </span>
-    <%= link_to_document document, document_show_link_field(document), counter: counter, title: document[blacklight_config.index.title_field] %>
+    <%= link_to_document document, document_show_link_field(document), counter: counter, title: document[blacklight_config.index.title_field], itemprop: "name" %>
   </h3>
 
   <div class='col-md-12 more-info-area'>
@@ -20,4 +20,3 @@
     </div>
   </div>
 <% end %>
-

--- a/lib/generators/geoblacklight/templates/catalog_controller.rb
+++ b/lib/generators/geoblacklight/templates/catalog_controller.rb
@@ -110,10 +110,10 @@ class CatalogController < ApplicationController
     # config.add_index_field Settings.FIELDS.RIGHTS, :label => 'Access:'
     # # config.add_index_field 'Area', :label => 'Area:'
     # config.add_index_field Settings.FIELDS.SUBJECT, :label => 'Keywords:'
-    config.add_index_field Settings.FIELDS.YEAR
-    config.add_index_field Settings.FIELDS.CREATOR
+    config.add_index_field Settings.FIELDS.YEAR, itemprop: 'temporal'
+    config.add_index_field Settings.FIELDS.CREATOR, itemprop: 'author'
     config.add_index_field Settings.FIELDS.DESCRIPTION, helper_method: :snippit
-    config.add_index_field Settings.FIELDS.PUBLISHER
+    config.add_index_field Settings.FIELDS.PUBLISHER, itemprop: 'publisher'
 
 
 
@@ -127,10 +127,10 @@ class CatalogController < ApplicationController
     config.add_show_field Settings.FIELDS.DESCRIPTION, label: 'Description', itemprop: 'description', helper_method: :render_value_as_truncate_abstract
     config.add_show_field Settings.FIELDS.PUBLISHER, label: 'Publisher', itemprop: 'publisher'
     config.add_show_field Settings.FIELDS.PART_OF, label: 'Collection', itemprop: 'isPartOf'
-    config.add_show_field Settings.FIELDS.SPATIAL_COVERAGE, label: 'Place(s)', itemprop: 'spatial', link_to_search: true
-    config.add_show_field Settings.FIELDS.SUBJECT, label: 'Subject(s)', itemprop: 'keywords', link_to_search: true
+    config.add_show_field Settings.FIELDS.SPATIAL_COVERAGE, label: 'Place(s)', itemprop: 'spatial', link_to_facet: true
+    config.add_show_field Settings.FIELDS.SUBJECT, label: 'Subject(s)', itemprop: 'keywords', link_to_facet: true
     config.add_show_field Settings.FIELDS.TEMPORAL, label: 'Year', itemprop: 'temporal'
-    config.add_show_field Settings.FIELDS.PROVENANCE, label: 'Held by', link_to_search: true
+    config.add_show_field Settings.FIELDS.PROVENANCE, label: 'Held by', link_to_facet: true
 
     # "fielded" search configuration. Used by pulldown among other places.
     # For supported keys in hash, see rdoc for Blacklight::SearchFields
@@ -213,6 +213,16 @@ class CatalogController < ApplicationController
     # mean") suggestion is offered.
     config.spell_max = 5
 
+    # Nav actions from Blacklight
+    config.add_nav_action(:bookmark, partial: 'blacklight/nav/bookmark', if: :render_bookmarks_control?)
+    config.add_nav_action(:search_history, partial: 'blacklight/nav/search_history')
+
+    # Tools from Blacklight
+    config.add_results_collection_tool(:sort_widget)
+    config.add_results_collection_tool(:per_page_widget)
+    config.add_show_tools_partial(:bookmark, partial: 'bookmark_control', if: :render_bookmarks_control?)
+    config.add_show_tools_partial(:email, callback: :email_action, validator: :validate_email_params)
+
     # Custom tools for GeoBlacklight
     config.add_show_tools_partial :web_services, if: proc { |_context, _config, options| options[:document] && (Settings.WEBSERVICES_SHOWN & options[:document].references.refs.map(&:type).map(&:to_s)).any? }
     config.add_show_tools_partial :metadata, if: proc { |_context, _config, options| options[:document] && (Settings.METADATA_SHOWN & options[:document].references.refs.map(&:type).map(&:to_s)).any? }
@@ -228,8 +238,8 @@ class CatalogController < ApplicationController
     # 'worldAntique'
     # 'worldEco'
     # 'flatBlue'
-    # 'midnightCommander' 
-    
+    # 'midnightCommander'
+
     config.basemap_provider = 'positron'
 
     # Configuration for autocomplete suggestor

--- a/spec/features/split_view.html.erb_spec.rb
+++ b/spec/features/split_view.html.erb_spec.rb
@@ -64,4 +64,17 @@ feature 'Index view', js: true do
       expect(page).to have_css 'span.filterName', text: 'Bounding Box'
     end
   end
+
+  scenario 'should have schema.org props listed' do
+    visit search_catalog_path(f: { Settings.FIELDS.PROVENANCE => ['Stanford'] })
+    within '#documents' do
+      expect(page).to have_selector("a[itemprop='name']")
+      within('.documentHeader', match: :first) do
+        find('.caret-toggle').click
+        expect(page).to have_selector("span[itemprop='temporal']")
+        expect(page).to have_selector("span[itemprop='author']")
+        expect(page).to have_selector("span[itemprop='publisher']")
+      end
+    end
+  end
 end


### PR DESCRIPTION
Partially addresses #317

Adds name, temporal, author, and publisher to search results following the GBL/BL show page itemprop pattern. Needs further discussion to determine the correct set of props to include before closing this issue.

Some BL/GBL helpers, like snippit, should be refactored to wrap semantic itemprops around field data.  