### PR TITLE
Add border to item map and space between it and WMS table

### DIFF
--- a/app/assets/stylesheets/geoblacklight/_styles.scss
+++ b/app/assets/stylesheets/geoblacklight/_styles.scss
@@ -1,4 +1,5 @@
 #table-container{
   overflow:scroll;
+  margin-top: 20px;
   max-height: 450px;
 }

--- a/app/assets/stylesheets/geoblacklight/modules/item.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/item.scss
@@ -7,6 +7,7 @@
 
   #viewer-container {
     [data-map="item"] {
+      border: 1px solid $gray-400;
       height: 27.5rem;
     }
 


### PR DESCRIPTION
This PR address two styling issues:

- The maps on the item show page don't have borders, which feel a little odd given they are so close to other page elements that do have borders (sidebar cards), and generally they would just feel more defined on the page with a subtle border (which is easy to override locally for implementers that don't want it).

- For the WMS maps, the table is jammed up directly against the bottom of the map. Perhaps this was intentional -- because selections on the map directly affect the contents of the table -- but as a relatively new GeoBlacklight user I found this confusing; for a while I thought the map and table were some kind of  single element.

Here are those two issues as seen in current `master`:

<img width="822" alt="Screen Shot 2020-07-10 at 4 23 44 PM" src="https://user-images.githubusercontent.com/101482/87210613-1550fc00-c2cb-11ea-86fe-c8931f91df09.png">

---
And here is how this PR changes them:

<img width="822" alt="Screen Shot 2020-07-10 at 4 25 12 PM" src="https://user-images.githubusercontent.com/101482/87210632-269a0880-c2cb-11ea-9fc8-4ece2ca9441d.png">
