### PR TITLE
Add help text feature

### DIFF
--- a/app/assets/javascripts/geoblacklight/modules/help_text.js
+++ b/app/assets/javascripts/geoblacklight/modules/help_text.js
@@ -1,0 +1,7 @@
+Blacklight.onLoad(function() {
+  $(function () {
+      $('[data-toggle="popover"]').popover({
+        trigger: 'hover'
+      })
+    })
+});

--- a/app/helpers/geoblacklight_helper.rb
+++ b/app/helpers/geoblacklight_helper.rb
@@ -140,6 +140,29 @@ module GeoblacklightHelper
   end
 
   ##
+  # Deteremines if a feature should include help text popover
+  # @return [Boolean]
+  def show_help_text?(feature, key)
+    Settings&.HELP_TEXT&.send(feature)&.include?(key)
+  end
+
+  ##
+  # Render help text popover for a given feature and translation key
+  # @return [HTML tag]
+  def render_help_text_entry(feature, key)
+    if I18n.exists?("geoblacklight.help_text.#{feature}.#{key}", locale)
+      help_text = I18n.t("geoblacklight.help_text.#{feature}.#{key}")
+      content_tag :h3, class: 'help-text viewer_protocol h6' do
+        content_tag :a, 'data': { toggle: 'popover', title: help_text[:title], content: help_text[:content] } do
+          help_text[:title]
+        end
+      end
+    else
+      tag.span class: 'help-text translation-missing'
+    end
+  end
+
+  ##
   # Deteremines if item view should include attribute table
   # @return [Boolean]
   def show_attribute_table?

--- a/app/views/catalog/_show_default_viewer_container.html.erb
+++ b/app/views/catalog/_show_default_viewer_container.html.erb
@@ -1,6 +1,11 @@
 <% document ||= @document %>
 <div class='row'>
   <div id='viewer-container' class="col-md-12">
+
+    <% if show_help_text?('viewer_protocol', document.viewer_protocol) %>
+      <%= render_help_text_entry('viewer_protocol', document.viewer_protocol) %>
+    <% end %>
+
     <%= content_tag :div, id: 'map', data: { map: 'item', protocol: document.viewer_protocol.camelize, url: document.viewer_endpoint, 'layer-id' => document.wxs_identifier, 'map-bbox' => document.bounding_box_as_wsen, 'catalog-path'=> search_catalog_path, available: document_available?, inspect: show_attribute_table?, basemap: geoblacklight_basemap, leaflet_options: leaflet_options } do %>
     <% end %>
   </div>

--- a/config/locales/geoblacklight.en.yml
+++ b/config/locales/geoblacklight.en.yml
@@ -73,3 +73,29 @@ en:
       attribute: 'Attribute'
       value: 'Value'
       click_map: 'Click on map to inspect values'
+    help_text:
+      viewer_protocol:
+        dynamic_map_layer:
+          title: ArcGIS Dynamic Map Layer
+          content: An ArcGIS Dynamic Map Layer represents vector data (points, lines, and polygons). Map image layers are dynamically rendered image tiles.
+        feature_layer:
+          title: ArcGIS Feature Layer
+          content: An ArcGIS Feature Layer Service displays vector data (points, lines, and polygons) as individual or collected features.
+        iiif:
+          title: IIIF Service
+          content: The International Image Interoperability Framework (IIIF) web service API displays an image from a server. This image can be panned and zoomed.
+        iiif_manifest:
+          title: IIIF Service
+          content: The International Image Interoperability Framework (IIIF) web service API displays an image from a server. This image can be panned and zoomed.
+        image_map_layer:
+          title: ArcGIS Image Map Layer
+          content: An ArcGIS Image Map Layer displays raster data (a grid of cells used to store imagery).
+        index_map:
+          title: Index Map
+          content: Index maps are a "table of contents" that allow users to select a specific map or item within a larger set and navigate to it for viewing or downloading.
+        tiled_map_layer:
+          title: ArcGIS Tiled Map Layer
+          content: An ArcGIS Tiled Map Layer Service displays set of web-accessible tiles that reside on a server.
+        wms:
+          title: Web Map Service (WMS)
+          content: A Web Map Service displays a geospatial dataset as map images.

