### PR TITLE
Ensures that JSON representations of Solr Documents can be retrieved

### DIFF
--- a/lib/generators/geoblacklight/templates/catalog_controller.rb
+++ b/lib/generators/geoblacklight/templates/catalog_controller.rb
@@ -6,6 +6,12 @@ class CatalogController < ApplicationController
   include Blacklight::Catalog
 
   configure_blacklight do |config|
+
+    # Ensures that JSON representations of Solr Documents can be retrieved using
+    # the path /catalog/:id/raw
+    # Please see https://github.com/projectblacklight/blacklight/pull/2006/
+    config.raw_endpoint.enabled = true
+
     ## Default parameters to send to solr for all search-like requests. See also SolrHelper#solr_search_params
     ## @see https://lucene.apache.org/solr/guide/6_6/common-query-parameters.html
     ## @see https://lucene.apache.org/solr/guide/6_6/the-dismax-query-parser.html#TheDisMaxQueryParser-Theq.altParameter
@@ -25,6 +31,7 @@ class CatalogController < ApplicationController
      :qt => 'document',
      :q => '{!raw f=layer_slug_s v=$id}'
     }
+
 
     # solr field configuration for search results/index views
     # config.index.show_link = 'title_display'

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -63,4 +63,20 @@ describe CatalogController, type: :controller do
       end
     end
   end
+
+  describe '#raw' do
+    it 'returns a JSON representation of a Solr Document' do
+      get :raw, params: { id: 'tufts-cambridgegrid100-04' }
+      expect(response.status).to eq 200
+      expect(response.body).not_to be_empty
+      response_values = JSON.parse(response.body)
+      expect(response_values).to include 'geoblacklight_version' => '1.0'
+      expect(response_values).to include 'dc_title_s' => '100 Foot Grid Cambridge MA 2004'
+      expect(response_values).to include 'dc_identifier_s' => 'urn:geodata.tufts.edu:Tufts.CambridgeGrid100_04'
+      expect(response_values).to include 'dc_rights_s' => 'Public'
+      expect(response_values).to include 'dct_provenance_s' => 'Tufts'
+      expect(response_values).to include 'layer_slug_s' => 'tufts-cambridgegrid100-04'
+      expect(response_values).to include 'solr_geom' => 'ENVELOPE(-71.163984, -71.052581, 42.408316, 42.34757)'
+    end
+  end
 end


### PR DESCRIPTION
Resolves #711, but I believe that the update to `CatalogController` will likely need to be added manually for existing adopters.  I can add this to the Wiki following https://github.com/geoblacklight/geoblacklight/wiki/GeoBlacklight-1.0-Upgrade-Guide as an example.