### PR TITLE
[WIP] Adds experimental references and downloads enabling multiple downloads

### DIFF
--- a/app/models/concerns/geoblacklight/solr_document.rb
+++ b/app/models/concerns/geoblacklight/solr_document.rb
@@ -32,6 +32,12 @@ module Geoblacklight
       References.new(self)
     end
 
+    ##
+    # Experimental feature
+    def experimental_downloads
+      NestedReferences.new(self).downloads
+    end
+
     def direct_download
       references.download.to_hash unless references.download.blank?
     end

--- a/app/views/catalog/_downloads_primary.html.erb
+++ b/app/views/catalog/_downloads_primary.html.erb
@@ -5,6 +5,23 @@
   <%= render partial: 'download_link', locals: { download_link: download_link_direct(download_text(document.file_format), document) } %>
 <% end %>
 
+<% document.experimental_downloads.each do |download| %>
+  <%= render(
+    partial: 'download_link',
+    locals: { download_link: link_to(
+      download.label,
+      download.url,
+      'contentUrl' => download.url,
+      class: ['btn', 'btn-default', 'download', 'download-original'],
+      data: {
+        download: 'trigger',
+        download_type: 'direct',
+        download_id: document.id
+      }
+    )})
+  %>
+<% end %>
+
 <% if document.hgl_download.present? %>
   <%= render partial: 'download_link', locals: { download_link: download_link_hgl(download_text(document.download_types.first[0]), document) } %>
 <% end %>

--- a/lib/geoblacklight.rb
+++ b/lib/geoblacklight.rb
@@ -27,6 +27,7 @@ module Geoblacklight
   require 'geoblacklight/metadata_transformer/base'
   require 'geoblacklight/metadata_transformer/fgdc'
   require 'geoblacklight/metadata_transformer/iso19139'
+  require 'geoblacklight/nested_references'
   require 'geoblacklight/reference'
   require 'geoblacklight/references'
   require 'geoblacklight/routes'

--- a/lib/geoblacklight/nested_references.rb
+++ b/lib/geoblacklight/nested_references.rb
@@ -1,0 +1,49 @@
+module Geoblacklight
+  # Determines whether references or dct_references_s is used
+  class NestedReferences
+    attr_reader :document
+
+    def initialize(document)
+      @document = document
+    end
+    
+    def references
+      @references = document.fetch('references', []).map { |r| NestedReference.new(r) }
+    end
+
+    def downloads
+      references.select { |d| d.type == 'http://schema.org/downloadUrl' }
+    end
+    
+    class NestedReference
+      attr_reader :reference
+
+      def initialize(reference)
+        @reference = reference
+      end
+
+      def type
+        parsed.select { |p| p[0] == 'type' }&.first&.dig(1)
+      end
+
+      def url
+        parsed.select { |p| p[0] == 'url' }&.first&.dig(1)
+      end
+
+      def label
+        parsed.select { |p| p[0] == 'label' }&.first&.dig(1)
+      end
+
+
+      private
+
+      ##
+      # We have to do some fun parsing here since the docs returned aren't JSON
+      def parsed
+        reference.sub(/^{/, '').sub(/}$/, '').split(',').map do |s|
+          s.strip.split('=', 2)
+        end
+      end
+    end
+  end
+end

--- a/solr/conf/schema.xml
+++ b/solr/conf/schema.xml
@@ -12,6 +12,14 @@
     <field name="text" type="text_en" stored="false" indexed="true" multiValued="true"
                        termVectors="true" termPositions="true" termOffsets="true" />
 
+
+                       
+    <field name="_root_" type="string" indexed="true" stored="true" docValues="false" />
+    <field name="_nest_parent_" type="string" indexed="true" stored="true"/>
+    <field name="_nest_path_" type="_nest_path_" indexed="true" stored="true"/>
+ 
+    <field name="references" type="_nest_path_" indexed="true" stored="true" multiValued="true"/>
+
     <!-- dynamic field with simple types by suffix -->
     <dynamicField name="*_b"    type="boolean" stored="true"  indexed="true"/>
     <dynamicField name="*_d"    type="double"  stored="true"  indexed="true"/>
@@ -147,7 +155,8 @@
     <!-- Adding field type for bboxField that enables, among other things, overlap ratio calculations -->
     <fieldType name="bbox" class="solr.BBoxField"
            geo="true" distanceUnits="kilometers" numberType="pdouble" />
-    <fieldType name="pdouble" class="solr.DoublePointField" docValues="true"/>   
+    <fieldType name="pdouble" class="solr.DoublePointField" docValues="true"/>
+    <fieldType name="_nest_path_" class="solr.NestPathField" /> 
    
 
   </types>

--- a/spec/fixtures/solr_documents/actual-point1.json
+++ b/spec/fixtures/solr_documents/actual-point1.json
@@ -26,6 +26,18 @@
   "dct_temporal_sm": [
     "2014"
   ],
+  "references": [
+    {
+      "type": "http://schema.org/downloadUrl",
+      "url": "https://archive.nyu.edu/retrieve/74563/nyu_2451_34564.zip",
+      "label": "Shapefile"
+    },
+    {
+      "type": "http://schema.org/downloadUrl",
+      "url": "https://archive.nyu.edu/retrieve/74563/nyu_2451_34564.zip",
+      "label": "File GeoDatabase"
+    }
+  ],
   "geoblacklight_version": "1.0",
   "layer_geom_type_s": "Point",
   "layer_id_s": "sdr:nyu_2451_34564",


### PR DESCRIPTION
A few things about this PR.

 - It enables multiple downloads in an experimental way
 - It kind of hacks around nested Solr documents unless/until Solr can support `UUIDUpdateProcessorFactory` for child documents or we want to provide UUIDs for each child. https://issues.apache.org/jira/browse/SOLR-9477?focusedCommentId=17025912&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-17025912
 - We could look at changing the UUID field away from `layer_slug_s` if we want to better support this
 - I _think_ this will be extensible to the other types of services we want to provide access to
 - Has to have more than 1 value