### PR TITLE
Updating the structure of the CircleCI config. to test against Ruby 2.6.z and 2.5.z releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,21 +1,30 @@
 ---
-version: 2
+version: 2.1
 jobs:
-  rails_5_2_3:
+  build:
     working_directory: ~/geoblacklight
+    parameters:
+      ruby_version:
+        type: string
+        default: '2.5.7'
+      solr_port:
+        type: string
+        default: '8983'
+      rails_version:
+        type: string
+        default: '5.1.7'
     docker:
-      - image: circleci/ruby:2.5.7-node-browsers
-        environment:
-          BUNDLE_JOBS: 3
-          BUNDLE_RETRY: 3
-          # We need both GEM_HOME and BUNDLE_PATH because of the test app
-          GEM_HOME: /home/circleci/geoblacklight/vendor/bundle
-          BUNDLE_PATH: /home/circleci/geoblacklight/vendor/bundle
-          CI: true
-          RAILS_ENV: test
-          RAILS_VERSION: 5.2.3
+      - image: circleci/ruby:<< parameters.ruby_version >>-node-browsers-legacy
       - image: solr:7-alpine
-        command: bin/solr -cloud -noprompt -f -p 8983
+        command: bin/solr -cloud -noprompt -f -p <<parameters.solr_port>>
+    environment:
+      GEM_HOME: /home/circleci/geoblacklight/vendor/bundle
+      BUNDLE_PATH: /home/circleci/geoblacklight/vendor/bundle
+      BUNDLE_JOBS: 4
+      BUNDLE_RETRY: 3
+      RAILS_ENV: test
+      RACK_ENV: test
+      RAILS_VERSION: <<parameters.rails_version>>
     steps:
       - checkout
       # Update chrome
@@ -24,23 +33,22 @@ jobs:
       - run: sudo apt-get update
       - run: sudo apt-get -y install google-chrome-stable
       # Restore bundle cache
-      - type: cache-restore
-        name: Restore bundle cache
-        key: geoblacklight-bundle-5-2-0-{{ checksum "geoblacklight.gemspec" }}-{{ checksum "Gemfile" }}-3f5eff
+      - restore_cache:
+          key: geoblacklight-bundle-5-2-0-{{ checksum "geoblacklight.gemspec" }}-{{ checksum "Gemfile" }}-3f5eff
       # Install gems
       - run: bundle check || bundle install
       # Run the test suites
       - run: bundle exec rake engine_cart:generate
       - run:
           name: Wait for Solr
