### PR TITLE
Breakout individual tools into their own show tools configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,18 +31,18 @@ jobs:
       # Restore bundle and internal test app from the cache
       - restore_cache:
           keys:
-            - cachebust-2020-07-02-geoblacklight-bundle-{{ checksum "geoblacklight.gemspec" }}-{{ checksum "Gemfile" }}-<< parameters.ruby_version >>-<< parameters.rails_version >>
+            - cachebust-2020-07-13-geoblacklight-bundle-{{ checksum "geoblacklight.gemspec" }}-{{ checksum "Gemfile" }}-<< parameters.ruby_version >>-<< parameters.rails_version >>
       # Install gems
       - run: bundle check || bundle install
       # Store bundle cache
       - save_cache:
-          key: cachebust-2020-07-02-geoblacklight-bundle-{{ checksum "geoblacklight.gemspec" }}-{{ checksum "Gemfile" }}-<< parameters.ruby_version >>-<< parameters.rails_version >>
+          key: cachebust-2020-07-13-geoblacklight-bundle-{{ checksum "geoblacklight.gemspec" }}-{{ checksum "Gemfile" }}-<< parameters.ruby_version >>-<< parameters.rails_version >>
           paths:
             - /home/circleci/geoblacklight/vendor/bundle
         # Restore internal test app from the cache
       - restore_cache:
           keys:
-            - cachebust-2020-07-02-geoblacklight-internal-test-app-{{ checksum "geoblacklight.gemspec" }}-{{ checksum "Gemfile" }}-{{ checksum "spec/test_app_templates/Gemfile.extra" }}-<< parameters.ruby_version >>-<< parameters.rails_version >>
+            - cachebust-2020-07-13-geoblacklight-internal-test-app-{{ checksum "geoblacklight.gemspec" }}-{{ checksum "Gemfile" }}-{{ checksum "spec/test_app_templates/Gemfile.extra" }}-<< parameters.ruby_version >>-<< parameters.rails_version >>
       # Generate the internal test app
       - run:
           name: Generate test app
@@ -50,7 +50,7 @@ jobs:
             [ -e ./.internal_test_app ] || bundle exec rake engine_cart:generate
       - save_cache:
           name: Save test app cache
-          key: cachebust-2020-07-02-geoblacklight-internal-test-app-{{ checksum "geoblacklight.gemspec" }}-{{ checksum "Gemfile" }}-{{ checksum "spec/test_app_templates/Gemfile.extra" }}-<< parameters.ruby_version >>-<< parameters.rails_version >>
+          key: cachebust-2020-07-13-geoblacklight-internal-test-app-{{ checksum "geoblacklight.gemspec" }}-{{ checksum "Gemfile" }}-{{ checksum "spec/test_app_templates/Gemfile.extra" }}-<< parameters.ruby_version >>-<< parameters.rails_version >>
           paths:
             - ./.internal_test_app
       - run:
@@ -101,7 +101,7 @@ jobs:
       # Restore bundle cache
       - restore_cache:
           keys:
-            - cachebust-2020-07-02-geoblacklight-bundle-{{ checksum "geoblacklight.gemspec" }}-{{ checksum "Gemfile" }}-<< parameters.ruby_version >>-<< parameters.rails_version >>
+            - cachebust-2020-07-13-geoblacklight-bundle-{{ checksum "geoblacklight.gemspec" }}-{{ checksum "Gemfile" }}-<< parameters.ruby_version >>-<< parameters.rails_version >>
           paths:
             - /home/circleci/geoblacklight/vendor/bundle
       # Install gems and run rubocop

--- a/app/helpers/geoblacklight_helper.rb
+++ b/app/helpers/geoblacklight_helper.rb
@@ -230,23 +230,6 @@ module GeoblacklightHelper
     blacklight_config.basemap_provider || 'positron'
   end
 
-  def display_carto
-    return link_to(
-      content_tag(:span, '', class: 'geoblacklight geoblacklight-carto') +
-      t('geoblacklight.tools.open_carto'),
-      carto_link(@document.carto_reference),
-      target: '_blank'
-    ) if @document.carto_reference.present? && !Settings.CARTO_HIDE
-  end
-
-  def display_arcgis
-    return link_to(
-      blacklight_icon('esri-globe') + ' ' +
-      t('geoblacklight.tools.open_arcgis'),
-      arcgis_link(@document.arcgis_urls)
-    ) if @document.arcgis_urls.present? && !Settings.ARCGIS_HIDE
-  end
-
   ##
   # Creates a Carto OneClick link link, using the configuration link
   # @param [String] file_link

--- a/app/views/catalog/_arcgis.html.erb
+++ b/app/views/catalog/_arcgis.html.erb
@@ -1,0 +1,4 @@
+<% document ||= @document %>
+<%= link_to(arcgis_link(document.arcgis_urls)) do %>
+  <%= blacklight_icon('esri-globe') %> <%= t('geoblacklight.tools.open_arcgis') %>
+<% end %>

