### PR TITLE
Provide a more graceful fallback for non-parsable geometry

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -113,7 +113,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [2.5]
+        ruby: [2.6]
     steps:
     - uses: actions/checkout@v2
 
@@ -133,10 +133,10 @@ jobs:
     - name: Install dependencies
       run: bundle install
       env:
-        RAILS_VERSION: 5.2.4.2
+        RAILS_VERSION: 5.2.6
 
     - name: Run tests
       run: bundle exec rake ci
       env:
-        RAILS_VERSION: 5.2.4.2
+        RAILS_VERSION: 5.2.6
         ENGINE_CART_RAILS_OPTIONS: '--skip-git --skip-listen --skip-spring --skip-keeps --skip-action-cable --skip-coffee --skip-test'

--- a/lib/geoblacklight/geometry.rb
+++ b/lib/geoblacklight/geometry.rb
@@ -17,7 +17,8 @@ module Geoblacklight
     def geojson
       obj = factory.parse_wkt(geometry_as_wkt)
       RGeo::GeoJSON.encode(obj).to_json
-    rescue RGeo::Error::ParseError
+    rescue StandardError
+      Geoblacklight.logger.warn "Geometry is not valid: #{geom}"
       ''
     end
 

--- a/spec/lib/geoblacklight/geometry_spec.rb
+++ b/spec/lib/geoblacklight/geometry_spec.rb
@@ -5,6 +5,7 @@ describe Geoblacklight::Geometry do
   let(:wkt_geom) { 'MULTIPOLYGON(((-180 81.66, -180 -12.93, -168.35 -12.93, -168.35 81.66, -180 81.66)), ((180 81.66, 25 81.66, 25 -12.93, 180 -12.93, 180 81.66)))' }
   let(:envelope_geom) { 'ENVELOPE(25, -168.35, 81.66, -12.93)' }
   let(:invalid_geom) { 'INVALID' }
+  let(:non_polygon_geom) { 'ENVELOPE(130, 130, 33, 33)' }
 
   describe '#geojson' do
     context 'with standard WKT geometry' do
@@ -22,6 +23,16 @@ describe Geoblacklight::Geometry do
     context 'with an invalid geometry' do
       it 'returns an empty string' do
         expect(described_class.new(invalid_geom).geojson).to eq ''
+      end
+    end
+
+    context 'with a non-polygon geometry' do
+      before do
+        allow(RGeo::GeoJSON).to receive(:encode).and_raise(RGeo::Error::InvalidGeometry)
+      end
+
+      it 'returns an empty string' do
+        expect(described_class.new(non_polygon_geom).geojson).to eq ''
       end
     end
   end


### PR DESCRIPTION
Closes #1042 

My comment from the ticket:

> The underlying issue here, is that the envelopes / bounding boxes should be valid polygons. The most important reason is to enable a valid solr spatial search with the record. Perhaps we should add some validation to the envelope in GeoCombine. That being said, invalid polygon geometry should not prevent record display in GeoBlacklight. After doing some reading and experimentation, I've come to understand that this is a bit of a tricky issue. As far as I can tell, the problem is the underlying version of libgeos, which can be different between machines. For example, I can't replicate this directly on my development laptop. Everything works as it should. I'll work up a patch that tests the error indirectly and let's see if it fixes the problem.