-          command: dockerize -wait tcp://localhost:8983 -timeout 1m
+          command: dockerize -wait tcp://localhost:<<parameters.solr_port>> -timeout 1m
       - run:
           name: Load config into solr
           command: |
             cd .internal_test_app/solr/conf
             zip -1 -r solr_config.zip ./*
             curl -H "Content-type:application/octet-stream" --data-binary @solr_config.zip "http://localhost:8983/solr/admin/configs?action=UPLOAD&name=solrconfig"
-            curl -H 'Content-type: application/json' http://localhost:8983/api/collections/ -d '{create: {name: blacklight-core, config: solrconfig, numShards: 1}}'
+            curl -H 'Content-type: application/json' http://localhost:<<parameters.solr_port>>/api/collections/ -d '{create: {name: blacklight-core, config: solrconfig, numShards: 1}}'
       - run:
           name: Seed Solr
           command: |
@@ -61,92 +69,71 @@ jobs:
           name: Run the Teaspoon test suites
           command: bundle exec rake teaspoon
       # Store bundle cache
-      - type: cache-save
-        name: Store bundle cache
-        key: geoblacklight-bundle-5-2-0-{{ checksum "geoblacklight.gemspec" }}-{{ checksum "Gemfile" }}-3f5eff
-        paths:
-          - /home/circleci/geoblacklight/vendor/bundle
-  rails_5_1_7:
-    working_directory: ~/geoblacklight
-    docker:
-      - image: circleci/ruby:2.4.9-node-browsers
-        environment:
-          BUNDLE_JOBS: 3
-          BUNDLE_RETRY: 3
-          GEM_HOME: /home/circleci/geoblacklight/vendor/bundle
-          BUNDLE_PATH: /home/circleci/geoblacklight/vendor/bundle
-          RAILS_ENV: test
-          RAILS_VERSION: 5.1.7
-      - image: solr:7-alpine
-        command: bin/solr -cloud -noprompt -f -p 8983
-    steps:
-      - checkout
-      # Restore bundle cache
-      - type: cache-restore
-        name: Restore bundle cache
-        key: geoblacklight-bundle-5-1-7-{{ checksum "Gemfile" }}-{{ checksum "geoblacklight.gemspec" }}-3f5eff
-      # Install gems and run specs
-      - run: bundle check || bundle install
-      # Run the test suites
-      - run: bundle exec rake engine_cart:generate
-      - run:
-          name: Wait for Solr
-          command: dockerize -wait tcp://localhost:8983 -timeout 1m
-      - run:
-          name: Load config into solr
-          command: |
-            cd .internal_test_app/solr/conf
-            zip -1 -r solr_config.zip ./*
-            curl -H "Content-type:application/octet-stream" --data-binary @solr_config.zip "http://localhost:8983/solr/admin/configs?action=UPLOAD&name=solrconfig"
-            curl -H 'Content-type: application/json' http://localhost:8983/api/collections/ -d '{create: {name: blacklight-core, config: solrconfig, numShards: 1}}'
-      - run:
-          name: Seed Solr
-          command: |
-            cd .internal_test_app
-            bundle exec rake geoblacklight:index:seed
-            bundle exec rake geoblacklight:downloads:mkdir
-      - run:
-          name: Compile the assets for Webpack
-          command: |
-            cd .internal_test_app
-            rm config/webpacker.yml
-            bundle exec rails webpacker:install
-            bundle exec rails webpacker:compile
-      - run:
-          name: Run the RSpec test suites
-          command: bundle exec rake geoblacklight:coverage
-      - run:
-          name: Run the Teaspoon test suites
-          command: bundle exec rake teaspoon
-      # Store bundle cache
-      - type: cache-save
-        name: Store bundle cache
-        key: geoblacklight-bundle-5-1-7-{{ checksum "Gemfile" }}-{{ checksum "geoblacklight.gemspec" }}-3f5eff
-        paths:
-          - /home/circleci/geoblacklight/vendor/bundle
+      - save_cache:
+          key: geoblacklight-bundle-5-2-0-{{ checksum "geoblacklight.gemspec" }}-{{ checksum "Gemfile" }}-3f5eff
+          paths:
+            - /home/circleci/geoblacklight/vendor/bundle
+
   rubocop:
     working_directory: ~/geoblacklight
+    parameters:
+      ruby_version:
+        type: string
+        default: '2.5.7'
+      rails_version:
+        type: string
+        default: '5.1.7'
     docker:
-      - image: circleci/ruby:2.5.7-node-browsers
-        environment:
-          GEM_HOME: /home/circleci/geoblacklight/vendor/bundle
-          BUNDLE_PATH: /home/circleci/geoblacklight/vendor/bundle
-          RAILS_ENV: test
+      - image: circleci/ruby:<< parameters.ruby_version >>-node-browsers-legacy
+    environment:
+      GEM_HOME: /home/circleci/geoblacklight/vendor/bundle
+      BUNDLE_PATH: /home/circleci/geoblacklight/vendor/bundle
+      BUNDLE_JOBS: 4
+      BUNDLE_RETRY: 3
+      RAILS_ENV: test
+      RACK_ENV: test
+      RAILS_VERSION: <<parameters.rails_version>>
     steps:
       - checkout
       # Restore bundle cache
-      - type: cache-restore
-        name: Restore bundle cache
-        key: geoblacklight-bundle-5-2-3-{{ checksum "geoblacklight.gemspec" }}-{{ checksum "Gemfile" }}-3f5eff
+      - save_cache:
+          key: geoblacklight-bundle-5-2-3-{{ checksum "geoblacklight.gemspec" }}-{{ checksum "Gemfile" }}-3f5eff
+          paths:
+            - /home/circleci/geoblacklight/vendor/bundle
       # Install gems and run rubocop
       - run: bundle check || bundle install
       - run: bundle exec rake rubocop
+
 workflows:
   version: 2
-  build_accept_deploy:
+  build:
     jobs:
-      - rails_5_2_3
-      - rails_5_1_7
+      - build:
+          ruby_version: 2.6.5
+          rails_version: 5.2.4.1
+          name: "ruby2-6_rails5-2"
+      - build:
+          ruby_version: 2.5.7
+          rails_version: 5.2.4.1
+          name: "ruby2-5_rails5-2"
       - rubocop:
-          requires:
-            - rails_5_2_3
+          ruby_version: 2.6.5
+          rails_version: 5.2.4.1
+          name: "rubocop_ruby2-6_rails5-2"
+      - rubocop:
+          ruby_version: 2.5.7
+          rails_version: 5.2.4.1
+          name: "rubocop_ruby2-5_rails5-2"
+
+      - build:
+          ruby_version: 2.6.5
+          name: "ruby2-6_rails5-1"
+      - build:
+          ruby_version: 2.5.7
+          name: "ruby2-5_rails5-1"
+      - rubocop:
+          ruby_version: 2.6.5
+          name: "rubocop_ruby2-6_rails5-1"
+      - rubocop:
+          ruby_version: 2.5.7
+          name: "rubocop_ruby2-5_rails5-1"

--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,8 @@ else
     end
   end
 end
-# END ENGINE_CART BLOCK
 
-gem 'pry-byebug'
+if File.exists?('spec/test_app_templates/Gemfile.extra')
+  eval File.read('spec/test_app_templates/Gemfile.extra'), nil, 'spec/test_app_templates/Gemfile.extra'
+end
+# END ENGINE_CART BLOCK

--- a/Gemfile
+++ b/Gemfile
@@ -31,16 +31,7 @@ else
       gem 'rails', ENV['RAILS_VERSION']
     end
   end
-
-  case ENV['RAILS_VERSION']
-  when /^5.[12]/, /^6.0/
-    gem 'sass-rails', '~> 5.0'
-  when /^4.2/
-    gem 'responders', '~> 2.0'
-    gem 'sass-rails', '>= 5.0'
-    gem 'coffee-rails', '~> 4.1.0'
-  when /^4.[01]/
-    gem 'sass-rails', '< 5.0'
-  end
 end
 # END ENGINE_CART BLOCK
+
+gem 'pry-byebug'

--- a/lib/generators/geoblacklight/install_generator.rb
+++ b/lib/generators/geoblacklight/install_generator.rb
@@ -92,6 +92,11 @@ module Geoblacklight
     end
 
     def bundle_install
+      # Override the sass-rails problem
+      if Rails.version =~ /5\.[12]/
+        gsub_file('Gemfile', "gem 'sass-rails', '~> 5.0'", "gem 'sass-rails', '~> 6.0'")
+      end
+
       Bundler.with_clean_env do
         run 'bundle install'
       end

--- a/lib/generators/geoblacklight/install_generator.rb
+++ b/lib/generators/geoblacklight/install_generator.rb
@@ -97,11 +97,6 @@ module Geoblacklight
     end
 
     def bundle_install
-      # Override the sass-rails problem
-      if Rails.version =~ /5\.[12]/
-        gsub_file('Gemfile', "gem 'sass-rails', '~> 5.0'", "gem 'sass-rails', '~> 6.0'")
-      end
-
       Bundler.with_clean_env do
         run 'bundle install'
       end

--- a/lib/generators/geoblacklight/install_generator.rb
+++ b/lib/generators/geoblacklight/install_generator.rb
@@ -91,6 +91,11 @@ module Geoblacklight
       gsub_file('config/locales/blacklight.en.yml', 'Blacklight', 'GeoBlacklight')
     end
 
+    # Ensure that assets/images exists
+    def create_image_assets_directory
+      FileUtils.mkdir_p('app/assets/images') unless File.directory?('app/assets/images')
+    end
+
     def bundle_install
       # Override the sass-rails problem
       if Rails.version =~ /5\.[12]/

--- a/spec/test_app_templates/Gemfile.extra
+++ b/spec/test_app_templates/Gemfile.extra
@@ -1,0 +1,1 @@
+gem 'sprockets', '< 4'


### PR DESCRIPTION
Advances #866 and #789 

- Updating the structure of the CircleCI config. to test against Ruby 2.6.z and 2.5.z releases along with Rails 5.1.z and 5.2.z releases
- Ensuring that sass-rails 6.0.z releases are used when generating Rails 5.1.z and 5.2.z apps
- Removing support for Rails 4.y.z releases from the Gemfile