### PR TITLE
Redo the search results display to be accessible

### DIFF
--- a/app/assets/javascripts/geoblacklight/modules/collapse.js
+++ b/app/assets/javascripts/geoblacklight/modules/collapse.js
@@ -1,7 +1,0 @@
-Blacklight.onLoad(function() {
-  $('#content')
-    .on('click', '#documents [data-layer-id]', function() {
-      $(this).find('.collapse').collapse('toggle');
-      $(this).find('.caret-toggle').toggleClass('open');
-    });
-});

--- a/app/assets/stylesheets/geoblacklight/modules/results.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/results.scss
@@ -3,45 +3,54 @@
 }
 
 .more-info-area {
-  float: left;
-  order:3;
   max-height: 100px;
   overflow:hidden;
 }
 
-.text-span{
-  width:80%;
-  float:left;
-}
-
-.hide-overflow {
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  display:block
-}
-
-.status-icons {
-  order: 2;
-  margin-left: 0.5rem;
-}
-
 .index_title {
-  order: 1;
-  @extend .text-span;
-  @extend .hide-overflow;
   @extend h5;
+  display: flex;
+  justify-content: space-between;
   font-size:1rem;
   width:80%;
-}
 
-.caret-toggle {
-  @extend .fa, .fa-caret-right;
-  cursor: pointer;
-  width: 10px;
+  .title-wrapper {
+    @extend .d-flex;
+    @extend .justify-content-start;
+    flex: 1;
+    min-width: 0;
+  }
 
-  &.open {
-    @extend .fa, .fa-caret-down;
+  .document-counter {
+    @extend .pr-1;
+  }
+
+  a {
+    white-space: nowrap;
+    overflow-x: hidden;
+    min-width: 0;
+    text-overflow: ellipsis;
+    position: relative;
+    z-index: 2; // get the link above the toggle
+  }
+
+  .caret-toggle {
+    @extend .fa, .fa-caret-right;
+    flex-grow: 0;
+    width: 10px;
+
+    &[aria-expanded="true"] {
+      @extend .fa, .fa-caret-down;
+    }
+  }
+
+  .document-counter {
+    flex-grow: 0;
+  }
+
+  .status-icons {
+    margin-left: 0.5rem;
+    white-space: nowrap;
   }
 }
 

--- a/app/views/catalog/_index_split_default.html.erb
+++ b/app/views/catalog/_index_split_default.html.erb
@@ -1,19 +1,27 @@
 <% # header bar for doc items in index view -%>
 <%= content_tag :div, class: 'documentHeader row', data: { layer_id: document.id, bbox: document.bounding_box_as_wsen } do %>
-  <div class='status-icons'>
-    <%= render partial: 'header_icons', locals: { document: document } %>
-  </div>
-  <h3 class="index_title col-sm-9s cosl-lg-10 text-span">
-    <span class='caret-toggle'></span>
-    <% counter = document_counter_with_offset(document_counter) %>
-    <span class="document-counter">
-      <%= t('blacklight.search.documents.counter', :counter => counter) if counter %>
+  <h3 class="index_title col pl-2">
+    <button
+      class="caret-toggle btn pl-0 py-0 stretched-link"
+      data-toggle="collapse"
+      data-target="#doc-<%= document.id %>-fields-collapse"
+      aria-expanded="false"
+      aria-controls="doc-<%= document.id %>-fields-collapse">
+    </button>
+    <span class="title-wrapper">
+      <% counter = document_counter_with_offset(document_counter) %>
+      <span class="document-counter">
+        <%= t('blacklight.search.documents.counter', :counter => counter) if counter %>
+      </span>
+      <%= link_to_document document, counter: counter, title: document[blacklight_config.index.title_field] %>
     </span>
-    <%= link_to_document document, counter: counter, title: document[blacklight_config.index.title_field] %>
+    <span class='status-icons'>
+      <%= render partial: 'header_icons', locals: { document: document } %>
+    </span>
   </h3>
 
   <div class='col-md-12 more-info-area'>
-    <div class='collapse' data-collapse-target="<%= document.id %>">
+    <div id="doc-<%= document.id %>-fields-collapse" class='collapse'>
       <small>
         <%= geoblacklight_present(:index_fields_display, document) %>
       </small>

--- a/spec/features/split_view.html.erb_spec.rb
+++ b/spec/features/split_view.html.erb_spec.rb
@@ -53,7 +53,7 @@ feature 'Index view', js: true do
   scenario 'click on a record area to expand collapse' do
     within('.documentHeader', match: :first) do
       expect(page).not_to have_css('.collapse')
-      find('.status-icons').click
+      find('button').click
       expect(page).to have_css('.collapse', visible: true)
     end
   end


### PR DESCRIPTION
- Use bootstrap collapse to handle collapsing
- Make the collapse toggle a button
- Use flexbox for truncation

Addresses part of https://github.com/sul-dlss/earthworks/issues/687

![Screen Shot 2020-07-01 at 09 48 11](https://user-images.githubusercontent.com/111218/86270368-fbebd980-bb7f-11ea-95bf-c8c5e94ff34a.png)
![Kapture 2020-07-01 at 9 50 14](https://user-images.githubusercontent.com/111218/86270579-4e2cfa80-bb80-11ea-8e43-1ac0edcc82dd.gif)
