### PR TITLE
changing crs protocol

### DIFF
--- a/app/assets/javascripts/geoblacklight/viewers/wms.js
+++ b/app/assets/javascripts/geoblacklight/viewers/wms.js
@@ -23,7 +23,7 @@ GeoBlacklight.Viewer.Wms = GeoBlacklight.Viewer.Map.extend({
       format: 'image/png',
       transparent: true,
       tiled: true,
-      CRS: 'EPSG:900913',
+      CRS: 'EPSG:3857',
       opacity: this.options.opacity,
       detectRetina: _this.detectRetina()
     });

--- a/lib/geoblacklight/download/kmz_download.rb
+++ b/lib/geoblacklight/download/kmz_download.rb
@@ -4,7 +4,7 @@ module Geoblacklight
     KMZ_DOWNLOAD_PARAMS = { service: 'wms',
                             version: '1.1.0',
                             request: 'GetMap',
-                            srsName: 'EPSG:900913',
+                            srsName: 'EPSG:3857',
                             format: 'application/vnd.google-earth.kmz',
                             width: 2000, height: 2000 }.freeze
 


### PR DESCRIPTION
Issue #897 Testing effects of change from CRS:900913 to CRS:3857 on service calls.

Use Chrome developer tools to see if this protocol change breaks any existing layers. I inspected layers in the console by navigating to the Network Tab. Records detail which CRS request is passed and if it is successful. It is believed that this will not break any existing records.