### PR TITLE
Bookmarks: remove search functionality from bookmarks js map

### DIFF
--- a/app/assets/javascripts/geoblacklight/modules/bookmarks.js
+++ b/app/assets/javascripts/geoblacklight/modules/bookmarks.js
@@ -1,0 +1,44 @@
+Blacklight.onLoad(function() {
+  $('[data-map="bookmarks"]').each(function() {
+    var data = $(this).data(),
+    world = L.latLngBounds([[-90, -180], [90, 180]]),
+    geoblacklight, bbox;
+
+    if (typeof data.mapBbox === 'string') {
+      bbox = L.bboxToBounds(data.mapBbox);
+    } else {
+      $('.document [data-bbox]').each(function() {
+
+        try {
+          var currentBounds = L.bboxToBounds($(this).data().bbox);
+          if (!world.contains(currentBounds)) {
+            throw "Invalid bounds";
+          }
+          if (typeof bbox === 'undefined') {
+            bbox = currentBounds;
+          } else {
+            bbox.extend(currentBounds);
+          }
+        } catch (e) {
+          bbox = L.bboxToBounds("-180 -90 180 90");
+        }
+      });
+    }
+
+    // instantiate new map
+    geoblacklight = new GeoBlacklight.Viewer.Map(this, { bbox: bbox });
+    geoblacklight.removeBoundsOverlay();
+
+    // set hover listeners on map
+    $('#content')
+      .on('mouseenter', '#documents [data-layer-id]', function() {
+        if($(this).data('bbox').length > 0) {
+          var bounds = L.bboxToBounds($(this).data('bbox'));
+          geoblacklight.addBoundsOverlay(bounds);
+        }
+      })
+      .on('mouseleave', '#documents [data-layer-id]', function() {
+        geoblacklight.removeBoundsOverlay();
+      });
+  });
+});

--- a/app/assets/stylesheets/geoblacklight/modules/results.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/results.scss
@@ -1,4 +1,4 @@
-[data-map="index"] {
+[data-map="index"], [data-map="bookmarks"] {
   height: 480px;
 }
 

--- a/app/helpers/geoblacklight_helper.rb
+++ b/app/helpers/geoblacklight_helper.rb
@@ -282,4 +282,16 @@ module GeoblacklightHelper
     icon_options = { classes: 'svg_tooltip' } if Settings.USE_GEOM_FOR_RELATIONS_ICON
     geoblacklight_icon(icon_name, icon_options)
   end
+
+  ## Returns the data-map attribute value used as the JS map selector
+  def results_js_map_selector(controller_name)
+    case controller_name
+    when 'bookmarks'
+      'bookmarks'
+    when 'catalog'
+      'index'
+    else
+      'index'
+    end
+  end
 end

--- a/app/views/catalog/_document_split.html.erb
+++ b/app/views/catalog/_document_split.html.erb
@@ -2,5 +2,5 @@
   <div id="documents" class="documents-list col-md-6">
     <%= render documents, :as => :document %>
   </div>
-  <%= content_tag :div, '', id: 'map', class: 'col-md-6', aria: { label: t('geoblacklight.map.label') }, data: { map: 'index', 'catalog-path'=> search_catalog_path , 'map-bbox' => params[:bbox], basemap: geoblacklight_basemap, leaflet_options: leaflet_options } %>
+  <%= content_tag :div, '', id: 'map', class: 'col-md-6', aria: { label: t('geoblacklight.map.label') }, data: { map: results_js_map_selector(controller.controller_name), 'catalog-path'=> search_catalog_path , 'map-bbox' => params[:bbox], basemap: geoblacklight_basemap, leaflet_options: leaflet_options } %>
 </div>

--- a/spec/helpers/geoblacklight_helper_spec.rb
+++ b/spec/helpers/geoblacklight_helper_spec.rb
@@ -372,4 +372,30 @@ describe GeoblacklightHelper, type: :helper do
       end
     end
   end
+
+  describe '#results_js_map_selector' do
+    context 'viewing bookmarks' do
+      let(:controller_name) { 'bookmarks' }
+
+      it 'returns bookmarks data-map selector' do
+        expect(results_js_map_selector(controller_name)).to eq 'bookmarks'
+      end
+    end
+
+    context 'viewing catalog results' do
+      let(:controller_name) { 'catalog' }
+
+      it 'returns index data-map selector' do
+        expect(results_js_map_selector(controller_name)).to eq 'index'
+      end
+    end
+
+    context 'calling outside of intended scope' do
+      let(:controller_name) { 'outside' }
+
+      it 'returns default data-map value' do
+        expect(results_js_map_selector(controller_name)).to eq 'index'
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes #246

Adds a new JS map for the bookmarks controller, removing the search features of the search results map. Sets the data-map attribute value via a new GBL helper to initialize the proper JS map on page load. Includes specs to test new helper.

### Results
<img width="1277" alt="Screen Shot 2021-02-23 at 12 15 41 PM" src="https://user-images.githubusercontent.com/69827/108901815-f6e10c00-75e0-11eb-9548-c1189292d5cb.png">

With search feature.

### Bookmarks
<img width="1277" alt="Screen Shot 2021-02-23 at 12 15 03 PM" src="https://user-images.githubusercontent.com/69827/108901843-fea0b080-75e0-11eb-9508-551a4d31e37a.png">

Without search feature.