### PR TITLE
Use modern node-browsers for circle-ci + Blacklight v7.8.0 fixes to fix build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,18 +32,18 @@ jobs:
       # Restore bundle and internal test app from the cache
       - restore_cache:
           keys:
-            - geoblacklight-bundle-{{ checksum "geoblacklight.gemspec" }}-{{ checksum "Gemfile" }}-<< parameters.ruby_version >>-<< parameters.rails_version >>
+            - bust123-geoblacklight-bundle-{{ checksum "geoblacklight.gemspec" }}-{{ checksum "Gemfile" }}-<< parameters.ruby_version >>-<< parameters.rails_version >>
       # Install gems
       - run: bundle check || bundle install
       # Store bundle cache
       - save_cache:
-          key: geoblacklight-bundle-{{ checksum "geoblacklight.gemspec" }}-{{ checksum "Gemfile" }}-<< parameters.ruby_version >>-<< parameters.rails_version >>
+          key: bust123-geoblacklight-bundle-{{ checksum "geoblacklight.gemspec" }}-{{ checksum "Gemfile" }}-<< parameters.ruby_version >>-<< parameters.rails_version >>
           paths:
             - /home/circleci/geoblacklight/vendor/bundle
         # Restore internal test app from the cache
       - restore_cache:
           keys:
-            - geoblacklight-internal-test-app-{{ checksum "geoblacklight.gemspec" }}-{{ checksum "Gemfile" }}-{{ checksum "spec/test_app_templates/Gemfile.extra" }}-<< parameters.ruby_version >>-<< parameters.rails_version >>
+            - bust123-geoblacklight-internal-test-app-{{ checksum "geoblacklight.gemspec" }}-{{ checksum "Gemfile" }}-{{ checksum "spec/test_app_templates/Gemfile.extra" }}-<< parameters.ruby_version >>-<< parameters.rails_version >>
       # Generate the internal test app
       - run:
           name: Generate test app
@@ -51,7 +51,7 @@ jobs:
             [ -e ./.internal_test_app ] || bundle exec rake engine_cart:generate
       - save_cache:
           name: Save test app cache
-          key: geoblacklight-internal-test-app-{{ checksum "geoblacklight.gemspec" }}-{{ checksum "Gemfile" }}-{{ checksum "spec/test_app_templates/Gemfile.extra" }}-<< parameters.ruby_version >>-<< parameters.rails_version >>
+          key: bust123-geoblacklight-internal-test-app-{{ checksum "geoblacklight.gemspec" }}-{{ checksum "Gemfile" }}-{{ checksum "spec/test_app_templates/Gemfile.extra" }}-<< parameters.ruby_version >>-<< parameters.rails_version >>
           paths:
             - ./.internal_test_app
       - run:
@@ -109,7 +109,7 @@ jobs:
       # Restore bundle cache
       - restore_cache:
           keys:
-            - geoblacklight-bundle-{{ checksum "geoblacklight.gemspec" }}-{{ checksum "Gemfile" }}-<< parameters.ruby_version >>-<< parameters.rails_version >>
+            - bust123-geoblacklight-bundle-{{ checksum "geoblacklight.gemspec" }}-{{ checksum "Gemfile" }}-<< parameters.ruby_version >>-<< parameters.rails_version >>
           paths:
             - /home/circleci/geoblacklight/vendor/bundle
       # Install gems and run rubocop

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,11 +29,6 @@ jobs:
     parallelism: 4
     steps:
       - checkout
-      # Update chrome
-      - run: wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
-      - run: sudo sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
-      - run: sudo apt-get update
-      - run: sudo apt-get -y install google-chrome-stable
       # Restore bundle and internal test app from the cache
       - restore_cache:
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
         type: string
         default: '5.1.7'
     docker:
-      - image: circleci/ruby:<< parameters.ruby_version >>-node-browsers-legacy
+      - image: circleci/ruby:<< parameters.ruby_version >>-node-browsers
       - image: solr:7-alpine
         command: bin/solr -cloud -noprompt -f -p <<parameters.solr_port>>
     environment:
@@ -100,7 +100,7 @@ jobs:
         type: string
         default: '5.1.7'
     docker:
-      - image: circleci/ruby:<< parameters.ruby_version >>-node-browsers-legacy
+      - image: circleci/ruby:<< parameters.ruby_version >>-node-browsers
     environment:
       GEM_HOME: /home/circleci/geoblacklight/vendor/bundle
       BUNDLE_PATH: /home/circleci/geoblacklight/vendor/bundle

--- a/lib/geoblacklight/catalog_helper_override.rb
+++ b/lib/geoblacklight/catalog_helper_override.rb
@@ -5,7 +5,7 @@ module Geoblacklight
     # @param [Symbol] symbol of field to be removed
     # @param [Hash] request parameters
     def remove_spatial_filter_group(field, source_params = params)
-      p = source_params.dup
+      p = source_params.dup.to_h
       p.delete(field.to_s)
       p
     end

--- a/lib/geoblacklight/view_helper_override.rb
+++ b/lib/geoblacklight/view_helper_override.rb
@@ -26,7 +26,7 @@ module Geoblacklight
 
     def render_constraints_filters(localized_params = params)
       content = super(localized_params)
-      localized_params = localized_params.to_unsafe_h unless localized_params.is_a?(Hash)
+      localized_params = localized_params.to_unsafe_h if localized_params.respond_to?(:to_unsafe_h)
 
       if localized_params[:bbox]
         path = search_action_path(remove_spatial_filter_group(:bbox, localized_params))


### PR DESCRIPTION
2e90cde8c48c1cbc48a0d07aaf3f2b3eca36da76 busts the cache for the circle-ci builds. We probably want to revisit this at some point.

Fixes #895 