### PR TITLE
Enable data relations widget to use icons from the related item 

### DIFF
--- a/app/helpers/geoblacklight_helper.rb
+++ b/app/helpers/geoblacklight_helper.rb
@@ -322,4 +322,11 @@ module GeoblacklightHelper
       args[:document].references.url.endpoint
     ) if args[:document]&.references&.url
   end
+
+  ## Returns the icon used based off a Settings strategy
+  def relations_icon(document, icon)
+    icon_name = document[Settings.FIELDS.GEOM_TYPE] if Settings.USE_GEOM_FOR_RELATIONS_ICON
+    icon_name = icon if icon_name.blank?
+    geoblacklight_icon(icon_name)
+  end
 end

--- a/app/views/relation/_ancestors.html.erb
+++ b/app/views/relation/_ancestors.html.erb
@@ -4,7 +4,7 @@
 <% @relations.ancestors['docs'].each do |ancestor| %>
   <li class="list-group-item">
     <%= link_to solr_document_path(ancestor['layer_slug_s']) do %>
-      <%= geoblacklight_icon('pagelines-brands') %>
+      <%= relations_icon(ancestor, 'pagelines-brands') %>
       <%= ancestor['dc_title_s'] %>
     <% end %>
   </li>

--- a/app/views/relation/_descendants.html.erb
+++ b/app/views/relation/_descendants.html.erb
@@ -4,7 +4,7 @@
 <% @relations.descendants['docs'][0..2].each do |descendant| %>
   <li class="list-group-item">
     <%= link_to solr_document_path(descendant['layer_slug_s']) do %>
-      <%= geoblacklight_icon('leaf') %>
+      <%= relations_icon(descendant, 'leaf') %>
       <%= descendant['dc_title_s'] %>
     <% end %>
   </li>

--- a/lib/generators/geoblacklight/templates/settings.yml
+++ b/lib/generators/geoblacklight/templates/settings.yml
@@ -61,6 +61,9 @@ TIMEOUT_DOWNLOAD: 16
 # (For WMS inspection) timeout and open_timeout parameters for Faraday
 TIMEOUT_WMS: 4
 
+# Use the geometry type for the data relations icon
+USE_GEOM_FOR_RELATIONS_ICON: false
+
 # Web services shown in tool panel
 WEBSERVICES_SHOWN:
   - 'wms'

--- a/lib/geoblacklight/relation/ancestors.rb
+++ b/lib/geoblacklight/relation/ancestors.rb
@@ -8,7 +8,7 @@ module Geoblacklight
 
       def create_search_params
         { fq: ["{!join from=#{Settings.FIELDS.SOURCE} to=layer_slug_s}layer_slug_s:#{@search_id}"],
-          fl: [Settings.FIELDS.TITLE, 'layer_slug_s'] }
+          fl: [Settings.FIELDS.TITLE, 'layer_slug_s', Settings.FIELDS.GEOM_TYPE] }
       end
 
       def execute_query

--- a/lib/geoblacklight/relation/descendants.rb
+++ b/lib/geoblacklight/relation/descendants.rb
@@ -8,7 +8,7 @@ module Geoblacklight
 
       def create_search_params
         { fq: "#{Settings.FIELDS.SOURCE}:#{@search_id}",
-          fl: [Settings.FIELDS.TITLE, 'layer_slug_s'] }
+          fl: [Settings.FIELDS.TITLE, 'layer_slug_s', Settings.FIELDS.GEOM_TYPE] }
       end
 
       def execute_query

--- a/spec/features/relations_spec.rb
+++ b/spec/features/relations_spec.rb
@@ -17,7 +17,8 @@ feature 'Display related documents' do
                     [
                       {
                         'dc_title_s' => '2015 New York City Subway Complexes and Ridership',
-                        'layer_slug_s' => 'nyu_2451_34502'
+                        'layer_slug_s' => 'nyu_2451_34502',
+                        'layer_geom_type_s' => 'Point'
                       }
                     ]
             },

--- a/spec/helpers/geoblacklight_helper_spec.rb
+++ b/spec/helpers/geoblacklight_helper_spec.rb
@@ -326,4 +326,17 @@ describe GeoblacklightHelper, type: :helper do
       end
     end
   end
+
+  describe '#relations_icon' do
+    it 'renders a goemetry type if configured' do
+      allow(Settings).to receive(:USE_GEOM_FOR_RELATIONS_ICON).and_return(true)
+      html = Capybara.string(helper.relations_icon({ 'layer_geom_type_s' => 'polygon' }, 'leaf'))
+      expect(html.title.strip).to eq 'polygon icon'
+    end
+    it 'renders provided icon if not configured to use geometry' do
+      allow(Settings).to receive(:USE_GEOM_FOR_RELATIONS_ICON).and_return(false)
+      html = Capybara.string(helper.relations_icon({ 'layer_geom_type_s' => 'polygon' }, 'leaf'))
+      expect(html.title.strip).to eq 'leaf icon'
+    end
+  end
 end

--- a/spec/lib/geoblacklight/relation/ancestors_spec.rb
+++ b/spec/lib/geoblacklight/relation/ancestors_spec.rb
@@ -7,7 +7,7 @@ describe Geoblacklight::Relation::Ancestors do
 
   describe '#create_search_params' do
     it 'assembles the correct search params for finding ancestor documents' do
-      expect(ancestors.create_search_params).to eq(fq: ["{!join from=#{Settings.FIELDS.SOURCE} to=layer_slug_s}layer_slug_s:nyu_2451_34502"], fl: [Settings.FIELDS.TITLE.to_s, 'layer_slug_s'])
+      expect(ancestors.create_search_params).to eq(fq: ["{!join from=#{Settings.FIELDS.SOURCE} to=layer_slug_s}layer_slug_s:nyu_2451_34502"], fl: [Settings.FIELDS.TITLE.to_s, 'layer_slug_s', 'layer_geom_type_s'])
     end
   end
 

--- a/spec/lib/geoblacklight/relation/descendants_spec.rb
+++ b/spec/lib/geoblacklight/relation/descendants_spec.rb
@@ -7,7 +7,7 @@ describe Geoblacklight::Relation::Descendants do
 
   describe '#create_search_params' do
     it 'assembles the correct search params for finding descendant documents' do
-      expect(descendants.create_search_params).to eq(fq: "#{Settings.FIELDS.SOURCE}:nyu_2451_34636", fl: [Settings.FIELDS.TITLE.to_s, 'layer_slug_s'])
+      expect(descendants.create_search_params).to eq(fq: "#{Settings.FIELDS.SOURCE}:nyu_2451_34636", fl: [Settings.FIELDS.TITLE.to_s, 'layer_slug_s', 'layer_geom_type_s'])
     end
   end
 


### PR DESCRIPTION
fixes #907

This has been enabled in a backwards compatible way so that adopters wanting to use the static leaf icons still can do so.

![Kapture 2020-06-23 at 19 01 08](https://user-images.githubusercontent.com/1656824/85484474-220fe900-b584-11ea-9a1b-bf2d20184c40.gif)
