### PR TITLE
Add a for/id attribute on the wfs/wms specific web services partials.

### DIFF
--- a/app/views/catalog/_web_services_wfs.html.erb
+++ b/app/views/catalog/_web_services_wfs.html.erb
@@ -2,7 +2,7 @@
 
 <%= render partial: 'web_services_default', locals: { reference: reference } %>
 
-<div class='form-group form-inline'>
-  <label class='control-label'><%= t('geoblacklight.references.wfs_abv')%> <code><%= t('geoblacklight.references.wfs_label')%></code></label>
-  <input type='text' value='<%= document.wxs_identifier %>' readonly='readonly' class='form-control'>
+<div class="form-group form-inline">
+  <label for="wfs_abv_webservice" class="mr-2"><%= t('geoblacklight.references.wfs_abv')%> <code><%= t('geoblacklight.references.wfs_label')%></code></label>
+  <input id="wfs_abv_webservice" type='text' value='<%= document.wxs_identifier %>' readonly='readonly' class="form-control">
 </div>

--- a/app/views/catalog/_web_services_wms.html.erb
+++ b/app/views/catalog/_web_services_wms.html.erb
@@ -2,7 +2,7 @@
 
 <%= render partial: 'web_services_default', locals: { reference: reference } %>
 
-<div class='form-group form-inline'>
-  <label class='control-label'><%= t('geoblacklight.references.wms_abv')%> <code><%= t('geoblacklight.references.wms_label')%></code></label>
-  <input type='text' value='<%= document.wxs_identifier %>' readonly='readonly' class='form-control'>
+<div class="form-group form-inline">
+  <label for="wms_abv_webservice" class="mr-2"><%= t('geoblacklight.references.wms_abv')%> <code><%= t('geoblacklight.references.wms_label')%></code></label>
+  <input id="wms_abv_webservice" type='text' value='<%= document.wxs_identifier %>' readonly='readonly' class="form-control">
 </div>


### PR DESCRIPTION
(also update the bootstrap classes for improved styling)

Closes sul-dlss/earthworks#642

I can't speak to the usage of `readonly` form elements here, but it looks like it has been that way since this feature was implemented.

## stanford-cg357zz0321 (before)
<img width="523" alt="stanford-cg357zz0321-before" src="https://user-images.githubusercontent.com/96776/85503546-c868e800-b59e-11ea-8787-03d7381cd926.png">
## stanford-cg357zz0321 markup (before)
<img width="406" alt="stanford-cg357zz0321-markup-before" src="https://user-images.githubusercontent.com/96776/85503549-ca32ab80-b59e-11ea-8f20-db5a876cbc0c.png">

## stanford-cg357zz0321 (after)
<img width="525" alt="stanford-cg357zz0321-after" src="https://user-images.githubusercontent.com/96776/85503552-cacb4200-b59e-11ea-93f4-ba331b75b41c.png">
## stanford-cg357zz0321 markup (after)
<img width="415" alt="stanford-cg357zz0321-markup-after" src="https://user-images.githubusercontent.com/96776/85503553-cb63d880-b59e-11ea-838a-b7bd7c6e68f4.png">
