### PR TITLE
Add field to solr document that indicates if a record should be suppressed

### DIFF
--- a/app/models/concerns/geoblacklight/spatial_search_behavior.rb
+++ b/app/models/concerns/geoblacklight/spatial_search_behavior.rb
@@ -3,7 +3,7 @@ module Geoblacklight
     extend ActiveSupport::Concern
 
     included do
-      self.default_processor_chain += [:add_spatial_params]
+      self.default_processor_chain += [:add_spatial_params, :hide_suppressed_records]
     end
 
     ##
@@ -42,6 +42,17 @@ module Geoblacklight
     # @return [Geoblacklight::BoundingBox]
     def bounding_box
       Geoblacklight::BoundingBox.from_rectangle(blacklight_params[:bbox])
+    end
+
+    ##
+    # Hide suppressed records in search
+    # @param [Blacklight::Solr::Request]
+    # @return [Blacklight::Solr::Request]
+    def hide_suppressed_records(solr_params)
+      # Show child records if searching for a specific source parent
+      return unless blacklight_params.fetch(:f, {})[Settings.FIELDS.SOURCE.to_sym].nil?
+      solr_params[:fq] ||= []
+      solr_params[:fq] << '-suppressed_b: true'
     end
   end
 end

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+feature 'Search' do
+  scenario 'Suppressed records are hidden' do
+    visit '/?q=Sanborn+Map+Company'
+    expect(page).to have_css '.document', count: 1
+  end
+
+  scenario 'When searching child records from a parent record, supressed records are not hidden' do
+    visit '/?f[dc_source_sm][]=princeton-1r66j405w&q='
+    expect(page).to have_css '.document', count: 2
+  end
+end

--- a/spec/fixtures/solr_documents/README.md
+++ b/spec/fixtures/solr_documents/README.md
@@ -26,6 +26,9 @@ If you add a new document, please add it to the table below, and indicate its pu
 | index_map_polygon-no-downloadurl.json | GeoJSON index map of polygons, but lacking a downloadUrl for the index itself |
 | index-map-stanford.json | old-style (pre-GeoJSON) index map of rectangular polygons |
 | no_spatial.json |  |
+| princeton-child1.json | Child record for testing the `suppressed_b` property |
+| princeton-child2.json | Child record for testing the `suppressed_b` property |
+| princeton-parent.json | Parent record for testing the `suppressed_b` property |
 | public_direct_download.json | includes a tentative `dcat_distribution_sm` property |
 | public_iiif_princeton.json |  |
 | public_polygon_mit.json |  |

--- a/spec/fixtures/solr_documents/princeton-child1.json
+++ b/spec/fixtures/solr_documents/princeton-child1.json
@@ -1,0 +1,30 @@
+{
+    "call_number_s": "HMC04 (Princeton)",
+    "dc_creator_sm": [
+        "Sanborn Map Company"
+    ],
+    "dc_description_s": "Title taken from sheet 1 of 1927 map. \"Feb. 1885.\" Includes location map and key. Oriented with the north to the upper left.",
+    "dc_format_s": "TIFF",
+    "dc_identifier_s": "ark:/88435/n009w382v",
+    "dc_language_s": "eng",
+    "dc_publisher_s": "New York : Sanborn Map & Publishing Co., Limited, 1885.",
+    "dc_rights_s": "Public",
+    "dc_subject_sm": [
+        "Real property-New Jersey-Princeton-Maps",
+        "Princeton (N.J.)-Maps"
+    ],
+    "dc_title_s": "Princeton, Mercer County, New Jersey (Sheet 1)",
+    "dct_provenance_s": "Princeton",
+    "dct_references_s": "{\"http://schema.org/url\":\"https://catalog.princeton.edu/catalog/4266648\",\"http://schema.org/downloadUrl\":\"https://figgy.princeton.edu/downloads/b6ba3091-fcf4-4d2d-9d6a-df7df5c8c588/file/ff89fcc8-e61b-4b27-938f-a03e63d4f5f1\",\"http://schema.org/thumbnailUrl\":\"https://figgy.princeton.edu/downloads/b6ba3091-fcf4-4d2d-9d6a-df7df5c8c588/file/0cb6b6c7-bce2-46a8-8c79-2864c7ec5459\",\"http://iiif.io/api/image\":\"https://libimages1.princeton.edu/loris/figgy_prod/5a%2F20%2F58%2F5a20585db50d44959fe5ae44821fd174%2Fintermediate_file.jp2/info.json\",\"http://iiif.io/api/presentation#manifest\":\"https://figgy.princeton.edu/concern/scanned_maps/2806e4cf-effc-4827-b116-952dfe776d14/manifest\"}",
+    "dc_source_sm": [
+        "princeton-1r66j405w"
+    ],
+    "geoblacklight_version": "1.0",
+    "layer_geom_type_s": "Image",
+    "layer_id_s": "public-figgy:p-b6ba3091-fcf4-4d2d-9d6a-df7df5c8c588",
+    "layer_modified_dt": "2018-06-20T22:23:54Z",
+    "layer_slug_s": "princeton-n009w382v",
+    "solr_geom": "ENVELOPE(-74.68, -74.63, 40.37, 40.33)",
+    "suppressed_b": true,
+    "uuid": "princeton-n009w382v"
+}

