### PR TITLE
[WIP/Do not merge] Restructures the CircleCI config. for parallel builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,97 +1,49 @@
 ---
-version: 2
+version: 2.1
 jobs:
-  rails_5_2_3:
+  test:
+    parameters:
+      ruby_version:
+        type: string
+      rails_version:
+        type: string
     working_directory: ~/geoblacklight
     docker:
-      - image: circleci/ruby:2.5.1-node-browsers
+      - image: circleci/ruby:<< parameters.ruby_version >>-node-browsers
         environment:
-          BUNDLE_JOBS: 3
-          BUNDLE_RETRY: 3
-          # We need both GEM_HOME and BUNDLE_PATH because of the test app
-          GEM_HOME: /home/circleci/geoblacklight/vendor/bundle
-          BUNDLE_PATH: /home/circleci/geoblacklight/vendor/bundle
-          CI: true
-          RAILS_ENV: test
-          RAILS_VERSION: 5.2.3
-      - image: solr:7-alpine
-        command: bin/solr -cloud -noprompt -f -p 8983
-    steps:
-      - checkout
-      # Update chrome
-      - run: wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
-      - run: sudo sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
-      - run: sudo apt-get update
-      - run: sudo apt-get -y install google-chrome-stable
-      # Restore bundle cache
-      - type: cache-restore
-        name: Restore bundle cache
-        key: geoblacklight-bundle-5-2-0-{{ checksum "geoblacklight.gemspec" }}-{{ checksum "Gemfile" }}-3f5eff
-      # Install gems
-      - run: bundle check || bundle install
-      # Run the test suites
-      - run: bundle exec rake engine_cart:generate
-      - run:
-          name: Wait for Solr
-          command: dockerize -wait tcp://localhost:8983 -timeout 1m
-      - run:
-          name: Load config into solr
-          command: |
-            cd .internal_test_app/solr/conf
-            zip -1 -r solr_config.zip ./*
-            curl -H "Content-type:application/octet-stream" --data-binary @solr_config.zip "http://localhost:8983/solr/admin/configs?action=UPLOAD&name=solrconfig"
-            curl -H 'Content-type: application/json' http://localhost:8983/api/collections/ -d '{create: {name: blacklight-core, config: solrconfig, numShards: 1}}'
-      - run:
-          name: Seed Solr
-          command: |
-            cd .internal_test_app
-            bundle exec rake geoblacklight:index:seed
-            bundle exec rake geoblacklight:downloads:mkdir
-      - run:
-          name: Compile the assets for Webpack
-          command: |
-            cd .internal_test_app
-            rm config/webpacker.yml
-            bundle exec rails webpacker:install
-            bundle exec rails webpacker:compile
-      - run:
-          name: Run the RSpec test suites
-          command: bundle exec rake geoblacklight:coverage
-      - run:
-          name: Run the Teaspoon test suites
-          command: bundle exec rake teaspoon
-      # Store bundle cache
-      - type: cache-save
-        name: Store bundle cache
-        key: geoblacklight-bundle-5-2-0-{{ checksum "geoblacklight.gemspec" }}-{{ checksum "Gemfile" }}-3f5eff
-        paths:
-          - /home/circleci/geoblacklight/vendor/bundle
-  rails_5_1_7:
-    working_directory: ~/geoblacklight
-    docker:
-      - image: circleci/ruby:2.4.4-node-browsers
-        environment:
-          BUNDLE_JOBS: 3
+          BUNDLE_JOBS: 4
           BUNDLE_RETRY: 3
           GEM_HOME: /home/circleci/geoblacklight/vendor/bundle
           BUNDLE_PATH: /home/circleci/geoblacklight/vendor/bundle
           RAILS_ENV: test
-          RAILS_VERSION: 5.1.7
+          RAILS_VERSION: << parameters.rails_version >>
+          COVERAGE: true
       - image: solr:7-alpine
         command: bin/solr -cloud -noprompt -f -p 8983
+    parallelism: 4
     steps:
       - checkout
       # Restore bundle cache
-      - type: cache-restore
-        name: Restore bundle cache
-        key: geoblacklight-bundle-5-1-7-{{ checksum "Gemfile" }}-{{ checksum "geoblacklight.gemspec" }}-3f5eff
+      - restore_cache:
+          name: Restore bundle cache
+          keys:
+            - geoblacklight-<< parameters.ruby_version >>-{{ checksum "Gemfile" }}-{{ checksum "geoblacklight.gemspec" }}
       # Install gems and run specs
-      - run: bundle check || bundle install
-      # Run the test suites
-      - run: bundle exec rake engine_cart:generate
+      - run: bundle check --path=vendor/bundle || bundle install --path=vendor/bundle --jobs 4 --retry 3
       - run:
           name: Wait for Solr
           command: dockerize -wait tcp://localhost:8983 -timeout 1m
+      - run:
+          name: Generate the test app
+          command: |
+            [ -e ./.internal_test_app ] || bundle exec rake engine_cart:generate
+      # Store bundle cache
+      - save_cache:
+          name: Store bundle cache
+          key: geoblacklight-<< parameters.ruby_version >>-{{ checksum "Gemfile" }}-{{ checksum "geoblacklight.gemspec" }}
+          paths:
+            - vendor/bundle
+            - .internal_test_app
       - run:
           name: Load config into solr
           command: |
@@ -100,53 +52,30 @@ jobs:
             curl -H "Content-type:application/octet-stream" --data-binary @solr_config.zip "http://localhost:8983/solr/admin/configs?action=UPLOAD&name=solrconfig"
             curl -H 'Content-type: application/json' http://localhost:8983/api/collections/ -d '{create: {name: blacklight-core, config: solrconfig, numShards: 1}}'
       - run:
-          name: Seed Solr
+          name: Prepare the test app
           command: |
             cd .internal_test_app
-            bundle exec rake geoblacklight:index:seed
-            bundle exec rake geoblacklight:downloads:mkdir
-      - run:
-          name: Compile the assets for Webpack
-          command: |
-            cd .internal_test_app
+            bundle check --path=vendor/bundle || bundle install --path=vendor/bundle --jobs 4 --retry 3
             rm config/webpacker.yml
             bundle exec rails webpacker:install
             bundle exec rails webpacker:compile
+            bundle exec rake geoblacklight:index:seed
+            bundle exec rake geoblacklight:downloads:mkdir
+      - run: bundle check --path=vendor/bundle || bundle install --path=vendor/bundle --jobs 4 --retry 3
+      - run: bundle exec rake rubocop
       - run:
           name: Run the RSpec test suites
-          command: bundle exec rake geoblacklight:coverage
-      - run:
-          name: Run the Teaspoon test suites
-          command: bundle exec rake teaspoon
-      # Store bundle cache
-      - type: cache-save
-        name: Store bundle cache
-        key: geoblacklight-bundle-5-1-7-{{ checksum "Gemfile" }}-{{ checksum "geoblacklight.gemspec" }}-3f5eff
-        paths:
-          - /home/circleci/geoblacklight/vendor/bundle
-  rubocop:
-    working_directory: ~/geoblacklight
-    docker:
-      - image: circleci/ruby:2.5.1-node-browsers
-        environment:
-          GEM_HOME: /home/circleci/geoblacklight/vendor/bundle
-          BUNDLE_PATH: /home/circleci/geoblacklight/vendor/bundle
-          RAILS_ENV: test
-    steps:
-      - checkout
-      # Restore bundle cache
-      - type: cache-restore
-        name: Restore bundle cache
-        key: geoblacklight-bundle-5-2-3-{{ checksum "geoblacklight.gemspec" }}-{{ checksum "Gemfile" }}-3f5eff
-      # Install gems and run rubocop
-      - run: bundle check || bundle install
-      - run: bundle exec rake rubocop
+          command: bundle exec rspec $(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)
+
 workflows:
   version: 2
   build_accept_deploy:
     jobs:
-      - rails_5_2_3
-      - rails_5_1_7
-      - rubocop:
-          requires:
-            - rails_5_2_3
+      - test:
+          name: "test_ruby2-5_rails5-1"
+          ruby_version: "2.5.5"
+          rails_version: "5.1.7"
+      - test:
+          name: "test_ruby2-5_rails5-2"
+          ruby_version: "2.5.5"
+          rails_version: "5.2.3"

--- a/Rakefile
+++ b/Rakefile
@@ -31,14 +31,15 @@ task :teaspoon do
 end
 
 desc 'Run test suite'
-task ci: ['geoblacklight:generate'] do
+task ci: ['engine_cart:generate'] do
   SolrWrapper.wrap do |solr|
     solr.with_collection(name: 'blacklight-core', dir: File.join(File.expand_path('.', File.dirname(__FILE__)), 'solr', 'conf')) do
       within_test_app do
         system 'RAILS_ENV=test rake geoblacklight:index:seed'
         system 'RAILS_ENV=test bundle exec rails webpacker:compile'
       end
-      Rake::Task['geoblacklight:coverage'].invoke
+      ENV['COVERAGE'] = 'true'
+      Rake::Task['spec'].invoke
     end
   end
   # Run JavaScript tests
@@ -46,16 +47,6 @@ task ci: ['geoblacklight:generate'] do
 end
 
 namespace :geoblacklight do
-  desc 'Run tests with coverage'
-  task :coverage do
-    ENV['COVERAGE'] = 'true'
-    Rake::Task['spec'].invoke
-  end
-
-  desc 'Create the test rails app'
-  task generate: ['engine_cart:generate'] do
-  end
-
   namespace :internal do
     task seed: ['engine_cart:generate'] do
       within_test_app do

--- a/spec/features/metadata_panel_spec.rb
+++ b/spec/features/metadata_panel_spec.rb
@@ -44,18 +44,6 @@ feature 'Metadata tools' do
       end
     end
     context 'when the metadata is in the XML' do
-      let(:mods) { File.read(Rails.root.join('..', 'spec', 'fixtures', 'mods', 'fb897vt9938.mods')) }
-      let(:response) { instance_double(Faraday::Response) }
-      let(:connection) { instance_double(Faraday::Connection) }
-
-      before do
-        allow(response).to receive(:body).and_return(mods)
-        allow(response).to receive(:status).and_return(200)
-        allow(connection).to receive(:get).and_return(response)
-        allow(Faraday).to receive(:new).with(url: 'http://purl.stanford.edu/fb897vt9938.mods').and_return(connection)
-        allow(Faraday).to receive(:new).and_call_original
-      end
-
       scenario 'shows up as XML' do
         visit solr_document_path 'stanford-cg357zz0321'
         expect(page).to have_css 'li.metadata a', text: 'Metadata'


### PR DESCRIPTION
Resolves #789 by addressing the following:

- Restructuring the CircleCI into three build jobs: bundle, rubocop, and test
- Ensuring bundler Gems and the engine_cart internal test app. is cached on CircleCI
- Ensuring that the tests are run in parallel between containers

Also handles cases where OpenSSL errors are encountered when requesting metadata files