### PR TITLE
Issue 324 bboxrelevancy

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -41,6 +41,7 @@ Metrics/LineLength:
   - 'Rakefile'
   - 'lib/generators/geoblacklight/install_generator.rb'
   - 'lib/tasks/geoblacklight.rake'
+  - 'app/models/concerns/geoblacklight/spatial_search_behavior.rb'
 
 Metrics/MethodLength:
   Max: 16

--- a/app/models/concerns/geoblacklight/spatial_search_behavior.rb
+++ b/app/models/concerns/geoblacklight/spatial_search_behavior.rb
@@ -18,6 +18,12 @@ module Geoblacklight
         solr_params[:bq] << "#{Settings.FIELDS.GEOMETRY}:\"IsWithin(#{envelope_bounds})\"#{boost}"
         solr_params[:fq] ||= []
         solr_params[:fq] << "#{Settings.FIELDS.GEOMETRY}:\"Intersects(#{envelope_bounds})\""
+
+        if Settings.OVERLAP_RATIO_BOOST
+          solr_params[:overlap] =
+            "{!field uf=* defType=lucene f=solr_bboxtype score=overlapRatio}Intersects(#{envelope_bounds})"
+          solr_params[:bf] = "$overlap^#{Settings.OVERLAP_RATIO_BOOST}"
+        end
       end
       solr_params
     rescue Geoblacklight::Exceptions::WrongBoundingBoxFormat

--- a/lib/generators/geoblacklight/templates/settings.yml
+++ b/lib/generators/geoblacklight/templates/settings.yml
@@ -13,6 +13,9 @@ GEOMETRY_FIELD: 'solr_geom'
 # The bq boost value for spatial search matches within a bounding box
 BBOX_WITHIN_BOOST: '10'
 
+# The bf boost value for overlap ratio
+OVERLAP_RATIO_BOOST: '2'
+
 # Solr field mappings
 FIELDS:
   :FILE_FORMAT: 'dc_format_s'

--- a/solr/conf/core.properties
+++ b/solr/conf/core.properties
@@ -1,0 +1,5 @@
+#Written by CorePropertiesLocator
+#name=geoblacklight #Change the name to the appropriate one you would like to use
+config=solrconfig.xml
+schema=schema.xml
+#dataDir=geodata #Change this directory to the appropriate one you would like to use

--- a/solr/conf/schema.xml
+++ b/solr/conf/schema.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<schema name="geoblacklight-schema" version="1.6">
+<schema name="geoblacklight-schema" version="1.7">
   <uniqueKey>layer_slug_s</uniqueKey>
   <fields>
     <field name="_version_" type="long"   stored="true" indexed="true"/>
@@ -64,6 +64,8 @@
     <dynamicField name="*_pt"   type="location"     stored="true" indexed="true"/>
     <dynamicField name="*_bbox" type="location_rpt" stored="true" indexed="true"/><!-- deprecated -->
     <dynamicField name="*_geom" type="location_rpt" stored="true" indexed="true"/>
+    <dynamicField name="*_bboxtype" type="bbox" stored="true" indexed="true"/>
+
   </fields>
 
   <types>
@@ -144,6 +146,11 @@
 
     <fieldType name="location_rpt" class="solr.SpatialRecursivePrefixTreeFieldType"
                geo="true" distErrPct="0.025" maxDistErr="0.001" distanceUnits="kilometers"/>
+    <!-- Adding field type for bboxField that enables, among other things, overlap ratio calculations -->
+    <fieldType name="bbox" class="solr.BBoxField"
+           geo="true" distanceUnits="kilometers" numberType="pdouble" />
+    <fieldType name="pdouble" class="solr.DoublePointField" docValues="true"/>   
+   
 
   </types>
 
@@ -187,4 +194,7 @@
   <copyField source="dct_provenance_s" dest="suggest"/>
   <copyField source="dc_subject_sm" dest="suggest"/>
   <copyField source="dct_spatial_sm" dest="suggest"/>
+  
+  <!-- for bbox value -->
+  <copyField source="solr_geom" dest="solr_bboxtype"/>
 </schema>

--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -27,7 +27,7 @@
        that you fully re-index after changing this setting as it can
        affect both how text is indexed and queried.
   -->
