### PR TITLE
Deprecation Fix - Use SearchState#to_h instead of SearchState#to_unsafe_h

### DIFF
--- a/lib/geoblacklight/view_helper_override.rb
+++ b/lib/geoblacklight/view_helper_override.rb
@@ -27,7 +27,7 @@ module Geoblacklight
 
     def render_constraints_filters(localized_params = params)
       content = super(localized_params)
-      localized_params = localized_params.to_unsafe_h if localized_params.respond_to?(:to_unsafe_h)
+      localized_params = localized_params.to_h if localized_params.respond_to?(:to_h)
 
       if localized_params[:bbox]
         path = search_action_path(remove_spatial_filter_group(:bbox, localized_params))


### PR DESCRIPTION
Fixes #1068

Addresses:
DEPRECATION WARNING: Use SearchState#to_h instead of SearchState#to_unsafe_h. (called from render_constraints_filters at /Users/ewlarson/Rails/geoblacklight/lib/geoblacklight/view_helper_override.rb:30)


