### PR TITLE
Add support for multiple downloads using current dct_references_s approach

### DIFF
--- a/app/helpers/geoblacklight_helper.rb
+++ b/app/helpers/geoblacklight_helper.rb
@@ -40,6 +40,7 @@ module GeoblacklightHelper
       }
     )
   end
+  deprecation_deprecate download_link_direct: 'Use download_link_file instead'
 
   def download_link_hgl(text, document)
     link_to(

--- a/app/helpers/geoblacklight_helper.rb
+++ b/app/helpers/geoblacklight_helper.rb
@@ -13,6 +13,20 @@ module GeoblacklightHelper
     @document.references.iiif.endpoint.sub! 'info.json', 'full/full/0/default.jpg'
   end
 
+  def download_link_file(label, id, url)
+    link_to(
+      label,
+      url,
+      'contentUrl' => url,
+      class: ['btn', 'btn-default', 'download', 'download-original'],
+      data: {
+        download: 'trigger',
+        download_type: 'direct',
+        download_id: id
+      }
+    )
+  end
+
   def download_link_direct(text, document)
     link_to(
       text,

--- a/app/views/catalog/_downloads_primary.html.erb
+++ b/app/views/catalog/_downloads_primary.html.erb
@@ -2,7 +2,14 @@
 <% document ||= @document %>
 
 <% if document.direct_download.present? %>
-  <%= render partial: 'download_link', locals: { download_link: download_link_direct(download_text(document.file_format), document) } %>
+  <% if document.direct_download[:download].is_a? Array %>
+    <% document.direct_download[:download].each do |download| %>
+      <%= render partial: 'download_link', locals: { download_link: download_link_file(download['label'], document.id, download['url']) } %>
+    <% end %>
+  <% end %>
+  <% if document.direct_download[:download].is_a? String %>
+    <%= render partial: 'download_link', locals: { download_link: download_link_direct(download_text(document.file_format), document) } %>
+  <% end %>
 <% end %>
 
 <% if document.hgl_download.present? %>

--- a/spec/features/multiple_downloads_spec.rb
+++ b/spec/features/multiple_downloads_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+feature 'Multiple downloads' do
+  feature 'when item has multiple downloads in dct_references_s' do
+    scenario 'downloads are listed in download card' do
+      visit solr_document_path 'cugir-007950'
+      within '.card.downloads' do
+        expect(page).to have_link 'Shapefile', href: 'https://cugir-data.s3.amazonaws.com/00/79/50/cugir-007950.zip'
+        expect(page).to have_link 'PDF', href: 'https://cugir-data.s3.amazonaws.com/00/79/50/agBROO.pdf'
+        expect(page).to have_link 'KMZ', href: 'https://cugir-data.s3.amazonaws.com/00/79/50/agBROO2011.kmz'
+      end
+    end
+  end
+end

--- a/spec/features/search_results_overlap_ratio_spec.rb
+++ b/spec/features/search_results_overlap_ratio_spec.rb
@@ -34,15 +34,15 @@ feature 'spatial search results overlap ratio' do
 
     # NY State result
     # Bigger bbox / result bbox overlaps bbox param best
-    expect(position_in_result_page(page, 'cugir-008186')).to be < 3
+    expect(position_in_result_page(page, 'cugir-008186')).to be < 4
 
     # NY State result
     # Bigger bbox / result bbox overlaps bbox param best (score tie)
-    expect(position_in_result_page(page, 'cugir-008186-no-downloadurl')).to be < 3
+    expect(position_in_result_page(page, 'cugir-008186-no-downloadurl')).to be < 4
 
     # NY Adirondak Region result
     # Smaller bbox / result bbox overlaps bbox param the least
-    expect(position_in_result_page(page, 'cugir-007741')).to eq 3
+    expect(position_in_result_page(page, 'cugir-007741')).to eq 4
   end
 end
 

--- a/spec/fixtures/solr_documents/multiple-downloads.json
+++ b/spec/fixtures/solr_documents/multiple-downloads.json
@@ -1,0 +1,30 @@
+{
+  "geoblacklight_version": "1.0",
+  "dc_identifier_s": "https://cugir.library.cornell.edu/catalog/cugir-007950",
+  "dc_title_s": "Test record with additional download formats",
+  "dc_description_s": "This is a test record containing new-style references as nested child documents.  In addition to the origianl shapefile download, the references section contains additional PDF and KMZ downloads.",
+  "dc_rights_s": "Public",
+  "dct_provenance_s": "Cornell",
+  "dct_references_s": "{\"http:\/\/schema.org\/downloadUrl\":[{\"url\":\"https:\/\/cugir-data.s3.amazonaws.com\/00\/79\/50\/cugir-007950.zip\",\"label\":\"Shapefile\"},{\"url\":\"https:\/\/cugir-data.s3.amazonaws.com\/00\/79\/50\/agBROO.pdf\",\"label\":\"PDF\"},{\"url\":\"https:\/\/cugir-data.s3.amazonaws.com\/00\/79\/50\/agBROO2011.kmz\",\"label\":\"KMZ\"}],\"http:\/\/www.opengis.net\/cat\/csw\/csdgm\":\"https:\/\/cugir-data.s3.amazonaws.com\/00\/79\/50\/fgdc.xml\",\"http:\/\/www.w3.org\/1999\/xhtml\":\"https:\/\/cugir-data.s3.amazonaws.com\/00\/79\/50\/fgdc.html\",\"http:\/\/www.opengis.net\/def\/serviceType\/ogc\/wfs\":\"https:\/\/cugir.library.cornell.edu\/geoserver\/cugir\/wfs\",\"http:\/\/www.opengis.net\/def\/serviceType\/ogc\/wms\":\"https:\/\/cugir.library.cornell.edu\/geoserver\/cugir\/wms\"}",
+  "layer_id_s": "cugir007950",
+  "layer_slug_s": "cugir-007950",
+  "dc_type_s": "Dataset",
+  "dc_format_s": "Shapefile",
+  "layer_geom_type_s": "Polygon",
+  "layer_modified_dt": "2019-05-24T00:00:00Z",
+  "dc_creator_sm": [
+    "Cornell Institute for Resource Information Sciences (Cornell IRIS)",
+    "NYS Department of Agriculture and Markets"
+  ],
+  "dc_subject_sm": [
+    "New York State Agricultural District boundaries",
+    "Agriculture and Markets",
+    "Agricultural Districts Mapping Program"
+  ],
+  "dct_spatial_sm": ["Broome County NY"],
+  "dct_issued_s": "2011-02-28",
+  "dct_temporal_sm": ["2011"],
+  "dct_isPartOf_sm": ["Agricultural Districts (NYS Ag and Markets)"],
+  "solr_geom": "ENVELOPE(-76.12987, -75.42034, 42.414648, 41.997963)",
+  "solr_year_i": 2011
+}

--- a/spec/helpers/geoblacklight_helper_spec.rb
+++ b/spec/helpers/geoblacklight_helper_spec.rb
@@ -52,6 +52,17 @@ describe GeoblacklightHelper, type: :helper do
     end
   end
 
+  describe '#download_link_file' do
+    let(:label) { 'Test Link Text' }
+    let(:id) { 'test-id' }
+    let(:url) { 'http://example.com/urn:hul.harvard.edu:HARVARD.SDE2.TG10USAIANNH/data.zip' }
+
+    it 'generates a link to download the original file' do
+      puts download_link_file(label, id, url)
+      expect(download_link_file(label, id, url)).to eq '<a contentUrl="http://example.com/urn:hul.harvard.edu:HARVARD.SDE2.TG10USAIANNH/data.zip" class="btn btn-default download download-original" data-download="trigger" data-download-type="direct" data-download-id="test-id" href="http://example.com/urn:hul.harvard.edu:HARVARD.SDE2.TG10USAIANNH/data.zip">Test Link Text</a>'
+    end
+  end
+
   describe '#download_link_direct' do
     let(:text) { 'Test Link Text' }
     let(:references_field) { Settings.FIELDS.REFERENCES }


### PR DESCRIPTION
This pull request aims to fix #340 in the most backwards compatible way possible. While great work has happened in investigating alternatives to this approach (#884, #882, #846) I'm wondering if this helps us unblock the way forward so that a feature like this can be used without a large data migration.

![image](https://user-images.githubusercontent.com/1656824/86256239-52074f80-bb75-11ea-8e43-5761904acc59.png)

This aims to accomplish the goal using the simplest means possible. While it does not accomplish some of the previous goals of using a now serialized JSON for the dct_references_s, I'm hoping it is a useful feature to adopters.

### Metadata updates

dct_references_s now can take an array as a value for `http://schema.org/downloadUrl`. That ends up looking like this (unescaped):
```json
{
  "http://schema.org/downloadUrl": [
    {
      "url": "https://cugir-data.s3.amazonaws.com/00/79/50/cugir-007950.zip",
      "label": "Shapefile"
    },
    {
      "url": "https://cugir-data.s3.amazonaws.com/00/79/50/agBROO.pdf",
      "label": "PDF"
    },
    {
      "url": "https://cugir-data.s3.amazonaws.com/00/79/50/agBROO2011.kmz",
      "label": "KMZ"
    }
  ],
  "http://www.opengis.net/cat/csw/csdgm": "https://cugir-data.s3.amazonaws.com/00/79/50/fgdc.xml",
  "http://www.w3.org/1999/xhtml": "https://cugir-data.s3.amazonaws.com/00/79/50/fgdc.html",
  "http://www.opengis.net/def/serviceType/ogc/wfs": "https://cugir.library.cornell.edu/geoserver/cugir/wfs",
  "http://www.opengis.net/def/serviceType/ogc/wms": "https://cugir.library.cornell.edu/geoserver/cugir/wms"
}
```
Where `url` and `label` are required here. Regular string values for `http://schema.org/downloadUrl` will also still work. This means no current metadata practices are needing to be updated, but those wanting to take advantage of this feature can. Also the `dct_references_s` field will still need to be stringified/escaped.

See https://github.com/geoblacklight/geoblacklight/compare/multi-downloads?expand=1#diff-f386df29f180a461a31b203807e17cf6 for a modified version of the test document submitted in #884 