### PR TITLE
Ensures that the SMS tool link is rendered by default

### DIFF
--- a/lib/generators/geoblacklight/templates/catalog_controller.rb
+++ b/lib/generators/geoblacklight/templates/catalog_controller.rb
@@ -239,6 +239,7 @@ class CatalogController < ApplicationController
     config.add_results_collection_tool(:per_page_widget)
     config.add_show_tools_partial(:bookmark, partial: 'bookmark_control', if: :render_bookmarks_control?)
     config.add_show_tools_partial(:email, callback: :email_action, validator: :validate_email_params)
+    config.add_show_tools_partial(:sms, if: :render_sms_action?, callback: :sms_action, validator: :validate_sms_params)
 
     # Custom tools for GeoBlacklight
     config.add_show_tools_partial :web_services, if: proc { |_context, _config, options| options[:document] && (Settings.WEBSERVICES_SHOWN & options[:document].references.refs.map(&:type).map(&:to_s)).any? }

--- a/spec/features/sms_spec.rb
+++ b/spec/features/sms_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+feature 'SMS tool', js: true do
+  scenario 'shows up in tools' do
+    visit solr_document_path 'stanford-cg357zz0321'
+    expect(page).to have_css 'li.sms a', text: 'SMS This'
+    click_link 'SMS This'
+    within '.modal-body' do
+      expect(page).to have_css 'input', count: 1
+      expect(page).to have_css 'label', text: 'Phone Number:'
+      expect(page).to have_css 'select', count: 1
+      expect(page).to have_css 'label', text: 'Carrier'
+    end
+  end
+end


### PR DESCRIPTION
Resolves #734 .  Please see the following screenshots:

<img width="1020" alt="geoblacklight_issues_734_screenshot_0" src="https://user-images.githubusercontent.com/1443986/51705808-9db1e300-1fea-11e9-9434-c18863373997.png">
<img width="848" alt="geoblacklight_issues_734_screenshot_1" src="https://user-images.githubusercontent.com/1443986/51705813-a0143d00-1fea-11e9-9a05-922ec340c79d.png">
