### PR TITLE
Bug fix: Remove JS map from bookmarks view

### DIFF
--- a/app/assets/javascripts/geoblacklight/modules/results.js
+++ b/app/assets/javascripts/geoblacklight/modules/results.js
@@ -8,7 +8,7 @@ Blacklight.onLoad(function() {
     });
   }
 
-  $('[data-map="index"]').each(function() {
+  $('body.blacklight-catalog [data-map="index"]').each(function() {
     var data = $(this).data(),
     opts = { baseUrl: data.catalogPath },
     world = L.latLngBounds([[-90, -180], [90, 180]]),

--- a/spec/features/bookmarks_spec.rb
+++ b/spec/features/bookmarks_spec.rb
@@ -7,5 +7,8 @@ feature 'Blacklight Bookmarks' do
     click_button 'Bookmark'
     visit bookmarks_path
     expect(page).to have_css '.document', count: 1
+
+    # The JS selector to initiate a leaflet map should not be present
+    expect(page).not_to have_css 'body.blacklight-catalog [data-map="index"]'
   end
 end


### PR DESCRIPTION
Make the GBL leaflet map selector more specific to prevent the map from rendering on the bookmarks view.

Fixes #246