### PR TITLE
Adds support for a TMS viewer

### DIFF
--- a/app/assets/javascripts/geoblacklight/viewers/tms.js
+++ b/app/assets/javascripts/geoblacklight/viewers/tms.js
@@ -1,0 +1,10 @@
+//= require geoblacklight/viewers/wms
+
+GeoBlacklight.Viewer.Tms = GeoBlacklight.Viewer.Wms.extend({
+
+  addPreviewLayer: function() {
+    var _this = this;
+    var wmtsLayer = L.tileLayer(this.data.url);
+    this.overlay.addLayer(wmtsLayer);
+  }
+});

--- a/config/locales/geoblacklight.en.yml
+++ b/config/locales/geoblacklight.en.yml
@@ -64,6 +64,7 @@ en:
       data_dictionary: 'Documentation'
       services: 'Web services'
       services_close: 'Close'
+      tms: 'Tile Map Service'
     relations:
       ancestor: 'Source Datasets'
       descendant: 'Derived Datasets'
@@ -104,6 +105,9 @@ en:
         tiled_map_layer:
           title: ArcGIS Tiled Map Layer
           content: An ArcGIS Tiled Map Layer Service displays set of web-accessible tiles that reside on a server.
+        tms:
+          title: Tile Map Service
+          content: A Tile Map Service displays georeferenced map tiles as an image on a map.
         wms:
           title: Web Map Service (WMS)
           content: A Web Map Service displays a geospatial dataset as map images.

--- a/lib/generators/geoblacklight/templates/settings.yml
+++ b/lib/generators/geoblacklight/templates/settings.yml
@@ -62,6 +62,7 @@ USE_GEOM_FOR_RELATIONS_ICON: false
 # Web services shown in tool panel
 WEBSERVICES_SHOWN:
   - 'wms'
+  - 'tms'
   - 'wfs'
   - 'iiif'
   - 'feature_layer'
@@ -122,4 +123,5 @@ HELP_TEXT:
       - 'index_map'
       - 'tiled_map_layer'
       - 'wms'
+      - 'tms'
       - 'oembed'

--- a/lib/geoblacklight/constants.rb
+++ b/lib/geoblacklight/constants.rb
@@ -16,6 +16,7 @@ module Geoblacklight
       wcs: 'http://www.opengis.net/def/serviceType/ogc/wcs',
       wfs: 'http://www.opengis.net/def/serviceType/ogc/wfs',
       wms: 'http://www.opengis.net/def/serviceType/ogc/wms',
+      tms: 'https://wiki.osgeo.org/wiki/Tile_Map_Service_Specification',
       hgl: 'http://schema.org/DownloadAction',
       feature_layer: 'urn:x-esri:serviceType:ArcGIS#FeatureLayer',
       tiled_map_layer: 'urn:x-esri:serviceType:ArcGIS#TiledMapLayer',

--- a/lib/geoblacklight/item_viewer.rb
+++ b/lib/geoblacklight/item_viewer.rb
@@ -47,8 +47,12 @@ module Geoblacklight
       @references.oembed
     end
 
+    def tms
+      @references.tms
+    end
+
     def viewer_preference
-      [oembed, index_map, wms, iiif, tiled_map_layer, dynamic_map_layer,
+      [oembed, index_map, tms, wms, iiif, tiled_map_layer, dynamic_map_layer,
        image_map_layer, feature_layer].compact.map(&:to_hash).first
     end
   end

--- a/spec/features/split_view.html.erb_spec.rb
+++ b/spec/features/split_view.html.erb_spec.rb
@@ -10,7 +10,7 @@ feature 'Index view', js: true do
   scenario 'should have documents and map on page' do
     visit search_catalog_path(f: { Settings.FIELDS.PROVENANCE => ['Stanford'] })
     expect(page).to have_css('#documents')
-    expect(page).to have_css('.document', count: 5)
+    expect(page).to have_css('.document', count: 6)
     expect(page).to have_css('#map')
   end
 

--- a/spec/features/tms_spec.rb
+++ b/spec/features/tms_spec.rb
@@ -1,0 +1,11 @@
+
+# frozen_string_literal: true
+require 'spec_helper'
+
+feature 'tms layer' do
+  scenario 'displays tms layer', js: true do
+    visit solr_document_path('6f47b103-9955-4bbe-a364-387039623106')
+    expect(page).to have_css '.leaflet-control-zoom', visible: true
+    expect(page).to have_css "img[src*='earthquake.usgs.gov']"
+  end
+end

--- a/spec/fixtures/solr_documents/tms.json
+++ b/spec/fixtures/solr_documents/tms.json
@@ -1,0 +1,29 @@
+{
+  "dc_identifier_s": "6f47b103-9955-4bbe-a364-387039623106",
+  "dc_title_s": "Quaternary Fault and Fold Database of the United States",
+  "dc_description_s": "Quaternary Fault and Fold Database of the United States",
+  "dc_rights_s": "Public",
+  "dct_provenance_s": "Stanford",
+  "dct_references_s": "{\"http://schema.org/url\":\"https://www.usgs.gov/natural-hazards/earthquake-hazards/faults\",\"https://wiki.osgeo.org/wiki/Tile_Map_Service_Specification\":\"https://earthquake.usgs.gov/basemap/tiles/faults/{z}/{x}/{y}.png\",\"http://schema.org/downloadUrl\":\"https://earthquake.usgs.gov/static/lfs/nshm/qfaults/Qfaults_GIS.zip\"}",
+  "layer_slug_s": "6f47b103-9955-4bbe-a364-387039623106",
+  "layer_geom_type_s": "Polyline",
+  "dc_format_s": "Shapefile",
+  "dc_language_s": "English",
+  "dc_type_s": "Dataset",
+  "dc_publisher_s": "Geological Survey (U.S.)",
+  "dc_subject_sm": [
+    "Earthquakes",
+    "Faults"
+  ],
+  "dct_issued_s": "2020",
+  "dct_temporal_sm": [
+    "2020"
+  ],
+  "dct_spatial_sm": [
+    "Earth (Planet)",
+    "North America"
+  ],
+  "solr_geom": "ENVELOPE(-156.02, -70.80, 65.59, 18.93)",
+  "solr_year_i": 2020,
+  "geoblacklight_version": "1.0"
+}

--- a/spec/lib/geoblacklight/item_viewer_spec.rb
+++ b/spec/lib/geoblacklight/item_viewer_spec.rb
@@ -26,6 +26,18 @@ describe Geoblacklight::ItemViewer do
         expect(item_viewer.viewer_preference).to eq wms: 'http://www.example.com/wms'
       end
     end
+    describe 'for tms reference' do
+      let(:document_attributes) do
+        {
+          references_field => {
+            'https://wiki.osgeo.org/wiki/Tile_Map_Service_Specification' => 'http://www.example.com/tms'
+          }.to_json
+        }
+      end
+      it 'tms if tms is present' do
+        expect(item_viewer.viewer_preference).to eq tms: 'http://www.example.com/tms'
+      end
+    end
     describe 'for iiif only reference' do
       let(:document_attributes) do
         {


### PR DESCRIPTION
In place of #1016

![Screen Shot 2021-02-24 at 7 41 11 AM](https://user-images.githubusercontent.com/1656824/109016802-c39b8d00-7673-11eb-915d-c6d2ef3a3bc0.png)

TMS layers would be specified like this:

```
"https://wiki.osgeo.org/wiki/Tile_Map_Service_Specification":"https://earthquake.usgs.gov/basemap/tiles/faults/{z}/{x}/{y}.png"
```

This allows you to modify the tile pattern if need be.