### PR TITLE
use bootstrap styles instead of custom scss + heading levels

### DIFF
--- a/app/assets/stylesheets/geoblacklight/modules/downloads.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/downloads.scss
@@ -25,7 +25,7 @@
   @extend %downloads-exports;
 
   .panel-heading {
-    h2 {
+    h3 {
       display: inline;
     }
 

--- a/app/assets/stylesheets/geoblacklight/modules/downloads.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/downloads.scss
@@ -9,15 +9,6 @@
   &-link {
     &-container {
       padding: 4px 15px;
-      text-align: center;
-
-      a {
-        width: 100%;
-        font-weight: 600;
-        background-color: $link-color;
-        color: #ffffff;
-        border-color: darken($link-color, 6.5%);
-      }
     }
   }
 }

--- a/app/helpers/geoblacklight_helper.rb
+++ b/app/helpers/geoblacklight_helper.rb
@@ -27,7 +27,7 @@ module GeoblacklightHelper
       text,
       document.direct_download[:download],
       'contentUrl' => document.direct_download[:download],
-      class: ['btn', 'btn-default', 'download', 'download-original'],
+      class: ['btn', 'btn-primary', 'btn-block', 'download', 'download-original'],
       data: {
         download: 'trigger',
         download_type: 'direct',
@@ -40,7 +40,7 @@ module GeoblacklightHelper
     link_to(
       text,
       download_hgl_path(id: document),
-      class: ['btn', 'btn-default', 'download', 'download-original'],
+      class: ['btn', 'btn-primary', 'btn-block', 'download', 'download-original'],
       data: {
         ajax_modal: 'trigger',
         download: 'trigger',
@@ -57,7 +57,7 @@ module GeoblacklightHelper
       download_text('JPG'),
       iiif_jpg_url,
       'contentUrl' => iiif_jpg_url,
-      class: ['btn', 'btn-default', 'download', 'download-generated'],
+      class: ['btn', 'btn-primary', 'btn-block', 'download', 'download-generated'],
       data: {
         download: 'trigger'
       }
@@ -68,7 +68,7 @@ module GeoblacklightHelper
     link_to(
       t('geoblacklight.download.export_link', download_format: proper_case_format(download_type)),
       '',
-      class: ['btn', 'btn-default', 'download', 'download-generated'],
+      class: ['btn', 'btn-primary', 'btn-block', 'download', 'download-generated'],
       data: {
         download_path: download_path(document.id, type: download_type),
         download: 'trigger',

--- a/app/views/catalog/_show_downloads.html.erb
+++ b/app/views/catalog/_show_downloads.html.erb
@@ -4,7 +4,7 @@
   <% if document.direct_download.present? || document.hgl_download.present? || document.iiif_download.present? %>
     <div class="panel panel-default downloads">
       <div class="panel-heading">
-        <h2 class="mb-0 h6"><%= t('geoblacklight.download.download').pluralize %></h2>
+        <h3 class="h5"><%= t('geoblacklight.download.download').pluralize %></h3>
       </div>
 
       <ul class="list-group list-group-flush">
@@ -16,7 +16,7 @@
   <% if document.download_types.present? %>
     <div class="panel panel-default exports">
       <div class="panel-heading">
-        <h2 class="mb-0 h6"><%= t('geoblacklight.download.export_formats') %></h2>
+        <h3 class="h5"><%= t('geoblacklight.download.export_formats') %></h3>
       </div>
 
       <ul class="list-group list-group-flush">

--- a/spec/features/download_layer_spec.rb
+++ b/spec/features/download_layer_spec.rb
@@ -63,9 +63,9 @@ feature 'Download layer' do
   scenario 'layer with direct download and wms/wfs should include all download types' do
     sign_in
     visit solr_document_path('stanford-cg357zz0321')
-    expect(page).to have_css 'h2', text: 'Downloads'
+    expect(page).to have_css 'h3', text: 'Downloads'
     expect(page).to have_css 'a', text: 'Original Shapefile'
-    expect(page).to have_css 'h2', text: 'Export Formats'
+    expect(page).to have_css 'h3', text: 'Export Formats'
     expect(page).to have_css 'a', text: 'Export'
   end
   scenario 'clicking GeoTIFF button for Harvard layer should show email form', js: true do

--- a/spec/features/download_layer_spec.rb
+++ b/spec/features/download_layer_spec.rb
@@ -42,7 +42,7 @@ feature 'Download layer' do
   end
   scenario 'clicking jpg download button should redirect to external image' do
     visit solr_document_path('princeton-02870w62c')
-    expect(page).to have_css("a.btn.btn-default[href='https://libimages.princeton.edu/loris/pudl0076/map_pownall/00000001.jp2/full/full/0/default.jpg']", text: 'Original JPG')
+    expect(page).to have_css("a.btn.btn-primary[href='https://libimages.princeton.edu/loris/pudl0076/map_pownall/00000001.jp2/full/full/0/default.jpg']", text: 'Original JPG')
   end
   scenario 'options should be available under toggle' do
     visit solr_document_path('mit-f6rqs4ucovjk2')

--- a/spec/helpers/geoblacklight_helper_spec.rb
+++ b/spec/helpers/geoblacklight_helper_spec.rb
@@ -82,7 +82,7 @@ describe GeoblacklightHelper, type: :helper do
       allow_any_instance_of(Geoblacklight::Reference).to receive(:to_hash).and_return(download: 'http://example.com/urn:hul.harvard.edu:HARVARD.SDE2.TG10USAIANNH/data.zip')
     end
     it 'generates a link to download the original file' do
-      expect(download_link_direct(text, document)).to eq '<a contentUrl="http://example.com/urn:hul.harvard.edu:HARVARD.SDE2.TG10USAIANNH/data.zip" class="btn btn-default download download-original" data-download="trigger" data-download-type="direct" href="http://example.com/urn:hul.harvard.edu:HARVARD.SDE2.TG10USAIANNH/data.zip">Test Link Text</a>'
+      expect(download_link_direct(text, document)).to eq '<a contentUrl="http://example.com/urn:hul.harvard.edu:HARVARD.SDE2.TG10USAIANNH/data.zip" class="btn btn-primary btn-block download download-original" data-download="trigger" data-download-type="direct" href="http://example.com/urn:hul.harvard.edu:HARVARD.SDE2.TG10USAIANNH/data.zip">Test Link Text</a>'
     end
   end
 
@@ -96,7 +96,7 @@ describe GeoblacklightHelper, type: :helper do
     end
 
     it 'generates a link to the HGL route' do
-      expect(download_link_hgl(text, document)).to eq '<a class="btn btn-default download download-original" data-ajax-modal="trigger" data-download="trigger" data-download-type="harvard-hgl" data-download-id="test-id" href="/download/hgl/test-id">Test Link Text</a>'
+      expect(download_link_hgl(text, document)).to eq '<a class="btn btn-primary btn-block download download-original" data-ajax-modal="trigger" data-download="trigger" data-download-type="harvard-hgl" data-download-id="test-id" href="/download/hgl/test-id">Test Link Text</a>'
     end
   end
 
@@ -117,7 +117,7 @@ describe GeoblacklightHelper, type: :helper do
 
     it 'generates a link to download the JPG file from the IIIF server' do
       assign(:document, document)
-      expect(helper.download_link_iiif).to eq '<a contentUrl="https://example.edu/image/full/full/0/default.jpg" class="btn btn-default download download-generated" data-download="trigger" href="https://example.edu/image/full/full/0/default.jpg">Original JPG</a>'
+      expect(helper.download_link_iiif).to eq '<a contentUrl="https://example.edu/image/full/full/0/default.jpg" class="btn btn-primary btn-block download download-generated" data-download="trigger" href="https://example.edu/image/full/full/0/default.jpg">Original JPG</a>'
     end
   end
 
@@ -131,7 +131,7 @@ describe GeoblacklightHelper, type: :helper do
     end
 
     it 'generates a link to download the JPG file from the IIIF server' do
-      expect(download_link_generated(download_type, document)).to eq '<a class="btn btn-default download download-generated" data-download-path="/download/test-id?type=SHAPEFILE" data-download="trigger" data-download-type="SHAPEFILE" data-download-id="test-id" href="">Export</a>'
+      expect(download_link_generated(download_type, document)).to eq '<a class="btn btn-primary btn-block download download-generated" data-download-path="/download/test-id?type=SHAPEFILE" data-download="trigger" data-download-type="SHAPEFILE" data-download-id="test-id" href="">Export</a>'
     end
   end
 


### PR DESCRIPTION
When trying to update to v1.9.0 i found myself having to override some of the scss. I wonder if using some of these default classes can help us prevent that. @jrgriffiniii what do you think?

Also updates the heading levels for accessibility compliance.

![screen shot 2018-08-07 at 10 09 00 am](https://user-images.githubusercontent.com/1656824/43788143-f0fb7fd6-9a29-11e8-8646-f5ee6095571b.png)
![screen shot 2018-08-07 at 10 08 28 am](https://user-images.githubusercontent.com/1656824/43788144-f119dbe8-9a29-11e8-953a-33f53640b764.png)
