### PR TITLE
add <div> id for geoblacklight version text

### DIFF
--- a/app/views/catalog/_home_text.html.erb
+++ b/app/views/catalog/_home_text.html.erb
@@ -40,7 +40,7 @@
       <%= content_tag :div, '', id: 'map', aria: { label: t('geoblacklight.map.label') }, data: { map: 'home', 'catalog-path'=> search_catalog_path , 'map-bbox' => params[:bbox], basemap: geoblacklight_basemap, leaflet_options: leaflet_options } %>
     </div>
   </div>
-  <div class="text-right">
+  <div id="geoblacklight-version" class="text-right">
     <%= t('geoblacklight.home.version', version: Geoblacklight::VERSION ) %>
   </div>
 </div>


### PR DESCRIPTION
applications will likely want custom styles for the geoblacklight version text. this gives them a hook for customization.