--- a/spec/fixtures/solr_documents/princeton-child2.json
+++ b/spec/fixtures/solr_documents/princeton-child2.json
@@ -1,0 +1,30 @@
+{
+    "call_number_s": "HMC04 (Princeton)",
+    "dc_creator_sm": [
+        "Sanborn Map Company"
+    ],
+    "dc_description_s": "Title taken from sheet 1 of 1927 map. \"Feb. 1885.\" Includes location map and key. Oriented with the north to the upper left.",
+    "dc_format_s": "TIFF",
+    "dc_identifier_s": "ark:/88435/jq085m62x",
+    "dc_language_s": "eng",
+    "dc_publisher_s": "New York : Sanborn Map & Publishing Co., Limited, 1885.",
+    "dc_rights_s": "Public",
+    "dc_subject_sm": [
+        "Real property-New Jersey-Princeton-Maps",
+        "Princeton (N.J.)-Maps"
+    ],
+    "dc_title_s": "Princeton, Mercer County, New Jersey (Sheet 2)",
+    "dct_provenance_s": "Princeton",
+    "dct_references_s": "{\"http://schema.org/url\":\"https://catalog.princeton.edu/catalog/4266648\",\"http://schema.org/downloadUrl\":\"https://figgy.princeton.edu/downloads/db890be9-02bf-43c1-85c8-69c0684e25f6/file/dc08e083-5044-4949-bdd1-9d16a1fef818\",\"http://schema.org/thumbnailUrl\":\"https://figgy.princeton.edu/downloads/db890be9-02bf-43c1-85c8-69c0684e25f6/file/342e2f50-c9ff-4f86-9317-f5ce331e766e\",\"http://iiif.io/api/image\":\"https://libimages1.princeton.edu/loris/figgy_prod/a6%2Fb9%2Ff9%2Fa6b9f96251724546ae37ea3fa37a5e57%2Fintermediate_file.jp2/info.json\",\"http://iiif.io/api/presentation#manifest\":\"https://figgy.princeton.edu/concern/scanned_maps/68e90289-74ce-4f21-89e5-852f3e96ce35/manifest\"}",
+    "dc_source_sm": [
+        "princeton-1r66j405w"
+    ],
+    "geoblacklight_version": "1.0",
+    "layer_geom_type_s": "Image",
+    "layer_id_s": "public-figgy:p-db890be9-02bf-43c1-85c8-69c0684e25f6",
+    "layer_modified_dt": "2018-06-20T22:24:29Z",
+    "layer_slug_s": "princeton-jq085m62x",
+    "solr_geom": "ENVELOPE(-74.68, -74.63, 40.37, 40.33)",
+    "suppressed_b": true,
+    "uuid": "princeton-jq085m62x"
+}

--- a/spec/fixtures/solr_documents/princeton-parent.json
+++ b/spec/fixtures/solr_documents/princeton-parent.json
@@ -1,0 +1,25 @@
+{
+    "call_number_s": "HMC04 (Princeton)",
+    "dc_creator_sm": [
+        "Sanborn Map Company"
+    ],
+    "dc_description_s": "Title taken from sheet 1 of 1927 map. \"Feb. 1885.\" Includes location map and key. Oriented with the north to the upper left.",
+    "dc_identifier_s": "ark:/88435/1r66j405w",
+    "dc_language_s": "eng",
+    "dc_publisher_s": "New York : Sanborn Map & Publishing Co., Limited, 1885.",
+    "dc_rights_s": "Public",
+    "dc_subject_sm": [
+        "Real property-New Jersey-Princeton-Maps",
+        "Princeton (N.J.)-Maps"
+    ],
+    "dc_title_s": "Princeton, Mercer County, New Jersey",
+    "dct_provenance_s": "Princeton",
+    "dct_references_s": "{\"http://schema.org/url\":\"https://catalog.princeton.edu/catalog/4266648\",\"http://schema.org/thumbnailUrl\":\"https://figgy.princeton.edu/downloads/b6ba3091-fcf4-4d2d-9d6a-df7df5c8c588/file/0cb6b6c7-bce2-46a8-8c79-2864c7ec5459\",\"http://iiif.io/api/image\":\"https://libimages1.princeton.edu/loris/figgy_prod/5a%2F20%2F58%2F5a20585db50d44959fe5ae44821fd174%2Fintermediate_file.jp2/info.json\",\"http://iiif.io/api/presentation#manifest\":\"https://figgy.princeton.edu/concern/scanned_maps/9a193476-5f2e-4f82-95a5-6db472e39b7b/manifest\"}",
+    "geoblacklight_version": "1.0",
+    "layer_geom_type_s": "Image",
+    "layer_id_s": "ark:/88435/1r66j405w",
+    "layer_modified_dt": "2018-06-07T05:12:50Z",
+    "layer_slug_s": "princeton-1r66j405w",
+    "solr_geom": "ENVELOPE(-74.68, -74.63, 40.37, 40.33)",
+    "uuid": "princeton-1r66j405w"
+}


### PR DESCRIPTION
Adds the `suppressed_b` field to the solr doc to indicate if a record should be suppressed in the search.

Closes #737 