### PR TITLE
Bug Fix: update copyField statements for "catch all" search field

### DIFF
--- a/solr/conf/schema.xml
+++ b/solr/conf/schema.xml
@@ -147,8 +147,8 @@
     <!-- Adding field type for bboxField that enables, among other things, overlap ratio calculations -->
     <fieldType name="bbox" class="solr.BBoxField"
            geo="true" distanceUnits="kilometers" numberType="pdouble" />
-    <fieldType name="pdouble" class="solr.DoublePointField" docValues="true"/>   
-   
+    <fieldType name="pdouble" class="solr.DoublePointField" docValues="true"/>
+
 
   </types>
 
@@ -169,8 +169,8 @@
   <copyField source="layer_slug_s"       dest="layer_slug_ti"       maxChars="100"/>
 
   <!-- core text search -->
-  <copyField source="*_ti"               dest="text" />
-  <copyField source="*_tmi"              dest="text" />
+  <copyField source="*_s"                dest="text" />
+  <copyField source="*_sm"               dest="text" />
 
   <!-- for sorting text fields -->
   <copyField source="dct_provenance_s"   dest="dct_provenance_sort"/>
@@ -192,7 +192,7 @@
   <copyField source="dct_provenance_s" dest="suggest"/>
   <copyField source="dc_subject_sm" dest="suggest"/>
   <copyField source="dct_spatial_sm" dest="suggest"/>
-  
+
   <!-- for bbox value -->
   <copyField source="solr_geom" dest="solr_bboxtype"/>
 </schema>


### PR DESCRIPTION
From Solr docs: "Copying is done at the stream source level and no copy feeds into another copy. This means that copy fields cannot be chained i.e. you cannot copy from here to there and then from there to elsewhere."

So! copying into a dynamically created wildcard field doesn't allow us to then "chain" that new dynamic field value to populate the "text" field.

Switch to using *_s and *_sm fields to ensure our "catch all" field is properly populated.

Fixes #857