### PR TITLE
Fix geoblacklight:downloads:mkdir task

### DIFF
--- a/lib/tasks/geoblacklight.rake
+++ b/lib/tasks/geoblacklight.rake
@@ -78,7 +78,7 @@ namespace :geoblacklight do
     end
     desc 'Create download directory'
     task mkdir: :environment do
-      FileUtils.mkdir_p Dir.glob("#{Rails.root}/tmp/cache/downloads")
+      FileUtils.mkdir_p Rails.root.join('tmp/cache/downloads'), verbose: true
     end
     desc 'Precaches a download'
     task :precache, [:doc_id, :download_type, :timeout] => [:environment] do |t, args|

--- a/spec/tasks/geoblacklight_spec.rb
+++ b/spec/tasks/geoblacklight_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+require 'rake'
+require 'fileutils'
+
+describe 'geoblacklight.rake' do
+  describe 'geoblacklight:downloads:mkdir' do
+    before do
+      Rails.application.load_tasks
+      FileUtils.rm_rf Rails.root.join('tmp/cache/downloads')
+    end
+
+    it 'creates the tmp/cache/downloads directory' do
+      Rake::Task['geoblacklight:downloads:mkdir'].invoke
+      expect(File.directory? Rails.root.join('tmp/cache/downloads')).
+        to be true
+    end
+  end
+end


### PR DESCRIPTION
- Removes unnecessary Dir.glob() call.
- Adds a test case (spec/tasks/geoblacklight.rake). This test case fails
with the original code.