### PR TITLE
Bug fix: Exportable actions should return 404 if doc not found

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
   rails_5_2_3:
     working_directory: ~/geoblacklight
     docker:
-      - image: circleci/ruby:2.5.1-node-browsers
+      - image: circleci/ruby:2.5.7-node-browsers
         environment:
           BUNDLE_JOBS: 3
           BUNDLE_RETRY: 3
@@ -69,7 +69,7 @@ jobs:
   rails_5_1_7:
     working_directory: ~/geoblacklight
     docker:
-      - image: circleci/ruby:2.4.4-node-browsers
+      - image: circleci/ruby:2.4.9-node-browsers
         environment:
           BUNDLE_JOBS: 3
           BUNDLE_RETRY: 3
@@ -127,7 +127,7 @@ jobs:
   rubocop:
     working_directory: ~/geoblacklight
     docker:
-      - image: circleci/ruby:2.5.1-node-browsers
+      - image: circleci/ruby:2.5.7-node-browsers
         environment:
           GEM_HOME: /home/circleci/geoblacklight/vendor/bundle
           BUNDLE_PATH: /home/circleci/geoblacklight/vendor/bundle

--- a/lib/generators/geoblacklight/templates/catalog_controller.rb
+++ b/lib/generators/geoblacklight/templates/catalog_controller.rb
@@ -265,6 +265,12 @@ class CatalogController < ApplicationController
     config.autocomplete_path = 'suggest'
   end
 
+  # @return [Array] first value is a Blacklight::Solr::Response and the second
+  #                 is a list of documents
+  def action_documents
+    deprecated_response, @documents = search_service.fetch(Array(params[:id]))
+    raise Blacklight::Exceptions::RecordNotFound unless @documents.present?
 
-
+    return deprecated_response, @documents
+  end
 end

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -7,6 +7,10 @@ describe CatalogController, type: :controller do
       expect(response.status).to eq 200
       expect(assigns(:documents)).not_to be_nil
     end
+
+    it 'returns 404 with a bad id' do
+      expect{ get :web_services, params: { id: 'bad-record-identifier' } }.to raise_error(Blacklight::Exceptions::RecordNotFound)
+    end
   end
 
   describe '.default_solr_params' do


### PR DESCRIPTION
Fixes #859

Opening this PR for review. This change overrides the stock BL CatalogController "action_documents" method, allowing us to raise record not found errors for exportable methods, like: /metadata, /web_services, or /citation. Currently GBL 500s on bad-document-id/metadata if no document is found, and awkwardly renders 200 for bad-document-id/citation. View issue for full details on the context for this bug.

This change _could_ also be submitted to Blacklight. I vacillate on whether GBL or BL is the best path forward here, as we'd need them to cut a release and GBL might not be ready for the latest BL release. 

Opinions requested!