-  <luceneMatchVersion>6.1</luceneMatchVersion>
+  <luceneMatchVersion>7.6</luceneMatchVersion>
   
   <lib dir="${solr.install.dir:../../../..}/contrib/analysis-extras/lib" />
   <lib dir="${solr.install.dir:../../../..}/contrib/analysis-extras/lucene-libs" />

--- a/spec/features/search_results_overlap_ratio_spec.rb
+++ b/spec/features/search_results_overlap_ratio_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+
+feature 'spatial search results overlap ratio' do
+  scenario 'result bboxes fully contained, overlap ratio applied to relevancy' do
+    allow(Settings).to receive(:OVERLAP_RATIO_BOOST).and_return 200
+
+    # BBox param is the US upper midwest and Canada, roughly centered on the state of Minnesota
+    visit search_catalog_path(
+      bbox: '-103.196521 39.21962 -84.431873 53.63497',
+      'f[dct_provenance_s][]': 'Minnesota'
+    )
+
+    # MN State result
+    # Slightly bigger bbox / result bbox fits bbox param best
+    expect(position_in_result_page(page, 'e9c71086-6b25-4950-8e1c-84c2794e3382')).to eq 1
+
+    # MN State result
+    # Slightly smaller bbox / result bbox fits bbox param second best
+    expect(position_in_result_page(page, '2eddde2f-c222-41ca-bd07-2fd74a21f4de')).to eq 2
+
+    # TC Metro result
+    # Smaller bbox / result bbox fits bbox param third
+    expect(position_in_result_page(page, '02236876-9c21-42f6-9870-d2562da8e44f')).to eq 3
+  end
+
+  scenario 'three bboxes overlap, but none are fully contained, overlap ratio should still impact relevancy' do
+    allow(Settings).to receive(:OVERLAP_RATIO_BOOST).and_return 200
+
+    # BBox param is the center to western edge of New York state and Canada, roughly centered on Lake Ontario
+    visit search_catalog_path(
+      bbox: '-83.750499 40.41709 -74.368175 47.963663',
+      'f[dct_provenance_s][]': 'Cornell'
+    )
+
+    # NY State result
+    # Bigger bbox / result bbox overlaps bbox param best
+    expect(position_in_result_page(page, 'cugir-008186')).to be < 3
+
+    # NY State result
+    # Bigger bbox / result bbox overlaps bbox param best (score tie)
+    expect(position_in_result_page(page, 'cugir-008186-no-downloadurl')).to be < 3
+
+    # NY Adirondak Region result
+    # Smaller bbox / result bbox overlaps bbox param the least
+    expect(position_in_result_page(page, 'cugir-007741')).to eq 3
+  end
+end
+
+def position_in_result_page(page, id)
+  results = []
+  page.all('div.documentHeader.row').each do |div|
+    results << div['data-layer-id']
+  end
+  results.index(id) + 1
+end

--- a/spec/models/concerns/geoblacklight/spatial_search_behavior_spec.rb
+++ b/spec/models/concerns/geoblacklight/spatial_search_behavior_spec.rb
@@ -43,6 +43,16 @@ describe Geoblacklight::SpatialSearchBehavior do
         expect(subject.add_spatial_params(solr_params)[:bq].to_s).to include('^10')
       end
 
+      it 'applies overlapRatio when Settings.OVERLAP_RATIO_BOOST is configured' do
+        allow(Settings).to receive(:OVERLAP_RATIO_BOOST).and_return 2
+        expect(subject.add_spatial_params(solr_params)[:bf].to_s).to include('$overlap^2')
+      end
+
+      it 'does not apply overlapRatio when Settings.OVERLAP_RATIO_BOOST not configured' do
+        allow(Settings).to receive(:OVERLAP_RATIO_BOOST).and_return nil
+        expect(subject.add_spatial_params(solr_params)).not_to have_key(:overlap)
+      end
+
       context 'when the wrong format for the bounding box is used' do
         before do
           allow(subject).to receive(:bounding_box).and_raise(Geoblacklight::Exceptions::WrongBoundingBoxFormat)


### PR DESCRIPTION
This PR adds optional spatial search overlapRatio relevancy support. Configurable via the presence of Settings.OVERLAP_RATIO_BOOST.

When a bbox param is present, the Settings.OVERLAP_RATIO_BOOST value will boost results based on the overlap ratio of the result bboxes.

Includes a modification to our Solr schema to include a _bboxtype fieldtype. Requires Solr 7.4+ 

Thanks to:
@hudajkhan / Feature development
@ewlarson / Rspec tests