### PR TITLE
100 percent coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,7 +188,7 @@ jobs:
           command: |
             RAILS_ENV=test bundle exec ruby ./bin/coverage.rb
       - store_artifacts:
-          path: ~/figgy/coverage
+          path: ~/geoblacklight/coverage
           destination: coverage
 
 workflows:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GeoBlacklight
 
-[![CircleCI](https://circleci.com/gh/geoblacklight/geoblacklight.svg?style=svg)](https://circleci.com/gh/geoblacklight/geoblacklight) | [![Coverage Status](https://img.shields.io/coveralls/geoblacklight/geoblacklight.svg)](https://coveralls.io/r/geoblacklight/geoblacklight?branch=coveralls) | [![Gem Version](https://img.shields.io/gem/v/geoblacklight.svg)](https://github.com/geoblacklight/geoblacklight/releases)
+[![CircleCI](https://circleci.com/gh/geoblacklight/geoblacklight.svg?style=svg)](https://circleci.com/gh/geoblacklight/geoblacklight) | [![Coverage Status](https://raw.githubusercontent.com/geoblacklight/geoblacklight/coverage-badge/coverage.svg)]() | [![Gem Version](https://img.shields.io/gem/v/geoblacklight.svg)](https://github.com/geoblacklight/geoblacklight/releases)
 
 GeoBlacklight is a world-class discovery platform for geospatial (GIS) holdings. It
 is an open collaborative project aiming to build off of the successes

--- a/app/helpers/geoblacklight_helper.rb
+++ b/app/helpers/geoblacklight_helper.rb
@@ -95,13 +95,6 @@ module GeoblacklightHelper
   end
 
   ##
-  # Render an empty span
-  # @return [HTML tag]
-  def render_empty_span(classname)
-    tag.span class: classname
-  end
-
-  ##
   # Renders an unique array of search links based off of terms
   # passed in using the facet parameter
   #

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,7 @@ SimpleCov.start 'rails' do
   add_filter 'lib/generators/geoblacklight/install_generator.rb'
   add_filter 'lib/geoblacklight/version.rb'
   add_filter 'lib/generators'
+  add_filter 'lib/tasks/geoblacklight.rake'
   add_filter '/spec'
   add_filter '.internal_test_app/'
 end


### PR DESCRIPTION
- Bring our code coverage up to 100%.
- Since we're not using Coveralls now (and haven't for awhile), replaces the dynamically created badge for a static badge.
  - If we set code coverage to enforce 100% always, then this won't need to be updated.
  - If we want it to be dynamic in the future, there's a gem that can generate this for us in our CI process.
  - The badge doesn't link out anywhere now, but once I figure out how to get the latest CI artifacts it could link out to Circle. https://3950-21216322-gh.circle-artifacts.com/0/coverage/index.html#_AllFiles


Closes #961 