### PR TITLE
Deprecation Fix - Convert render_facet_tags to component

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -206,6 +206,10 @@ RSpec/FilePath:
     - 'spec/lib/geoblacklight/wms_layer/feature_info_response_spec.rb'
 
 # Offense count: 1
+RSpec/InstanceVariable:
+  Enabled: false
+
+# Offense count: 1
 RSpec/IteratedExpectation:
   Exclude:
     - 'spec/lib/geoblacklight/references_spec.rb'

--- a/app/components/geoblacklight/homepage_feature_facet_component.html.erb
+++ b/app/components/geoblacklight/homepage_feature_facet_component.html.erb
@@ -1,0 +1,11 @@
+<div class='category-block col-sm'>
+  <div class='category-icon'>
+    <%= geoblacklight_icon(@icon) %>
+  </div>
+  <%= content_tag :h4, t(@label) %>
+  <%- facets = @response.aggregations[@facet_field].items.map { |item|
+    link_to(item.value, search_catalog_path("f[#{@facet_field}][]": item.value), class: 'home-facet-link')
+  } %>
+  <%- facets << link_to('more »', facet_catalog_path(@facet_field), class: 'more_facets_link') %>
+  <%= facets.join(', ').html_safe %>
+</div>

--- a/app/components/geoblacklight/homepage_feature_facet_component.rb
+++ b/app/components/geoblacklight/homepage_feature_facet_component.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Geoblacklight
+  class HomepageFeatureFacetComponent < ViewComponent::Base
+    def initialize(icon:, label:, facet_field:, response:)
+      @icon = icon
+      @label = label
+      @facet_field = facet_field
+      @response = response
+      super
+    end
+  end
+end

--- a/app/helpers/geoblacklight_helper.rb
+++ b/app/helpers/geoblacklight_helper.rb
@@ -91,12 +91,6 @@ module GeoblacklightHelper
     truncate(Array(args[:value]).flatten.join(' '), length: 150)
   end
 
-  def render_facet_tags(facet)
-    render_facet_limit(facets_from_request(facet).first,
-                       partial: 'facet_tag_item',
-                       layout: 'facet_tag_layout')
-  end
-
   ##
   # Returns an SVG icon or empty HTML span element
   # @return [SVG or HTML tag]

--- a/app/views/catalog/_facet_tag_item.html.erb
+++ b/app/views/catalog/_facet_tag_item.html.erb
@@ -1,3 +1,0 @@
-<% display_facet.items.each do |item| %>
-  <%= link_to item.value, search_catalog_path({f: {"#{facet_field.field}" => [item.value]}}), class: 'home-facet-link' %><%= "," %>
-<% end %>

--- a/app/views/catalog/_facet_tag_layout.html.erb
+++ b/app/views/catalog/_facet_tag_layout.html.erb
@@ -1,2 +1,0 @@
-<%= yield %>
-<%= link_to t('blacklight.search.facets.more_html'), facet_catalog_path(display_facet.name), class: 'more_facets_link' %>

--- a/app/views/catalog/_home_text.html.erb
+++ b/app/views/catalog/_home_text.html.erb
@@ -3,36 +3,14 @@
     <div class='col-sm'>
       <%= content_tag :h3, t('geoblacklight.home.category_heading') %>
       <div class='row'>
-        <div class='category-block col-sm'>
-          <div class='category-icon'>
-            <%= geoblacklight_icon('home') %>
-          </div>
-          <%= content_tag :h4, t('geoblacklight.home.institution') %>
-          <%= render_facet_tags [Settings.FIELDS.PROVENANCE] %>
-        </div>
-        <div class='category-block col-sm'>
-          <div class='category-icon'>
-            <%= geoblacklight_icon('arrow-circle-down') %>
-          </div>
-          <%= content_tag :h4, t('geoblacklight.home.data_type') %>
-          <%= render_facet_tags [Settings.FIELDS.GEOM_TYPE] %>
-        </div>
+        <%= render(Geoblacklight::HomepageFeatureFacetComponent.new(icon: 'home', label: 'geoblacklight.home.institution', facet_field: Settings.FIELDS.PROVENANCE, response: @response)) %>
+
+        <%= render(Geoblacklight::HomepageFeatureFacetComponent.new(icon: 'arrow-circle-down', label: 'geoblacklight.home.data_type', facet_field: Settings.FIELDS.GEOM_TYPE, response: @response)) %>
       </div>
       <div class='row'>
-        <div class='category-block col-sm'>
-          <div class='category-icon'>
-            <%= geoblacklight_icon('globe') %>
-          </div>
-          <%= content_tag :h4, t('geoblacklight.home.placename') %>
-          <%= render_facet_tags [Settings.FIELDS.SPATIAL_COVERAGE] %>
-        </div>
-        <div class='category-block col-sm'>
-          <div class='category-icon'>
-            <%= geoblacklight_icon('tags') %>
-          </div>
-          <%= content_tag :h4, t('geoblacklight.home.subject') %>
-          <%= render_facet_tags [Settings.FIELDS.SUBJECT] %>
-        </div>
+        <%= render(Geoblacklight::HomepageFeatureFacetComponent.new(icon: 'globe', label: 'geoblacklight.home.placename', facet_field: Settings.FIELDS.SPATIAL_COVERAGE, response: @response)) %>
+
+        <%= render(Geoblacklight::HomepageFeatureFacetComponent.new(icon: 'tags', label: 'geoblacklight.home.subject', facet_field: Settings.FIELDS.SUBJECT, response: @response)) %>
       </div>
     </div>
     <div class='col-sm'>

