### PR TITLE
SpatialSearch: append boost instead of setting via hard assignment

### DIFF
--- a/app/models/concerns/geoblacklight/spatial_search_behavior.rb
+++ b/app/models/concerns/geoblacklight/spatial_search_behavior.rb
@@ -20,9 +20,10 @@ module Geoblacklight
         solr_params[:fq] << "#{Settings.FIELDS.GEOMETRY}:\"Intersects(#{envelope_bounds})\""
 
         if Settings.OVERLAP_RATIO_BOOST
+          solr_params[:bf] ||= []
           solr_params[:overlap] =
             "{!field uf=* defType=lucene f=solr_bboxtype score=overlapRatio}Intersects(#{envelope_bounds})"
-          solr_params[:bf] = "$overlap^#{Settings.OVERLAP_RATIO_BOOST}"
+          solr_params[:bf] << "$overlap^#{Settings.OVERLAP_RATIO_BOOST}"
         end
       end
       solr_params

--- a/spec/models/concerns/geoblacklight/spatial_search_behavior_spec.rb
+++ b/spec/models/concerns/geoblacklight/spatial_search_behavior_spec.rb
@@ -53,6 +53,18 @@ describe Geoblacklight::SpatialSearchBehavior do
         expect(subject.add_spatial_params(solr_params)).not_to have_key(:overlap)
       end
 
+      context "when local boost parameter is present" do
+        before do
+          solr_params[:bf] = ['local_boost^5']
+        end
+
+        it "appends overlap and includes the local boost" do
+          allow(Settings).to receive(:OVERLAP_RATIO_BOOST).and_return 2
+          expect(subject.add_spatial_params(solr_params)[:bf].to_s).to include('$overlap^2')
+          expect(solr_params[:bf].to_s).to include('local_boost^5')
+        end
+      end
+
       context 'when the wrong format for the bounding box is used' do
         before do
           allow(subject).to receive(:bounding_box).and_raise(Geoblacklight::Exceptions::WrongBoundingBoxFormat)


### PR DESCRIPTION
Fixes #894 - This allows local default solr params to remain included in the final solr query.