### PR TITLE
Use bash to run yarn test command

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -28,7 +28,7 @@ end
 
 desc 'Run JavaScript unit tests'
 task :javascript_tests do
-  system 'yarn test'
+  system '/bin/bash -c yarn test'
 end
 
 desc 'Run test suite'


### PR DESCRIPTION
Jest tests were not running on github actions CI:

```
yarn run v1.22.5
$ jest -c jest.config.js
/bin/sh: 1: jest: not found
error Command failed with exit code 127.
```

The solution is to force running the command with bash instead of sh (https://github.com/yarnpkg/yarn/issues/6686)