### PR TITLE
801 suppressed doc exportable views

### DIFF
--- a/app/models/concerns/geoblacklight/spatial_search_behavior.rb
+++ b/app/models/concerns/geoblacklight/spatial_search_behavior.rb
@@ -60,7 +60,7 @@ module Geoblacklight
 
       # Do not suppress action_documents method calls for individual documents
       # ex. CatalogController#web_services (exportable views)
-      return if solr_params[:q] && solr_params[:q].include?("{!lucene}layer_slug_s:")
+      return if solr_params[:q]&.include?('{!lucene}layer_slug_s:')
 
       solr_params[:fq] ||= []
       solr_params[:fq] << '-suppressed_b: true'

--- a/app/models/concerns/geoblacklight/spatial_search_behavior.rb
+++ b/app/models/concerns/geoblacklight/spatial_search_behavior.rb
@@ -57,6 +57,11 @@ module Geoblacklight
     def hide_suppressed_records(solr_params)
       # Show child records if searching for a specific source parent
       return unless blacklight_params.fetch(:f, {})[Settings.FIELDS.SOURCE.to_sym].nil?
+
+      # Do not suppress action_documents method calls for individual documents
+      # ex. CatalogController#web_services (exportable views)
+      return if solr_params[:q] && solr_params[:q].include?("{!lucene}layer_slug_s:")
+
       solr_params[:fq] ||= []
       solr_params[:fq] << '-suppressed_b: true'
     end

--- a/spec/features/suppressed_records_spec.rb
+++ b/spec/features/suppressed_records_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+feature 'Suppressed records' do
+  scenario 'are viewable' do
+    visit solr_document_path 'princeton-jq085m62x'
+    expect(page).to have_css('#document')
+  end
+
+  scenario 'are exportable' do
+    visit solr_document_path 'princeton-jq085m62x'
+    click_link 'Web services'
+    expect(page).to have_css 'h1.modal-title', text: 'Web services'
+  end
+end


### PR DESCRIPTION
Fixes #801 / Bug fix for exportable methods on suppressed documents.

CatalogController#show and CatalogController#web_services spawn different queries to Solr. The #show method queries for a single document. The #web_services method (and other exportable actions) assumes a potential array of documents.

The query syntax for an array of documents includes any applied filters and additionally appends the SpatialSearchBehavior#hide_suppressed_records filter, which causes #web_services calls on suppressed documents to 500.

This PR adds a secondary check to the hide_suppressed_records method to ensure queries for single records (likely from exportable view calls) are not filtered, so #web_services calls properly return 200. Specs added to test for successful call.