### PR TITLE
adds version number to homepage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,3 @@ jetty
 .internal_test_app
 # Ignore byebug history
 .byebug_history
-.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ jetty
 .internal_test_app
 # Ignore byebug history
 .byebug_history
+.DS_Store

--- a/app/views/catalog/_home_text.html.erb
+++ b/app/views/catalog/_home_text.html.erb
@@ -40,4 +40,7 @@
       <%= content_tag :div, '', id: 'map', aria: { label: t('geoblacklight.map.label') }, data: { map: 'home', 'catalog-path'=> search_catalog_path , 'map-bbox' => params[:bbox], basemap: geoblacklight_basemap, leaflet_options: leaflet_options } %>
     </div>
   </div>
+  <div align='right'>
+  <p>GeoBlacklight version <%= Geoblacklight::VERSION %></p>
+  </div>
 </div>

--- a/app/views/catalog/_home_text.html.erb
+++ b/app/views/catalog/_home_text.html.erb
@@ -40,7 +40,7 @@
       <%= content_tag :div, '', id: 'map', aria: { label: t('geoblacklight.map.label') }, data: { map: 'home', 'catalog-path'=> search_catalog_path , 'map-bbox' => params[:bbox], basemap: geoblacklight_basemap, leaflet_options: leaflet_options } %>
     </div>
   </div>
-  <div align='right'>
-  <%= content_tag :h5, t('geoblacklight.home.version') %> <%= Geoblacklight::VERSION %></p>
+  <div class="text-right">
+    <%= t('geoblacklight.home.version', version: Geoblacklight::VERSION ) %>
   </div>
 </div>

--- a/app/views/catalog/_home_text.html.erb
+++ b/app/views/catalog/_home_text.html.erb
@@ -41,6 +41,6 @@
     </div>
   </div>
   <div align='right'>
-  <p>GeoBlacklight version <%= Geoblacklight::VERSION %></p>
+  <%= content_tag :h5, t('geoblacklight.home.version') %> <%= Geoblacklight::VERSION %></p>
   </div>
 </div>

--- a/config/locales/geoblacklight.en.yml
+++ b/config/locales/geoblacklight.en.yml
@@ -29,7 +29,7 @@ en:
       data_type: 'Data type'
       placename: 'Placename'
       subject: 'Subject'
-      version: 'GeoBlacklight version'
+      version: 'GeoBlacklight version %{version}'
     tools:
       login_to_view: 'Login to View and Download'
       open_carto: 'Open in Carto'

--- a/config/locales/geoblacklight.en.yml
+++ b/config/locales/geoblacklight.en.yml
@@ -29,6 +29,7 @@ en:
       data_type: 'Data type'
       placename: 'Placename'
       subject: 'Subject'
+      version: 'GeoBlacklight version'
     tools:
       login_to_view: 'Login to View and Download'
       open_carto: 'Open in Carto'


### PR DESCRIPTION
This PR addresses #853 and exposes the current GeoBlacklight version running on the app homepage. It references the value present in the `lib/geoblacklight/version.rb` file. 

This PR also adds `.DS_Store` to the `.gitignore` file in the project