### PR TITLE
Corrects the Teaspoon test fixture for metadata download buttons

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,6 +57,9 @@ jobs:
       - run:
           name: Run the RSpec test suites
           command: bundle exec rake geoblacklight:coverage
+      - run:
+          name: Run the Teaspoon test suites
+          command: bundle exec rake teaspoon
       # Store bundle cache
       - type: cache-save
         name: Store bundle cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,6 +115,9 @@ jobs:
       - run:
           name: Run the RSpec test suites
           command: bundle exec rake geoblacklight:coverage
+      - run:
+          name: Run the Teaspoon test suites
+          command: bundle exec rake teaspoon
       # Store bundle cache
       - type: cache-save
         name: Store bundle cache

--- a/geoblacklight.gemspec
+++ b/geoblacklight.gemspec
@@ -45,4 +45,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'coveralls'
   spec.add_development_dependency 'simplecov', '~> 0.16'
   spec.add_development_dependency 'foreman'
+  spec.add_development_dependency 'teaspoon'
 end

--- a/package.json
+++ b/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "geoblacklight",
+  "version": "2.1.2"
+}

--- a/spec/javascripts/metadata_download_button_spec.js
+++ b/spec/javascripts/metadata_download_button_spec.js
@@ -2,7 +2,7 @@
 
 describe('MetadataDownloadButton', function() {
   describe('initialize', function() {
-    fixture.set('<button id="foo" data-ref-endpoint="http://testdomain" data-ref-download="#bar">test element</button><a href="http://test2domain" id="bar">another test element</a>');
+    fixture.set('<button id="foo" data-ref-endpoint="http://testdomain" data-ref-download="#bar">test element</button><a href="http://testdomain" id="bar">another test element</a>');
 
     it('creates a new instance and sets the download button @href value', function() {
       var button = new GeoBlacklight.MetadataDownloadButton('#foo');


### PR DESCRIPTION
Also ensures that a minimal `package.json` is present (this eases the process of testing in local development environments), explicitly specifies `teaspoon` as a development dependency, and ensures that the teaspoon test suites are run on CircleCI.  Resolves #819 