### PR TITLE
Deprecation Fix - presenter

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -65,7 +65,7 @@ Lint/BooleanSymbol:
 # AllowedMethods: enums
 Lint/ConstantDefinitionInBlock:
   Exclude:
-    - 'spec/lib/geoblacklight/geoblacklight_helper_behavior_spec.rb'
+    - 'spec/helpers/geoblacklight/geoblacklight_helper_behavior_spec.rb'
     - 'spec/lib/geoblacklight/view_helper_override_spec.rb'
     - 'spec/models/concerns/geoblacklight/solr_document/carto_spec.rb'
     - 'spec/models/concerns/geoblacklight/solr_document/finder_spec.rb'
@@ -131,7 +131,7 @@ RSpec/Capybara/VisibilityMatcher:
 RSpec/ContextWording:
   Exclude:
     - 'spec/helpers/geoblacklight_helper_spec.rb'
-    - 'spec/lib/geoblacklight/geoblacklight_helper_behavior_spec.rb'
+    - 'spec/helpers/geoblacklight/geoblacklight_helper_behavior_spec.rb'
     - 'spec/lib/geoblacklight/item_viewer_spec.rb'
     - 'spec/lib/geoblacklight/reference_spec.rb'
     - 'spec/views/catalog/_show_downloads.html.erb_spec.rb'
@@ -167,7 +167,7 @@ RSpec/EmptyLineAfterHook:
     - 'spec/features/home_page_spec.rb'
     - 'spec/helpers/geoblacklight_helper_spec.rb'
     - 'spec/lib/geoblacklight/download_spec.rb'
-    - 'spec/lib/geoblacklight/geoblacklight_helper_behavior_spec.rb'
+    - 'spec/helpers/geoblacklight/geoblacklight_helper_behavior_spec.rb'
     - 'spec/lib/geoblacklight/metadata_spec.rb'
     - 'spec/lib/geoblacklight/metadata_transformer/base_spec.rb'
     - 'spec/lib/geoblacklight/references_spec.rb'
@@ -188,7 +188,7 @@ RSpec/EmptyLineAfterSubject:
 # Offense count: 5
 RSpec/ExpectInHook:
   Exclude:
-    - 'spec/lib/geoblacklight/geoblacklight_helper_behavior_spec.rb'
+    - 'spec/helpers/geoblacklight/geoblacklight_helper_behavior_spec.rb'
     - 'spec/lib/geoblacklight/metadata/base_spec.rb'
     - 'spec/lib/geoblacklight/metadata_transformer/iso19139_spec.rb'
     - 'spec/views/catalog/_show_downloads.html.erb_spec.rb'
@@ -213,7 +213,7 @@ RSpec/IteratedExpectation:
 # Offense count: 4
 RSpec/LeakyConstantDeclaration:
   Exclude:
-    - 'spec/lib/geoblacklight/geoblacklight_helper_behavior_spec.rb'
+    - 'spec/helpers/geoblacklight/geoblacklight_helper_behavior_spec.rb'
     - 'spec/lib/geoblacklight/view_helper_override_spec.rb'
     - 'spec/models/concerns/geoblacklight/solr_document/carto_spec.rb'
     - 'spec/models/concerns/geoblacklight/solr_document/finder_spec.rb'
@@ -283,7 +283,7 @@ RSpec/StubbedMock:
     - 'spec/features/download_layer_spec.rb'
     - 'spec/helpers/geoblacklight_helper_spec.rb'
     - 'spec/lib/geoblacklight/download_spec.rb'
-    - 'spec/lib/geoblacklight/geoblacklight_helper_behavior_spec.rb'
+    - 'spec/helpers/geoblacklight/geoblacklight_helper_behavior_spec.rb'
     - 'spec/lib/geoblacklight/metadata_transformer/iso19139_spec.rb'
     - 'spec/models/concerns/geoblacklight/solr_document/carto_spec.rb'
     - 'spec/models/concerns/geoblacklight/solr_document/inspection_spec.rb'
