### PR TITLE
Fixes bug in tiled_map_layer

### DIFF
--- a/app/assets/javascripts/geoblacklight/viewers/esri/tiled_map_layer.js
+++ b/app/assets/javascripts/geoblacklight/viewers/esri/tiled_map_layer.js
@@ -30,7 +30,7 @@ GeoBlacklight.Viewer.TiledMapLayer = GeoBlacklight.Viewer.Esri.extend({
       _this.appendLoadingMessage();
 
       // query layer at click location
-      L.esri.Tasks.identifyFeatures({
+      L.esri.identifyFeatures({
         url: layer.options.url,
         useCors: true
       })

--- a/spec/javascripts/geoblacklight/viewers/esri/tiled_map_layer_spec.js
+++ b/spec/javascripts/geoblacklight/viewers/esri/tiled_map_layer_spec.js
@@ -1,0 +1,12 @@
+//= require geoblacklight
+
+describe('setupInspection', function() {
+  describe('Inspect attribute on the map', function() {
+    it('identifyFeatures is defined', function() {
+      expect(L.esri.identifyFeatures).toBeDefined();
+    });
+    it('Tasks is not defined', function() {
+      expect(L.esri.Tasks).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
closes #936 
Update tiled_map_layer not to include nested namespace L.esri.Tasks
This was updated in esri-leaflet 2.0.0-beta.4

Release notes https://github.com/Esri/esri-leaflet/blob/542022a2f216b7ad43471876a693a0257e92582d/CHANGELOG.md#breaking-1

Relevant specs https://github.com/esri/esri-leaflet/compare/v2.0.0-beta.3...v2.0.0-beta.4#diff-06cb9def3f931de1e3006a21cb9fbae3L38-L39