--- a/lib/generators/geoblacklight/templates/settings.yml
+++ b/lib/generators/geoblacklight/templates/settings.yml
@@ -106,3 +106,15 @@ LEAFLET:
       <<: *opacity_control
     IMAGEMAPLAYER:
       <<: *opacity_control
+
+# Toggle the help text feature that offers users context
+HELP_TEXT:
+  viewer_protocol:
+      - 'dynamic_map_layer'
+      - 'feature_layer'
+      - 'iiif'
+      - 'iiif_manifest'
+      - 'image_map_layer'
+      - 'index_map'
+      - 'tiled_map_layer'
+      - 'wms'

--- a/spec/features/help_text_spec.rb
+++ b/spec/features/help_text_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+
+feature 'Help Text' do
+  scenario 'Displays help text entry' do
+    visit '/catalog/stanford-cg357zz0321'
+    expect(page).to have_css '.help-text', count: 1
+  end
+end

--- a/spec/helpers/geoblacklight_helper_spec.rb
+++ b/spec/helpers/geoblacklight_helper_spec.rb
@@ -303,4 +303,30 @@ describe GeoblacklightHelper, type: :helper do
       expect(helper.first_metadata?(document, metadata)).to be true
     end
   end
+
+  describe '#show_help_text?' do
+    let(:feature) { 'viewer_protocol' }
+    let(:translation_key) { 'wms' }
+
+    it 'confirms help text is available' do
+      expect(helper.show_help_text?(feature, translation_key)).to be true
+    end
+  end
+
+  describe '#render_help_text_entry' do
+    let(:feature) { 'viewer_protocol' }
+    let(:translation_key) { 'wms' }
+
+    context 'valid entry' do
+      it 'renders help text entry for the wms viewer protocol' do
+        expect(helper.render_help_text_entry(feature, translation_key)).to eq '<h3 class="help-text viewer_protocol h6"><a data-toggle="popover" data-title="Web Map Service (WMS)" data-content="A Web Map Service displays a geospatial dataset as map images.">Web Map Service (WMS)</a></h3>'
+      end
+    end
+
+    context 'invalid entry' do
+      it 'renders an empty span' do
+        expect(helper.render_help_text_entry('foo', 'bar')).to eq '<span class="help-text translation-missing"></span>'
+      end
+    end
+  end
 end


### PR DESCRIPTION
This WIP branch adds support for a generic help text feature. The help text feature can be added or removed from the GBL Settings file to toggle help text display.

```yaml

# Toggle the help text feature that offers users context
HELP_TEXT:
  viewer_protocol:
      - 'dynamic_map_layer'
      - 'feature_layer'
      - 'iiif'
      - 'iiif_manifest'
      - 'image_map_layer'
      - 'index_map'
      - 'tiled_map_layer'
      - 'wms'
```

The :en locale file defines the help text displayed.

```yaml

    help_text:
      viewer_protocol:
        dynamic_map_layer:
          title: ArcGIS Dynamic Map Layer
          content: An ArcGIS Dynamic Map Layer is based on vector data. (points, lines, and polygons). Map image layers are dynamically rendered image tiles. Click on a feature to view attribute information.
```

And, two new GBL helpers allow to check a feature for help text and render its display.

```ruby
    // Pass the "feature" and the translation "key" to check and/or render help text entry
    <% if show_help_text?('viewer_protocol', document.viewer_protocol) %>
      <%= render_help_text_entry('viewer_protocol', document.viewer_protocol) %>
    <% end %>
```

Help text is displayed as a Bootstrap popover. Here is an example of help text for the document.viewer_protocol 

<img width="724" alt="Screen Shot 2019-08-06 at 11 38 05 AM" src="https://user-images.githubusercontent.com/69827/62558507-ce4ac300-b83e-11e9-969e-7a669df0b4c8.png">
