### PR TITLE
Remove docker from the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ $ cd app-name
 $ rake geoblacklight:server
 ```
 
-Or install with [Docker](https://github.com/geoblacklight/geoblacklight-docker)
 For more information see the [installation guide](https://github.com/geoblacklight/geoblacklight/wiki/Installation)
 
 ### Webpacker


### PR DESCRIPTION
Should we remove this? Especially if geoblacklight-docker isn't really being supported?