--- a/geoblacklight.gemspec
+++ b/geoblacklight.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'mime-types'
   spec.add_dependency 'handlebars_assets'
   spec.add_dependency 'rgeo-geojson'
+  spec.add_dependency 'view_component', '>= 2.28.0'
 
   spec.add_development_dependency 'solr_wrapper'
   spec.add_development_dependency 'rails-controller-testing'

--- a/geoblacklight.gemspec
+++ b/geoblacklight.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.required_rubygems_version = '>= 2.5.2'
 
   spec.add_dependency 'rails', '>= 5.2.4', '< 6.2'
-  spec.add_dependency 'blacklight', '~> 7.0'
+  spec.add_dependency 'blacklight', '~> 7.8'
   spec.add_dependency 'config'
   spec.add_dependency 'faraday', '~> 1.0'
   spec.add_dependency 'faraday_middleware', '~> 1.0.0.rc1'
@@ -30,7 +30,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'mime-types'
   spec.add_dependency 'handlebars_assets'
   spec.add_dependency 'rgeo-geojson'
-  spec.add_dependency 'view_component', '>= 2.28.0'
 
   spec.add_development_dependency 'solr_wrapper'
   spec.add_development_dependency 'rails-controller-testing'

--- a/spec/components/geoblacklight/homepage_feature_facet_component_spec.rb
+++ b/spec/components/geoblacklight/homepage_feature_facet_component_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+RSpec.describe Geoblacklight::HomepageFeatureFacetComponent, type: :component do
+  subject(:rendered) do
+    render_inline_to_capybara_node(described_class.new(**kargs))
+  end
+
+  # Build a search
+  let(:context) { { whatever: :value } }
+  let(:service) { Blacklight::SearchService.new(config: blacklight_config, user_params: user_params, **context) }
+  let(:repository) { Blacklight::Solr::Repository.new(blacklight_config) }
+  let(:user_params) { {} }
+  let(:blacklight_config) { Blacklight::Configuration.new }
+  let(:copy_of_catalog_config) { ::CatalogController.blacklight_config.deep_copy }
+  let(:blacklight_solr) { RSolr.connect(Blacklight.connection_config.except(:adapter)) }
+
+  describe "homepage" do
+    before do
+      (@response, @document_list) = service.search_results
+    end
+
+    let(:kargs) do
+      {
+        icon: 'home',
+        label: 'geoblacklight.home.institution',
+        facet_field: Settings.FIELDS.PROVENANCE,
+        response: @response
+      }
+    end
+
+    it "includes facet links" do
+      expect(rendered).to have_selector("div.category-block")
+      expect(rendered).to have_selector("div.category-icon")
+      expect(rendered).to have_selector("a.home-facet-link")
+      expect(rendered).to have_selector("a.more_facets_link")
+    end
+  end
+end

--- a/spec/components/geoblacklight/homepage_feature_facet_component_spec.rb
+++ b/spec/components/geoblacklight/homepage_feature_facet_component_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Geoblacklight::HomepageFeatureFacetComponent, type: :component do
   let(:copy_of_catalog_config) { ::CatalogController.blacklight_config.deep_copy }
   let(:blacklight_solr) { RSolr.connect(Blacklight.connection_config.except(:adapter)) }
 
-  describe "homepage" do
+  describe 'homepage' do
     before do
       (@response, @document_list) = service.search_results
     end
@@ -29,11 +29,11 @@ RSpec.describe Geoblacklight::HomepageFeatureFacetComponent, type: :component do
       }
     end
 
-    it "includes facet links" do
-      expect(rendered).to have_selector("div.category-block")
-      expect(rendered).to have_selector("div.category-icon")
-      expect(rendered).to have_selector("a.home-facet-link")
-      expect(rendered).to have_selector("a.more_facets_link")
+    it 'includes facet links' do
+      expect(rendered).to have_selector('div.category-block')
+      expect(rendered).to have_selector('div.category-icon')
+      expect(rendered).to have_selector('a.home-facet-link')
+      expect(rendered).to have_selector('a.more_facets_link')
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -79,4 +79,6 @@ RSpec.configure do |config|
   end
 
   config.include Devise::Test::ControllerHelpers, type: :controller
+  config.include ViewComponent::TestHelpers, type: :component
+  config.include ViewComponentCapybaraTestHelpers, type: :component
 end

--- a/spec/support/view_component_capybara_test_helpers.rb
+++ b/spec/support/view_component_capybara_test_helpers.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module ViewComponentCapybaraTestHelpers
+  # Work around for https://github.com/teamcapybara/capybara/issues/2466
+  def render_inline_to_capybara_node(component)
+    Capybara::Node::Simple.new(render_inline(component).to_s)
+  end
+end


### PR DESCRIPTION
Removes our GBL render_facet_tags helper, which called deprecated methods from BL (render_facet_limit, facets_from_request). Replaces the helper with our first GBL ViewComponent component: Geoblacklight::HomepageFeatureFacetComponent

This new component renders each homepage feature facet block, including: icon, label, facet links, and the more link.

Fixes #1065, #1066
