### PR TITLE
Fix syntax in _blacklight_overrides.css

### DIFF
--- a/app/assets/stylesheets/geoblacklight/modules/_blacklight_overrides.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/_blacklight_overrides.scss
@@ -2,7 +2,7 @@
   Stylesheet for overriding styles inherited from Blacklight proper
 **/
 
-$logo-image: image_url('blacklight/logo.svg') !default
+$logo-image: image_url('blacklight/logo.svg') !default;
 
 .navbar-logo {  /* The main logo image for the Blacklight instance */
   @if $logo-image {


### PR DESCRIPTION
This fixes a syntax error in `_blacklight_overrides.scss`, a missing semicolon that breaks the application when using sass-rails ~> 5.0. This might not be an issue for most people, since sassc-rails (and/or sass-rails 6.0) seems to handle missing semicolons more gracefully. We encountered it in the midst of upgrading from an earlier version of GeoBlacklight, so hopefully this will save other folks some debugging time.