### PR TITLE
Split Data Relations card into separate cards for ancestors/descendants 

### DIFF
--- a/app/assets/stylesheets/geoblacklight/_geoblacklight.scss
+++ b/app/assets/stylesheets/geoblacklight/_geoblacklight.scss
@@ -30,7 +30,6 @@
 @import 'modules/search_widgets';
 @import 'modules/sidebar';
 @import 'modules/toolbar';
-@import 'modules/relations';
 @import 'modules/web_services';
 @import 'blacklight_overrides';
 @import 'modules/downloads';

--- a/app/assets/stylesheets/geoblacklight/modules/relations.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/relations.scss
@@ -1,8 +1,0 @@
-.relations {
-  @include sidebar-children;
-
-  .list-group .list-group-item {
-    margin-top: 8px;
-    padding-bottom: 6px;
-  }
-}

--- a/app/views/relation/_ancestors.html.erb
+++ b/app/views/relation/_ancestors.html.erb
@@ -1,5 +1,5 @@
 <% @relations.ancestors['docs'].each do |ancestor| %>
-  <li class="list-group-item">
+  <li class="list-group-item border-bottom-0">
     <%= link_to solr_document_path(ancestor['layer_slug_s']) do %>
       <%= relations_icon(ancestor, 'pagelines-brands') %>
       <%= ancestor['dc_title_s'] %>

--- a/app/views/relation/_ancestors.html.erb
+++ b/app/views/relation/_ancestors.html.erb
@@ -1,6 +1,3 @@
-<li class="list-group-item relations-ancestors">
-  <b><%= t('geoblacklight.relations.ancestor') %></b>
-</li>
 <% @relations.ancestors['docs'].each do |ancestor| %>
   <li class="list-group-item">
     <%= link_to solr_document_path(ancestor['layer_slug_s']) do %>

--- a/app/views/relation/_descendants.html.erb
+++ b/app/views/relation/_descendants.html.erb
@@ -1,6 +1,3 @@
-<li class="list-group-item relations-descendants">
-  <b><%= t('geoblacklight.relations.descendant', count: @relations.descendants['numFound']) %></b>
-</li>
 <% @relations.descendants['docs'][0..2].each do |descendant| %>
   <li class="list-group-item">
     <%= link_to solr_document_path(descendant['layer_slug_s']) do %>

--- a/app/views/relation/_descendants.html.erb
+++ b/app/views/relation/_descendants.html.erb
@@ -1,5 +1,5 @@
 <% @relations.descendants['docs'][0..2].each do |descendant| %>
-  <li class="list-group-item">
+  <li class="list-group-item border-bottom-0">
     <%= link_to solr_document_path(descendant['layer_slug_s']) do %>
       <%= relations_icon(descendant, 'leaf') %>
       <%= descendant['dc_title_s'] %>
@@ -7,7 +7,7 @@
   </li>
 <% end %>
 <% unless (@relations.descendants['numFound'].to_i <= 3) %>
-  <li class="list-group-item">
+  <li class="list-group-item border-bottom-0">
     <%= link_to search_catalog_path({f: {"#{Settings.FIELDS.SOURCE}" => [@relations.link_id]}}) do %>
       <%= t('geoblacklight.relations.browse_all', count: @relations.descendants['numFound']) %>
     <% end %>

--- a/app/views/relation/index.html.erb
+++ b/app/views/relation/index.html.erb
@@ -1,13 +1,25 @@
 <% unless @relations.empty? %>
-  <div class="card relations">
-    <div class="card-header">
-      <%= t('geoblacklight.relations.title') %>
+  <% unless @relations.ancestors['numFound'].to_i.zero? %>
+    <div class="card relations">
+      <div class="card-header">
+        <h2><%= t('geoblacklight.relations.ancestor') %></h2>
+      </div>
+
+      <ul class="list-group list-group-flush">
+        <%= render 'ancestors' %>
+      </ul>
     </div>
+  <% end %>
 
-    <ul class="list-group list-group-flush">
-      <%= render 'ancestors' unless @relations.ancestors['numFound'].to_i == 0 %>
-      <%= render 'descendants' unless @relations.descendants['numFound'].to_i == 0 %>
-    </ul>
+  <% unless @relations.descendants['numFound'].to_i.zero? %>
+    <div class="card relations">
+      <div class="card-header">
+        <h2><%= t('geoblacklight.relations.descendant') %></h2>
+      </div>
 
-  </div>
+      <ul class="list-group list-group-flush">
+        <%= render 'descendants' %>
+      </ul>
+    </div>
+  <% end %>
 <% end %>

