### PR TITLE
Update toolbar.scss

### DIFF
--- a/app/assets/stylesheets/geoblacklight/modules/toolbar.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/toolbar.scss
@@ -3,6 +3,10 @@
 
   .list-group {
 
+    .list-group-item.exports {
+      margin-top:0px;
+    }
+
     .list-group-item {
 
       form {


### PR DESCRIPTION
Fixes #792 / Removes accidental top margin from the "Open in Carto" link within .show-tools.