### PR TITLE
Add env variable to download path

### DIFF
--- a/lib/geoblacklight/download.rb
+++ b/lib/geoblacklight/download.rb
@@ -14,7 +14,7 @@ module Geoblacklight
     end
 
     def self.file_path
-      Settings.DOWNLOAD_PATH || "#{Rails.root}/tmp/cache/downloads"
+      Settings.DOWNLOAD_PATH || ENV['GEOBLACKLIGHT_DOWNLOAD_PATH'] || "#{Rails.root}/tmp/cache/downloads"
     end
 
     def file_path_and_name


### PR DESCRIPTION
The download path can be configured using the ENV variable GEOBLACKLIGHT_DOWNLOAD_PATH.  It will be easier for other app using GeoBlacklight gem to configure the download path.