--- a/app/views/relation/index.html.erb
+++ b/app/views/relation/index.html.erb
@@ -2,7 +2,7 @@
   <% unless @relations.ancestors['numFound'].to_i.zero? %>
     <div class="card relations">
       <div class="card-header">
-        <h2><%= t('geoblacklight.relations.ancestor') %></h2>
+        <h2 class="mb-0 h6"><%= t('geoblacklight.relations.ancestor') %></h2>
       </div>
 
       <ul class="list-group list-group-flush">
@@ -14,7 +14,7 @@
   <% unless @relations.descendants['numFound'].to_i.zero? %>
     <div class="card relations">
       <div class="card-header">
-        <h2><%= t('geoblacklight.relations.descendant') %></h2>
+        <h2 class="mb-0 h6"><%= t('geoblacklight.relations.descendant') %></h2>
       </div>
 
       <ul class="list-group list-group-flush">

--- a/config/locales/geoblacklight.en.yml
+++ b/config/locales/geoblacklight.en.yml
@@ -66,9 +66,8 @@ en:
       services_close: 'Close'
     relations:
       ancestor: 'Source Datasets'
-      descendant: 'Derived Datasets (%{count})'
+      descendant: 'Derived Datasets'
       browse_all: "Browse all %{count} records..."
-      title: 'Data Relations'
     metadata:
       view_metadata: 'View Metadata'
       more_details: 'More details at'

--- a/spec/features/relations_spec.rb
+++ b/spec/features/relations_spec.rb
@@ -3,12 +3,12 @@ require 'spec_helper'
 feature 'Display related documents' do
   scenario 'Record with dc_source_sm value(s) should have parent(s)' do
     visit relations_solr_document_path('nyu_2451_34502')
-    expect(page).to have_css('ul b', text: 'Source Datasets')
+    expect(page).to have_css('.relations .card-header h2', text: 'Source Datasets')
   end
 
   scenario 'Record that is pointed to by others should have children' do
     visit relations_solr_document_path('nyu_2451_34635')
-    expect(page).to have_css('ul b', text: 'Derived Datasets')
+    expect(page).to have_css('.relations .card-header h2', text: 'Derived Datasets')
   end
 
   scenario 'Relations should respond to json' do
@@ -21,11 +21,12 @@ feature 'Display related documents' do
 
   scenario 'Record with relations should render widget in catalog#show', js: true do
     visit solr_document_path('nyu_2451_34635')
-    expect(page).to have_css('div.card-header', text: 'Data Relations')
+    expect(page).to have_css('.card.relations')
+    expect(page).to have_css('div.card-header', text: 'Derived Datasets')
   end
 
   scenario 'Record without relations should not render widget in catalog#show', js: true do
     visit solr_document_path('harvard-g7064-s2-1834-k3')
-    expect(page).to have_no_css('div.panel-heading', text: 'Data Relations')
+    expect(page).to have_no_css('.card.relations')
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,6 +26,7 @@ require 'rails-controller-testing' if Rails::VERSION::MAJOR >= 5
 require 'rspec/rails'
 require 'capybara/rspec'
 require 'selenium-webdriver'
+require 'webdrivers'
 
 Capybara.register_driver(:headless_chrome) do |app|
   Capybara::Selenium::Driver.load_selenium


### PR DESCRIPTION
Part of #906 
Part of #909 

This also removed the custom relations css module to adopt something closer to the Blacklight approach for styling cards.

## princeton-1r66j405w (before)
<img width="277" alt="princeton-1r66j405w-before" src="https://user-images.githubusercontent.com/96776/85907675-20823300-b7c7-11ea-8f79-703fb638c712.png">

## princeton-1r66j405w (after)
<img width="287" alt="princeton-1r66j405w-after" src="https://user-images.githubusercontent.com/96776/85907681-2415ba00-b7c7-11ea-8aca-159520b0eab0.png">

## princeton-n009w382v (before)
<img width="294" alt="princeton-n009w382v-before" src="https://user-images.githubusercontent.com/96776/85907677-237d2380-b7c7-11ea-933b-fdb26e0d3db5.png">

## princeton-n009w382v (after)
<img width="285" alt="princeton-n009w382v-after" src="https://user-images.githubusercontent.com/96776/85908794-853f8c80-b7cb-11ea-9918-de41f34bc63e.png">


## nyu_2451_34502 (before)
<img width="280" alt="nyu_2451_34502-before" src="https://user-images.githubusercontent.com/96776/85907678-2415ba00-b7c7-11ea-8a61-b7c502eb4aed.png">

## nyu_2451_34502 (after)
<img width="279" alt="nyu_2451_34502-after" src="https://user-images.githubusercontent.com/96776/85908766-5cb79280-b7cb-11ea-87fd-872982a4ba28.png">

