### PR TITLE
Remove I18n call in catalog_controller.rb

### DIFF
--- a/lib/generators/geoblacklight/templates/catalog_controller.rb
+++ b/lib/generators/geoblacklight/templates/catalog_controller.rb
@@ -143,7 +143,7 @@ class CatalogController < ApplicationController
     config.add_show_field Settings.FIELDS.PROVENANCE, label: 'Held by', link_to_facet: true
     config.add_show_field(
       Settings.FIELDS.REFERENCES,
-      label: I18n.t('geoblacklight.metadata.more_details'),
+      label: 'More details at',
       accessor: [:external_url],
       if: proc { |_, _, doc| doc.external_url },
       helper_method: :render_references_url
@@ -256,8 +256,8 @@ class CatalogController < ApplicationController
     # 'worldAntique'
     # 'worldEco'
     # 'flatBlue'
-    # 'midnightCommander' 
-    
+    # 'midnightCommander'
+
     config.basemap_provider = 'positron'
 
     # Configuration for autocomplete suggestor


### PR DESCRIPTION
Putting translations directly into catalog_controller results in the translation not being loaded upon server startup. Our "More details at" field label is the only one using I18n in the catalog_controller. All of the other labels within that file are just written directly into it: "Author(s)", "Description", etc.

In Blacklight and GeoBlacklight catalog_controller.rb files I18n translations are not used at all. Removing this sole I18n call to follow common behavior for now.

Fixes: #736