### PR TITLE
Add a svg_tooltip css class to particular icons …

### DIFF
--- a/app/assets/javascripts/geoblacklight/modules/svg_tooltips.js
+++ b/app/assets/javascripts/geoblacklight/modules/svg_tooltips.js
@@ -1,0 +1,31 @@
+/* global Blacklight */
+
+Blacklight.onLoad(function() {
+  'use strict';
+
+  $('body').on('mouseenter', '.blacklight-icons.svg_tooltip svg', function() {
+    var svgTitle = $(this).find('title');
+    var titleText = svgTitle && svgTitle.text();
+
+    if (titleText !== undefined && titleText !== '') {
+      $(this).tooltip({ placement: 'bottom', title: titleText });
+      $(this).tooltip('show');
+
+      // Store the original title in the data-original-title attribute
+      // and remove the title element on mouseenter.
+      // This prevents the title from interfering w/ Bootstrap's tooltip.
+      $(this).attr('data-original-title', titleText);
+      svgTitle.remove();
+    }
+  });
+
+  $('body').on('mouseleave', '.blacklight-icons.svg_tooltip svg', function() {
+    var originalTitle = $(this).attr('data-original-title');
+
+    if (originalTitle !== undefined && originalTitle !== '') {
+      // Restore the SVG title element from data-original-title on mouseleave
+      $(this).prepend($('<title>' + originalTitle + '</title>'));
+      $(this).attr('data-original-title', '');
+    }
+  });
+});

--- a/app/assets/stylesheets/geoblacklight/modules/results.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/results.scss
@@ -49,8 +49,10 @@
   }
 
   .status-icons {
+    cursor: pointer;
     margin-left: 0.5rem;
     white-space: nowrap;
+    z-index: 2; // get the icons above the toggle
   }
 }
 

--- a/app/helpers/geoblacklight_helper.rb
+++ b/app/helpers/geoblacklight_helper.rb
@@ -285,7 +285,7 @@ module GeoblacklightHelper
   def render_facet_item_with_icon(field_name, item)
     doc = Nokogiri::HTML.fragment(render_facet_item(field_name, item))
     doc.at_css('.facet-label').children.first
-       .add_previous_sibling(geoblacklight_icon(item.value, aria_hidden: true))
+       .add_previous_sibling(geoblacklight_icon(item.value, aria_hidden: true, classes: 'svg_tooltip'))
     doc.to_html.html_safe
   end
 
@@ -327,6 +327,8 @@ module GeoblacklightHelper
   def relations_icon(document, icon)
     icon_name = document[Settings.FIELDS.GEOM_TYPE] if Settings.USE_GEOM_FOR_RELATIONS_ICON
     icon_name = icon if icon_name.blank?
-    geoblacklight_icon(icon_name)
+    icon_options = {}
+    icon_options = { classes: 'svg_tooltip' } if Settings.USE_GEOM_FOR_RELATIONS_ICON
+    geoblacklight_icon(icon_name, icon_options)
   end
 end

--- a/app/views/catalog/_header_icons.html.erb
+++ b/app/views/catalog/_header_icons.html.erb
@@ -1,3 +1,3 @@
-<%= geoblacklight_icon(document[Settings.FIELDS.GEOM_TYPE]) %>
-<%= geoblacklight_icon(document[Settings.FIELDS.PROVENANCE]) %>
-<%= geoblacklight_icon(document[Settings.FIELDS.RIGHTS]) %>
+<%= geoblacklight_icon(document[Settings.FIELDS.GEOM_TYPE], classes: 'svg_tooltip') %>
+<%= geoblacklight_icon(document[Settings.FIELDS.PROVENANCE], classes: 'svg_tooltip') %>
+<%= geoblacklight_icon(document[Settings.FIELDS.RIGHTS], classes: 'svg_tooltip') %>

--- a/app/views/catalog/_index_split_default.html.erb
+++ b/app/views/catalog/_index_split_default.html.erb
@@ -15,7 +15,13 @@
       </span>
       <%= link_to_document document, counter: counter, title: document[blacklight_config.index.title_field] %>
     </span>
-    <span class='status-icons'>
+    <span
+      class="status-icons"
+      data-toggle="collapse"
+      data-target="#doc-<%= document.id %>-fields-collapse"
+      aria-expanded="false"
+      aria-controls="doc-<%= document.id %>-fields-collapse"
+    >
       <%= render partial: 'header_icons', locals: { document: document } %>
     </span>
   </h3>

--- a/spec/helpers/geoblacklight_helper_spec.rb
+++ b/spec/helpers/geoblacklight_helper_spec.rb
@@ -328,15 +328,36 @@ describe GeoblacklightHelper, type: :helper do
   end
 
   describe '#relations_icon' do
-    it 'renders a goemetry type if configured' do
-      allow(Settings).to receive(:USE_GEOM_FOR_RELATIONS_ICON).and_return(true)
-      html = Capybara.string(helper.relations_icon({ 'layer_geom_type_s' => 'polygon' }, 'leaf'))
-      expect(html.title.strip).to eq 'Polygon'
+    context 'when configured to use the geometry type' do
+      before do
+        allow(Settings).to receive(:USE_GEOM_FOR_RELATIONS_ICON).and_return(true)
+      end
+
+      it 'renders a goemetry type as the icon' do
+        html = Capybara.string(helper.relations_icon({ 'layer_geom_type_s' => 'polygon' }, 'leaf'))
+        expect(html.title.strip).to eq 'Polygon'
+      end
+
+      it 'has the svg_tooltip class so that the Bootstrap tooltip is applied' do
+        html = Capybara.string(helper.relations_icon({ 'layer_geom_type_s' => 'polygon' }, 'leaf'))
+        expect(html).to have_css('.blacklight-icons.svg_tooltip')
+      end
     end
-    it 'renders provided icon if not configured to use geometry' do
-      allow(Settings).to receive(:USE_GEOM_FOR_RELATIONS_ICON).and_return(false)
-      html = Capybara.string(helper.relations_icon({ 'layer_geom_type_s' => 'polygon' }, 'leaf'))
-      expect(html.title.strip).to eq 'Leaf'
+
+    context 'when not confiugred to use the geometry type' do
+      before do
+        allow(Settings).to receive(:USE_GEOM_FOR_RELATIONS_ICON).and_return(false)
+      end
+
+      it 'renders the provided icon' do
+        html = Capybara.string(helper.relations_icon({ 'layer_geom_type_s' => 'polygon' }, 'leaf'))
+        expect(html.title.strip).to eq 'Leaf'
+      end
+
+      it 'does not have the svg_tooltip class' do
+        html = Capybara.string(helper.relations_icon({ 'layer_geom_type_s' => 'polygon' }, 'leaf'))
+        expect(html).not_to have_css('.blacklight-icons.svg_tooltip')
+      end
     end
   end
 end


### PR DESCRIPTION
… (format, institution, access, relationship) and some JS to invoke a Bootstrap tooltip w/ the SVG's title.

Closes #915 

This commit also adds the same field collapsing behavior on the status icons in the search results so we can both get hover behavior (for the tooltip) and toggle click behavior.

### Tooltips in Results
![results-icons](https://user-images.githubusercontent.com/96776/87453647-a835b300-c5b7-11ea-934e-874662085d64.gif)

### DOM Manipulation on Mouse Enter/Leave
![tooltip-hover-markup](https://user-images.githubusercontent.com/96776/87453658-ae2b9400-c5b7-11ea-8f66-283544753dd3.gif)
