### PR TITLE
Update template to make sure we use sprockets less than 4.0 until we …

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -2,6 +2,7 @@
 gem 'blacklight', '~> 7.0'
 gem 'geoblacklight', '~> 3.0'
 gem 'webpacker' unless Rails.version.to_s.start_with? '6.1.'
+gem 'sprockets', '< 4.0' # Use sprockets less than 4.0, let webpacker users set this up themselves
 
 # Hack for https://github.com/rails/rails/issues/35153
 # Adapted from https://github.com/projectblacklight/blacklight/pull/2065


### PR DESCRIPTION
…can support this automaticall

When following various installation guides, our "webpacker" install doesn't work out of the box. Make sure to at least make the template usable until we can do a better job internally to generate this functionally with Sprockets > 4.0 out of the box.