### PR TITLE
Deprecation Fix - document_heading

### DIFF
--- a/app/views/catalog/_show_header_default.html.erb
+++ b/app/views/catalog/_show_header_default.html.erb
@@ -1,4 +1,4 @@
 <h2>
-  <span itemprop="name"><%= document_heading(document) %></span>
+  <span itemprop="name"><%= document_presenter(document).heading %></span>
   <%= render partial: 'header_icons', locals: { document: document } %>
 </h2>


### PR DESCRIPTION
Swap document_heading for document_presenter.

Fixes #1070

Co-Authored-By: Chris Beer <chris@cbeer.info>