### PR TITLE
Return default GeoJSON extent on error

### DIFF
--- a/lib/geoblacklight/geometry.rb
+++ b/lib/geoblacklight/geometry.rb
@@ -19,7 +19,7 @@ module Geoblacklight
       RGeo::GeoJSON.encode(obj).to_json
     rescue StandardError
       Geoblacklight.logger.warn "Geometry is not valid: #{geom}"
-      ''
+      default_extent
     end
 
     # Generate a wsen bounding box from the geometry
@@ -37,10 +37,24 @@ module Geoblacklight
       maxy = bbox.coordinates[0][2][1]
       "#{minx}, #{miny}, #{maxx}, #{maxy}"
     rescue RGeo::Error::ParseError
-      ''
+      Geoblacklight.logger.warn "Error parsing geometry: #{geom}"
+      default_extent
     end
 
     private
+
+    # Default extent as GeoJSON
+    # @return [String]
+    def default_extent
+      {
+        'type' => 'Polygon',
+        'coordinates' => [
+          [
+            [-180.0, 90.0], [-180.0, -90.0], [180.0, -90.0], [180.0, 90.0], [-180.0, 90.0]
+          ]
+        ]
+      }.to_json
+    end
 
     # Convert WKT ENVELOPE string to WKT POLYGON string
     # @return [String]

--- a/spec/lib/geoblacklight/geometry_spec.rb
+++ b/spec/lib/geoblacklight/geometry_spec.rb
@@ -21,8 +21,8 @@ describe Geoblacklight::Geometry do
     end
 
     context 'with an invalid geometry' do
-      it 'returns an empty string' do
-        expect(described_class.new(invalid_geom).geojson).to eq ''
+      it 'returns a default GeoJSON extent' do
+        expect(described_class.new(invalid_geom).geojson).to include('coordinates', '-180.0,90.0')
       end
     end
 
@@ -31,8 +31,8 @@ describe Geoblacklight::Geometry do
         allow(RGeo::GeoJSON).to receive(:encode).and_raise(RGeo::Error::InvalidGeometry)
       end
 
-      it 'returns an empty string' do
-        expect(described_class.new(non_polygon_geom).geojson).to eq ''
+      it 'returns a default GeoJSON extent' do
+        expect(described_class.new(non_polygon_geom).geojson).to include('coordinates', '-180.0,90.0')
       end
     end
   end
@@ -51,8 +51,8 @@ describe Geoblacklight::Geometry do
     end
 
     context 'with an invalid geometry' do
-      it 'returns an empty string' do
-        expect(described_class.new(invalid_geom).bounding_box).to eq ''
+      it 'returns a default GeoJSON extent' do
+        expect(described_class.new(invalid_geom).bounding_box).to include('coordinates', '-180.0,90.0')
       end
     end
   end


### PR DESCRIPTION
Closes #1042 

Provides a default extent value when there is an error parsing a geometry or transforming into GeoJSON.