@@ -316,6 +316,7 @@ Rails/HelperInstanceVariable:
   Exclude:
     - 'app/helpers/blacklight_helper.rb'
     - 'app/helpers/geoblacklight_helper.rb'
+    - 'app/helpers/geoblacklight/geoblacklight_helper_behavior.rb'
 
 # Offense count: 6
 Rails/OutputSafety:

--- a/app/helpers/geoblacklight/geoblacklight_helper_behavior.rb
+++ b/app/helpers/geoblacklight/geoblacklight_helper_behavior.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
+##
+# Adds helper behavior logic for GeoBlacklight, to used alongside
+# BlacklightHelperBehavior
 module Geoblacklight
-  ##
-  # Adds helper behavior logic for GeoBlacklight, to used alongside
-  # BlacklightHelperBehavior
   module GeoblacklightHelperBehavior
+    include Blacklight::BlacklightHelperBehavior
+
     ##
     # Calls the presenter on the requested method
     # @param [Symbol, String] presenting_method

--- a/lib/geoblacklight.rb
+++ b/lib/geoblacklight.rb
@@ -7,7 +7,6 @@ module Geoblacklight
   require 'geoblacklight/catalog_helper_override'
   require 'geoblacklight/constants'
   require 'geoblacklight/exceptions'
-  require 'geoblacklight/geoblacklight_helper_behavior'
   require 'geoblacklight/geometry'
   require 'geoblacklight/view_helper_override'
   require 'geoblacklight/item_viewer'

--- a/lib/geoblacklight/geoblacklight_helper_behavior.rb
+++ b/lib/geoblacklight/geoblacklight_helper_behavior.rb
@@ -9,7 +9,7 @@ module Geoblacklight
     # @param [Symbol, String] presenting_method
     # @return [String]
     def geoblacklight_present(presenting_method, document = @document)
-      presenter(document).try(presenting_method.to_sym) || ''
+      document_presenter(document).try(presenting_method.to_sym) || ''
     end
   end
 end

--- a/spec/features/esri_viewer_spec.rb
+++ b/spec/features/esri_viewer_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 
 feature 'feature_layer reference', js: true do
   scenario 'displays image map layer' do
+    skip 'CORS error - Purdue web services are down'
     visit solr_document_path '32653ed6-8d83-4692-8a06-bf13ffe2c018'
     expect(page).to have_css '.leaflet-control-zoom', visible: true
     expect(page).to have_css 'img.leaflet-image-layer', visible: true

--- a/spec/features/layer_opacity_spec.rb
+++ b/spec/features/layer_opacity_spec.rb
@@ -9,6 +9,7 @@ feature 'Layer opacity', js: true do
   end
 
   scenario 'ESRI image service layer should have opacity control' do
+    skip 'CORS error - Purdue web services are down'
     visit solr_document_path('32653ed6-8d83-4692-8a06-bf13ffe2c018')
     expect(page).to have_css('div.opacity-text', text: '75%')
     expect(page.find('img.leaflet-image-layer', match: :first)[:style]).to match(/opacity: 0.75;/)

--- a/spec/helpers/geoblacklight/geoblacklight_helper_behavior_spec.rb
+++ b/spec/helpers/geoblacklight/geoblacklight_helper_behavior_spec.rb
@@ -17,6 +17,7 @@ describe Geoblacklight::GeoblacklightHelperBehavior do
     before do
       expect(dummy_class).to receive(:presenter).and_return(presenter)
     end
+
     context 'as a Symbol' do
       it 'calls defined presenter class' do
         expect(dummy_class.geoblacklight_present(:fake_name)).to eq 'druid:abc123'


### PR DESCRIPTION
Fixes #1067 

Moves GeoBlacklightHelperBehavior from lib to app/helpers, which is better aligned with Blacklight's HelperBehavior files, and allows us to include Blacklight::BlacklightHelperBehavior to access the document_presenter method.

Also adds skips for specs that reference Purdue ArcGIS web services, which are returning CORS errors at the moment.