### PR TITLE
Bug Fix: modify DynamicMapLayer calls to support layer specific argument

### DIFF
--- a/app/assets/javascripts/geoblacklight/viewers/esri/dynamic_map_layer.js
+++ b/app/assets/javascripts/geoblacklight/viewers/esri/dynamic_map_layer.js
@@ -63,18 +63,18 @@ GeoBlacklight.Viewer.DynamicMapLayer = GeoBlacklight.Viewer.Esri.extend({
           url: layer.options.url,
           useCors: true
       })
-        .tolerance(0)
+        .tolerance(2)
         .returnGeometry(false)
         .on(_this.map)
         .at(e.latlng);
 
       // query specific layer if dynamicLayerId is set
       if (_this.dynamicLayerId) {
-        identify.layers('ID: ' + _this.dynamicLayerId);
+        identify.layers('all: ' + _this.dynamicLayerId);
       }
 
       identify.run(function(error, featureCollection, response){
-        if (error) {
+        if (error || response['results'] < 1) {
           _this.appendErrorMessage();
         } else {
           _this.populateAttributeTable(featureCollection.features[0]);


### PR DESCRIPTION
Fixes #715 - New specific layer argument format fixes zero-result javascript errors. Out of map layer area map clicks will now also return the "Could not find that feature" message instead of a zero-result error. Bumping the default tolerance to 2 helps return results from very small layer markers.

Not adding or modifying tests here, as our test suite has very little coverage for our ESRI viewers. Rather, we should solve that problem elsewhere.