### PR TITLE
Improve consistency of sidebar styling and refactor relevant SCSS

### DIFF
--- a/app/assets/stylesheets/geoblacklight/modules/downloads.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/downloads.scss
@@ -1,91 +1,72 @@
-%downloads-exports {
-  .list-group-item {
-    display: inline-block;
-    width: 100%;
-  }
-}
+// Common styling for the Downloads, Export, and Authentication cards
+.downloads,
+.card.exports,
+.authentication {
+  @include sidebar-children;
 
-%download-export-links {
-  a {
-    width: 100%;
-    font-weight: 600;
-    background-color: $link-color;
-    color: #ffffff;
-    border-color: darken($link-color, 6.5%);
-    white-space: inherit;
-  }
-}
+  .list-group {
+    &.list-group-nested .list-group-item:last-child {
+      padding-bottom: 0;
+    }
 
-@mixin download-export {
-  &-link {
-    &-container {
-      text-align: center;
-      @extend %download-export-links;
+    .list-group-item {
+      padding: 8px 20px;
+
+      a {
+        @extend .btn-primary;
+      }
     }
   }
 }
 
-.downloads {
-  @include sidebar-children;
-  @extend %downloads-exports;
-
-  .download {
-    @include download-export;
-  }
-}
-
+// This section could be eliminated if we update the Authentication card
+// to follow the pattern of Dowloads and Exports (put the button in a
+// list-group rather than the card header).
 .authentication {
-  @include sidebar-children;
   .card-header {
     background-color: inherit;
     border-bottom: inherit;
 
-    @extend %download-export-links;
+    a {
+      @extend .btn-primary;
+    }
   }
 }
 
-.exports {
-  @include sidebar-children;
-  @extend %downloads-exports;
-
+// Specific to the Export card (mostly because of the current external
+// label + button approach, which could be mostly eliminated by reworking
+// as suggested in https://github.com/sul-dlss/earthworks/issues/646)
+.card.exports {
   .card-header {
-    .fa-spinner {
+    .fa-spinner { // if this is used, it probably should go in the card body rather than the card header
       float: right;
     }
   }
 
   .export {
-    @include download-export;
-
-    padding-left: 0px;
-    padding-right: 0px;
     text-align: center;
-    width: 100%;
 
     @include media-breakpoint-up(xl) {
       text-align: left;
     }
 
-    &-label {
-      padding: 6px 12px;
+    .export-label {
+      padding: 6px 6px 6px 0;
 
       @include media-breakpoint-up(xl) {
         display: inline-block;
       }
     }
 
-    &-link {
-      &-container {
+    .export-link-container {
+      @include media-breakpoint-up(xl) {
+        display: inline-block;
+        float: right;
+      }
 
+      a {
         @include media-breakpoint-up(xl) {
-          display: inline-block;
-          float: right;
-        }
-
-        a {
-          @include media-breakpoint-up(xl) {
-            width: inherit;
-          }
+          width: inherit;
         }
       }
     }

--- a/app/assets/stylesheets/geoblacklight/modules/relations.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/relations.scss
@@ -1,15 +1,8 @@
 .relations {
   @include sidebar-children;
 
-  .list-group {
-    .relations-ancestors {
-      padding-left: 16px;
-      padding-right: 16px;
-    }
-
-    .relations-descendants {
-      padding-left: 16px;
-      padding-right: 16px;
-    }
+  .list-group .list-group-item {
+    margin-top: 8px;
+    padding-bottom: 6px;
   }
 }

--- a/app/assets/stylesheets/geoblacklight/modules/sidebar.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/sidebar.scss
@@ -1,59 +1,29 @@
 // Mixins and shared properties for sidebar elements
-
 @mixin sidebar-children {
-  %list-group-item-children {
-    padding: 10px 15px;
-  }
+  margin-bottom: 20px;
+  margin-top: 20px;
 
-  %list-group-item-anchors {
-    text-align: center;
-    width: 1.4em;
-  }
-
-  margin-top: 16px;
-  margin-bottom: 16px;
-
-  .card-header {
-    h2 {
-      display: inline-block;
-      padding-top: 8px;
-      padding-bottom: 8px;
-      margin-bottom: 0px;
-      font-size: 1rem;
-    }
+  .card-header h2 {
+    @extend .h6;
+    margin-bottom: 0px;
   }
 
   .card-subtitle {
-    margin: 1rem 0 .2rem;
-    font-size: .9rem;
+    margin: 1rem 0 0;
+    font-size: 1rem;
     font-weight: normal;
-    color: $gray-600;
   }
 
   .list-group {
-    padding-top: 24px;
-    padding-bottom: 24px;
-    padding-left: 4px;
-    padding-right: 4px;
+     border: 0;
+     margin: 8px 0;
 
     .list-group-item {
-      border-color: $white;
-      padding: 8px 16px;
+      border: 0;
+      padding: 0 0 0 20px;
 
       a {
-        @extend %list-group-item-children;
-
-        .geoblacklight {
-          color: $gray-600;
-        }
-      }
-    }
-
-    &-nested {
-      padding: 0;
-
-      .list-group-item {
-        padding: 8px 0;
+        display: block;
       }
     }
   }

--- a/app/assets/stylesheets/geoblacklight/modules/toolbar.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/toolbar.scss
@@ -1,70 +1,28 @@
 .show-tools {
   @include sidebar-children;
 
-  .list-group {
-
-    .list-group-item.exports {
-      margin-top:0px;
-    }
-
-    .list-group-item {
-
-      form {
-        @extend %list-group-item-children;
-
-        .checkbox {
-          margin-left: 4px;
-          margin-right: 4px;
-
-          label {
-            margin-bottom: inherit;
-          }
-        }
+  .list-group .list-group-item {
+    // Adjustments to give Bookmark same spacing as other Tools links
+    .checkbox {
+      label {
+        margin-bottom: 0;
       }
 
-      a {
-
-        .geoblacklight {
-
-          &-citation {
-            @extend %list-group-item-anchors;
-          }
-
-          &-data-dictionary {
-            @extend %list-group-item-anchors;
-          }
-
-          &-sms {
-            @extend %list-group-item-anchors;
-          }
-
-          &-email {
-            @extend %list-group-item-anchors;
-          }
-
-          &-web_services {
-            @extend %list-group-item-anchors;
-          }
-
-          &-metadata {
-            @extend %list-group-item-anchors;
-          }
-
-          &-carto {
-            @extend %list-group-item-anchors;
-          }
-
-          // DEPRECATED: Will be removed in GeoBlacklight v2.0
-          &-cartodb {
-            @extend %list-group-item-anchors;
-          }
-        }
+      .toggle-bookmark {
+        margin-right: 4px;
+        padding-bottom: 8px;
+        padding-top: 8px;
       }
     }
 
-    .downloads {
-      margin-left: 4px;
-      margin-right: 4px;
+    // Spacing for Tools links other than Bookmark
+    a {
+      padding: 8px 1rem 8px 0;
     }
+  }
+
+  // Spacing between Tools icons and their labels
+  .blacklight-icons {
+    padding-right: 2px;
   }
 }


### PR DESCRIPTION
This PR updates the item show page sidebar styling, with two main goals:

* Improve consistency of element spacing within the sidebar cards and reduce excess vertical whitespace to make overall sidebar more compact

* Refactor and simplify the sidebar-related SCSS files to make it easier to maintain styling consistency and do local overrides

As discussed with @mejackreed, this PR shouldn't be considered until the next major release. The updates look good on all of the 35 test fixtures (tested on Firefox, Safari, and Chrome on MacOS, not tested on Windows) but might break existing local customizations to the sidebar styling.

Further visual and SCSS simplification could be done if the suggestions (https://github.com/sul-dlss/earthworks/issues/646)  for how we present the Download and Export buttons are implemented.

Below are some examples from the test fixtures of what this PR does, with current `master` on the left and the updates from this PR on the right.

<img width="680" alt="Screen Shot 2020-07-10 at 8 45 09 AM" src="https://user-images.githubusercontent.com/101482/87178035-70fe9380-c291-11ea-92b5-033507ee6583.png">


---

<img width="600" alt="Screen Shot 2020-07-10 at 8 48 30 AM" src="https://user-images.githubusercontent.com/101482/87178059-778d0b00-c291-11ea-898f-529eec4e472b.png">

---

<img width="600" alt="Screen Shot 2020-07-10 at 8 48 42 AM" src="https://user-images.githubusercontent.com/101482/87178079-7cea5580-c291-11ea-8f21-d8e587492e5c.png">

---

<img width="579" alt="Screen Shot 2020-07-10 at 8 48 58 AM" src="https://user-images.githubusercontent.com/101482/87178094-81af0980-c291-11ea-887e-b5967cd07370.png">