--- a/app/views/catalog/_carto.html.erb
+++ b/app/views/catalog/_carto.html.erb
@@ -1,0 +1,4 @@
+<% document ||= @document %>
+<%= link_to carto_link(document.carto_reference), target: '_blank' do %>
+  <span class='geoblacklight geoblacklight-carto'></span><%= t('geoblacklight.tools.open_carto') %>
+<% end %>

--- a/app/views/catalog/_exports.html.erb
+++ b/app/views/catalog/_exports.html.erb
@@ -1,3 +1,0 @@
-<% document ||= @document %>
-<%= display_carto %>
-<%= display_arcgis %>

--- a/lib/generators/geoblacklight/templates/catalog_controller.rb
+++ b/lib/generators/geoblacklight/templates/catalog_controller.rb
@@ -245,8 +245,9 @@ class CatalogController < ApplicationController
     # Custom tools for GeoBlacklight
     config.add_show_tools_partial :web_services, if: proc { |_context, _config, options| options[:document] && (Settings.WEBSERVICES_SHOWN & options[:document].references.refs.map(&:type).map(&:to_s)).any? }
     config.add_show_tools_partial :metadata, if: proc { |_context, _config, options| options[:document] && (Settings.METADATA_SHOWN & options[:document].references.refs.map(&:type).map(&:to_s)).any? }
-    config.add_show_tools_partial :exports, partial: 'exports', if: proc { |_context, _config, options| options[:document] }
-    config.add_show_tools_partial :data_dictionary, partial: 'data_dictionary', if: proc { |_context, _config, options| options[:document] }
+    config.add_show_tools_partial :carto, partial: 'carto', if: proc { |_context, _config, options| options[:document] && options[:document].carto_reference.present? }
+    config.add_show_tools_partial :arcgis, partial: 'arcgis', if: proc { |_context, _config, options| options[:document] && options[:document].arcgis_urls.present? }
+    config.add_show_tools_partial :data_dictionary, partial: 'data_dictionary', if: proc { |_context, _config, options| options[:document] && options[:document].data_dictionary_download.present? }
 
     # Configure basemap provider for GeoBlacklight maps (uses https only basemap
     # providers with open licenses)

--- a/lib/generators/geoblacklight/templates/settings.yml
+++ b/lib/generators/geoblacklight/templates/settings.yml
@@ -4,12 +4,6 @@ APPLICATION_LOGO_URL: 'http://geoblacklight.org/images/geoblacklight-logo.png'
 # Carto OneClick Service https://carto.com/engine/open-in-carto/
 CARTO_ONECLICK_LINK: 'http://oneclick.carto.com/'
 
-# Hide Carto export link
-# CARTO_HIDE: true
-
-# Hide ArcGIS export link
-# ARCGIS_HIDE: true
-
 # ArcGIS Online Base URL
 ARCGIS_BASE_URL: 'https://www.arcgis.com/home/webmap/viewer.html'
 

--- a/spec/features/exports_spec.rb
+++ b/spec/features/exports_spec.rb
@@ -5,7 +5,7 @@ feature 'Export features' do
     feature 'Open in Carto' do
       scenario 'shows up in tools' do
         visit solr_document_path 'tufts-cambridgegrid100-04'
-        expect(page).to have_css 'li.exports a', text: 'Open in Carto'
+        expect(page).to have_css 'li.carto a', text: 'Open in Carto'
         click_link 'Open in Carto'
       end
     end
@@ -14,23 +14,14 @@ feature 'Export features' do
     feature 'Open in ArcGIS Online' do
       scenario 'shows up in tools' do
         visit solr_document_path '90f14ff4-1359-4beb-b931-5cb41d20ab90'
-        expect(page).to have_css 'li.exports a', text: 'Open in ArcGIS Online'
+        expect(page).to have_css 'li.arcgis a', text: 'Open in ArcGIS Online'
       end
     end
   end
   feature 'when restricted or no wfs' do
     scenario 'is not in tools' do
       visit solr_document_path 'princeton-02870w62c'
-      expect(page).not_to have_css 'li.exports a', text: 'Open in Carto'
-    end
-  end
-  context 'when carto is configured not to display' do
-    before do
-      allow(Settings).to receive(:CARTO_HIDE).and_return(true)
-    end
-    it 'will not display the carto link' do
-      visit solr_document_path 'tufts-cambridgegrid100-04'
-      expect(page).not_to have_css 'li.exports a', text: 'Open in Carto'
+      expect(page).not_to have_css 'li.carto a', text: 'Open in Carto'
     end
   end
 end


### PR DESCRIPTION
A breaking change building on https://github.com/geoblacklight/geoblacklight/pull/837 which does things more like Blacklight would expect for configuring the display of a show tools partial. Rather than having our own setting in GeoBlacklight, just use the configurability that Blacklight gives us.