### PR TITLE
Makes CircleCI happy again

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
   rails_5_2_3:
     working_directory: ~/geoblacklight
     docker:
-      - image: circleci/ruby:2.5.1-node-browsers
+      - image: circleci/ruby:2.5.7-node-browsers
         environment:
           BUNDLE_JOBS: 3
           BUNDLE_RETRY: 3
@@ -69,7 +69,7 @@ jobs:
   rails_5_1_7:
     working_directory: ~/geoblacklight
     docker:
-      - image: circleci/ruby:2.4.4-node-browsers
+      - image: circleci/ruby:2.4.9-node-browsers
         environment:
           BUNDLE_JOBS: 3
           BUNDLE_RETRY: 3
@@ -127,7 +127,7 @@ jobs:
   rubocop:
     working_directory: ~/geoblacklight
     docker:
-      - image: circleci/ruby:2.5.1-node-browsers
+      - image: circleci/ruby:2.5.7-node-browsers
         environment:
           GEM_HOME: /home/circleci/geoblacklight/vendor/bundle
           BUNDLE_PATH: /home/circleci/geoblacklight/vendor/bundle

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -46,13 +46,6 @@ Lint/UnusedBlockArgument:
 Metrics/BlockLength:
   Max: 247
 
-# Offense count: 1
-# Cop supports --auto-correct.
-# Configuration parameters: AutoCorrect.
-Performance/HashEachMethods:
-  Exclude:
-    - 'app/presenters/geoblacklight/document_presenter.rb'
-
 # Offense count: 2
 # Configuration parameters: CustomIncludeMethods.
 RSpec/EmptyExampleGroup:
@@ -160,12 +153,6 @@ Style/FrozenStringLiteralComment:
 Style/HashSyntax:
   Exclude:
     - 'lib/tasks/geoblacklight.rake'
-
-# Offense count: 2
-Style/MethodMissing:
-  Exclude:
-    - 'app/models/concerns/geoblacklight/solr_document.rb'
-    - 'lib/geoblacklight/references.rb'
 
 # Offense count: 2
 # Cop supports --auto-correct.

--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,8 @@ else
   end
 
   case ENV['RAILS_VERSION']
+  when /^5.[12]/, /^6.0/
+    gem 'sass-rails', '~> 5.0'
   when /^4.2/
     gem 'responders', '~> 2.0'
     gem 'sass-rails', '>= 5.0'

--- a/spec/features/esri_viewer_spec.rb
+++ b/spec/features/esri_viewer_spec.rb
@@ -13,7 +13,6 @@ feature 'feature_layer reference', js: true do
     expect(page).to have_css 'img.leaflet-image-layer', visible: true
   end
   scenario 'displays dynamic layer (single layer)' do
-    pending 'external service disabled cors access'
     visit solr_document_path '4669301e-b4b2-4c8b-bf40-01b968a2865b'
     expect(page).to have_css '.leaflet-control-zoom', visible: true
     expect(page).to have_css 'img.leaflet-image-layer', visible: true

--- a/spec/features/split_view.html.erb_spec.rb
+++ b/spec/features/split_view.html.erb_spec.rb
@@ -30,7 +30,7 @@ feature 'Index view', js: true do
       expect(page).to have_css('div.card.facet-limit', text: 'Data type')
       expect(page).to have_css('div.card.facet-limit', text: 'Format')
     end
-    click_link 'Institution'
+    click_button 'Institution'
     using_wait_time 120 do
       expect(page).to have_css('a.facet-select', text: 'Minnesota', visible: true)
       expect(page).to have_css('a.facet-select', text: 'MIT', visible: true)

--- a/spec/lib/geoblacklight/wms_layer_spec.rb
+++ b/spec/lib/geoblacklight/wms_layer_spec.rb
@@ -79,7 +79,7 @@ describe Geoblacklight::WmsLayer do
       it 'logs the Faraday error' do
         expect(Geoblacklight.logger).to receive(:error).exactly(3).times
         expect(wms_layer.request_response).to be_a Hash
-        expect(wms_layer.request_response).to include(error: '#<Faraday::ConnectionFailed wrapped=#<StandardError: test connection error>>')
+        expect(wms_layer.request_response).to include(error: '#<Faraday::Error::ConnectionFailed wrapped=#<StandardError: test connection error>>')
       end
     end
 
@@ -92,7 +92,7 @@ describe Geoblacklight::WmsLayer do
       it 'logs the Faraday error' do
         expect(Geoblacklight.logger).to receive(:error).exactly(3).times
         expect(wms_layer.request_response).to be_a Hash
-        expect(wms_layer.request_response).to include(error: '#<Faraday::TimeoutError #<Faraday::TimeoutError: timeout>>')
+        expect(wms_layer.request_response).to include(error: '#<Faraday::Error::TimeoutError #<Faraday::Error::TimeoutError: timeout>>')
       end
     end
   end


### PR DESCRIPTION
This handful of commits makes our test suite run successfully on CircleCI again:

-  Bump our ruby versions to latest minor versions with node
-  Enable an ESRI pending test that passes now
-  Change a facet spec from click_link to a click_button
-  Update Faraday Error messages for WMS errors
-  Add a Gemfile sass-rails rule for Rails 5 to 6
-  Remove old cops from our rubocop_todo file

Fixes #864  
Might also solve #866
