### PR TITLE
Deprecation Fix - CSS-based icons for document actions

### DIFF
--- a/app/assets/stylesheets/geoblacklight/modules/icon-customization.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/icon-customization.scss
@@ -48,3 +48,44 @@ span.icon-missing {
     height: 100%;
   }
 }
+
+// Sidebar Action Icons
+#citationLink {
+  margin-left:0rem;
+  padding-left: 1.5rem;
+  background-position: left center;
+  background-repeat:no-repeat;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' version='1.1' width='16' height='16' viewBox='0 0 512 512' aria-label='Citation' role='img'%3E%3Ctitle%3ECitation%3C/title%3E%3Cpath fill='%236c757d' d='M464 256h-80v-64c0-35.3 28.7-64 64-64h8c13.3 0 24-10.7 24-24V56c0-13.3-10.7-24-24-24h-8c-88.4 0-160 71.6-160 160v240c0 26.5 21.5 48 48 48h128c26.5 0 48-21.5 48-48V304c0-26.5-21.5-48-48-48zm-288 0H96v-64c0-35.3 28.7-64 64-64h8c13.3 0 24-10.7 24-24V56c0-13.3-10.7-24-24-24h-8C71.6 32 0 103.6 0 192v240c0 26.5 21.5 48 48 48h128c26.5 0 48-21.5 48-48V304c0-26.5-21.5-48-48-48z'%3E%3C/path%3E%3C/svg%3E");
+}
+
+#emailLink {
+  margin-left:0rem;
+  padding-left: 1.5rem;
+  background-position: left center;
+  background-repeat:no-repeat;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' version='1.1' width='16' height='16' viewBox='0 0 28 28' aria-label='Email' role='img'%3E%3Ctitle%3EEmail%3C/title%3E%3Cpath fill='%236c757d' d='M28 11.1v12.4a2.5 2.5 0 0 1-2.5 2.5h-23A2.5 2.5 0 0 1 0 23.5V11.1c.47.51 1 .96 1.58 1.35 2.6 1.77 5.22 3.53 7.76 5.4 1.32.96 2.94 2.15 4.64 2.15h.04c1.7 0 3.32-1.19 4.64-2.16 2.54-1.84 5.17-3.62 7.78-5.39.56-.39 1.1-.84 1.56-1.36zm0-4.6c0 1.75-1.3 3.33-2.67 4.28-2.44 1.69-4.9 3.38-7.31 5.08-1.02.7-2.74 2.14-4 2.14h-.04c-1.26 0-2.98-1.44-4-2.14-2.42-1.7-4.87-3.4-7.3-5.08C1.59 10.03 0 8.26 0 6.84 0 5.31.83 4 2.5 4h23C26.86 4 28 5.12 28 6.5z'%3E%3C/path%3E%3C/svg%3E");
+}
+
+#smsLink {
+  margin-left:0rem;
+  padding-left: 1.5rem;
+  background-position: left center;
+  background-repeat:no-repeat;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' version='1.1' width='16' height='16' viewBox='0 0 12 28' aria-label='SMS' role='img'%3E%3Ctitle%3ESMS%3C/title%3E%3Cpath fill='%236c757d' d='M7.25 22a1.25 1.25 0 0 0-2.5 0 1.25 1.25 0 0 0 2.5 0zm3.25-2.5v-11c0-.27-.23-.5-.5-.5H2c-.27 0-.5.23-.5.5v11c0 .27.23.5.5.5h8c.27 0 .5-.23.5-.5zm-3-13.25c0-.14-.1-.25-.25-.25h-2.5c-.14 0-.25.1-.25.25s.1.25.25.25h2.5c.14 0 .25-.1.25-.25zM12 6v16c0 1.1-.9 2-2 2H2c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2h8c1.1 0 2 .9 2 2z'%3E%3C/path%3E%3C/svg%3E");
+}
+
+#web_servicesLink {
+  margin-left:0rem;
+  padding-left: 1.5rem;
+  background-position: left center;
+  background-repeat:no-repeat;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' version='1.1' width='16' height='16' viewBox='0 0 28 28' aria-label='Web Services' role='img'%3E%3Ctitle%3EWeb Services%3C/title%3E%3Cpath fill='%236c757d' d='M22 14.5v5a4.5 4.5 0 0 1-4.5 4.5h-13A4.5 4.5 0 0 1 0 19.5v-13A4.5 4.5 0 0 1 4.5 2h11c.28 0 .5.22.5.5v1a.5.5 0 0 1-.5.5h-11A2.5 2.5 0 0 0 2 6.5v13A2.5 2.5 0 0 0 4.5 22h13a2.5 2.5 0 0 0 2.5-2.5v-5c0-.28.22-.5.5-.5h1c.28 0 .5.22.5.5zM28 1v8a1 1 0 0 1-1 1 .99.99 0 0 1-.7-.3l-2.75-2.75-10.19 10.19c-.1.1-.23.16-.36.16s-.26-.07-.36-.16l-1.78-1.78c-.1-.1-.15-.23-.15-.36s.06-.27.15-.36L21.05 4.45 18.3 1.7A1 1 0 0 1 18 1a1 1 0 0 1 1-1h8a1 1 0 0 1 1 1z'%3E%3C/path%3E%3C/svg%3E");
+}
+
+#metadataLink {
+  margin-left:0rem;
+  padding-left: 1.5rem;
+  background-position: left center;
+  background-repeat:no-repeat;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' version='1.1' width='16' height='16' viewBox='0 0 27 32' role='img'%3E%3Ctitle%3EMetadata%3C/title%3E%3Cpath fill='%236c757d' d='M26.217 8.503c0.171 0.171 0.343 0.389 0.491 0.64h-8.423v-8.434c0.251 0.171 0.457 0.331 0.64 0.503zM17.714 11.429h9.714v18.857c0 0.949-0.766 1.714-1.714 1.714h-24c-0.947 0-1.714-0.767-1.714-1.714v0-28.571c0-0.949 0.766-1.714 1.714-1.714h14.286v9.714c0 0.949 0.766 1.714 1.714 1.714zM20.571 24.571v-1.143c0-0.316-0.256-0.571-0.571-0.571v0h-12.571c-0.316 0-0.571 0.256-0.571 0.571v0 1.143c0 0.32 0.251 0.571 0.571 0.571h12.571c0.316 0 0.571-0.256 0.571-0.571v0zM20.571 20v-1.143c0-0.316-0.256-0.571-0.571-0.571v0h-12.571c-0.316 0-0.571 0.256-0.571 0.571v0 1.143c0 0.32 0.251 0.571 0.571 0.571h12.571c0.316 0 0.571-0.256 0.571-0.571v0zM20.571 15.429v-1.143c0-0.316-0.256-0.571-0.571-0.571v0h-12.571c-0.316 0-0.571 0.256-0.571 0.571v0 1.143c0 0.32 0.251 0.571 0.571 0.571h12.571c0.316 0 0.571-0.256 0.571-0.571v0z'%3E%3C/path%3E%3C/svg%3E");
+}

--- a/app/assets/stylesheets/geoblacklight/modules/icon-customization.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/icon-customization.scss
@@ -55,7 +55,7 @@ span.icon-missing {
   padding-left: 1.5rem;
   background-position: left center;
   background-repeat:no-repeat;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' version='1.1' width='16' height='16' viewBox='0 0 512 512' aria-label='Citation' role='img'%3E%3Ctitle%3ECitation%3C/title%3E%3Cpath fill='%236c757d' d='M464 256h-80v-64c0-35.3 28.7-64 64-64h8c13.3 0 24-10.7 24-24V56c0-13.3-10.7-24-24-24h-8c-88.4 0-160 71.6-160 160v240c0 26.5 21.5 48 48 48h128c26.5 0 48-21.5 48-48V304c0-26.5-21.5-48-48-48zm-288 0H96v-64c0-35.3 28.7-64 64-64h8c13.3 0 24-10.7 24-24V56c0-13.3-10.7-24-24-24h-8C71.6 32 0 103.6 0 192v240c0 26.5 21.5 48 48 48h128c26.5 0 48-21.5 48-48V304c0-26.5-21.5-48-48-48z'%3E%3C/path%3E%3C/svg%3E");
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' version='1.1' width='14' height='14' viewBox='0 0 512 512' aria-label='Citation' role='img'%3E%3Ctitle%3ECitation%3C/title%3E%3Cpath fill='%236c757d' d='M464 256h-80v-64c0-35.3 28.7-64 64-64h8c13.3 0 24-10.7 24-24V56c0-13.3-10.7-24-24-24h-8c-88.4 0-160 71.6-160 160v240c0 26.5 21.5 48 48 48h128c26.5 0 48-21.5 48-48V304c0-26.5-21.5-48-48-48zm-288 0H96v-64c0-35.3 28.7-64 64-64h8c13.3 0 24-10.7 24-24V56c0-13.3-10.7-24-24-24h-8C71.6 32 0 103.6 0 192v240c0 26.5 21.5 48 48 48h128c26.5 0 48-21.5 48-48V304c0-26.5-21.5-48-48-48z'%3E%3C/path%3E%3C/svg%3E");
 }
 
 #emailLink {
@@ -63,15 +63,15 @@ span.icon-missing {
   padding-left: 1.5rem;
   background-position: left center;
   background-repeat:no-repeat;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' version='1.1' width='16' height='16' viewBox='0 0 28 28' aria-label='Email' role='img'%3E%3Ctitle%3EEmail%3C/title%3E%3Cpath fill='%236c757d' d='M28 11.1v12.4a2.5 2.5 0 0 1-2.5 2.5h-23A2.5 2.5 0 0 1 0 23.5V11.1c.47.51 1 .96 1.58 1.35 2.6 1.77 5.22 3.53 7.76 5.4 1.32.96 2.94 2.15 4.64 2.15h.04c1.7 0 3.32-1.19 4.64-2.16 2.54-1.84 5.17-3.62 7.78-5.39.56-.39 1.1-.84 1.56-1.36zm0-4.6c0 1.75-1.3 3.33-2.67 4.28-2.44 1.69-4.9 3.38-7.31 5.08-1.02.7-2.74 2.14-4 2.14h-.04c-1.26 0-2.98-1.44-4-2.14-2.42-1.7-4.87-3.4-7.3-5.08C1.59 10.03 0 8.26 0 6.84 0 5.31.83 4 2.5 4h23C26.86 4 28 5.12 28 6.5z'%3E%3C/path%3E%3C/svg%3E");
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' version='1.1' width='14' height='14' viewBox='0 0 28 28' aria-label='Email' role='img'%3E%3Ctitle%3EEmail%3C/title%3E%3Cpath fill='%236c757d' d='M28 11.1v12.4a2.5 2.5 0 0 1-2.5 2.5h-23A2.5 2.5 0 0 1 0 23.5V11.1c.47.51 1 .96 1.58 1.35 2.6 1.77 5.22 3.53 7.76 5.4 1.32.96 2.94 2.15 4.64 2.15h.04c1.7 0 3.32-1.19 4.64-2.16 2.54-1.84 5.17-3.62 7.78-5.39.56-.39 1.1-.84 1.56-1.36zm0-4.6c0 1.75-1.3 3.33-2.67 4.28-2.44 1.69-4.9 3.38-7.31 5.08-1.02.7-2.74 2.14-4 2.14h-.04c-1.26 0-2.98-1.44-4-2.14-2.42-1.7-4.87-3.4-7.3-5.08C1.59 10.03 0 8.26 0 6.84 0 5.31.83 4 2.5 4h23C26.86 4 28 5.12 28 6.5z'%3E%3C/path%3E%3C/svg%3E");
 }
 
 #smsLink {
-  margin-left:0rem;
-  padding-left: 1.5rem;
+  margin-left:-0.2rem;
+  padding-left: 1.7rem;
   background-position: left center;
   background-repeat:no-repeat;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' version='1.1' width='16' height='16' viewBox='0 0 12 28' aria-label='SMS' role='img'%3E%3Ctitle%3ESMS%3C/title%3E%3Cpath fill='%236c757d' d='M7.25 22a1.25 1.25 0 0 0-2.5 0 1.25 1.25 0 0 0 2.5 0zm3.25-2.5v-11c0-.27-.23-.5-.5-.5H2c-.27 0-.5.23-.5.5v11c0 .27.23.5.5.5h8c.27 0 .5-.23.5-.5zm-3-13.25c0-.14-.1-.25-.25-.25h-2.5c-.14 0-.25.1-.25.25s.1.25.25.25h2.5c.14 0 .25-.1.25-.25zM12 6v16c0 1.1-.9 2-2 2H2c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2h8c1.1 0 2 .9 2 2z'%3E%3C/path%3E%3C/svg%3E");
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' version='1.1' width='20' height='20' viewBox='0 0 12 28' aria-label='SMS' role='img'%3E%3Ctitle%3ESMS%3C/title%3E%3Cpath fill='%236c757d' d='M7.25 22a1.25 1.25 0 0 0-2.5 0 1.25 1.25 0 0 0 2.5 0zm3.25-2.5v-11c0-.27-.23-.5-.5-.5H2c-.27 0-.5.23-.5.5v11c0 .27.23.5.5.5h8c.27 0 .5-.23.5-.5zm-3-13.25c0-.14-.1-.25-.25-.25h-2.5c-.14 0-.25.1-.25.25s.1.25.25.25h2.5c.14 0 .25-.1.25-.25zM12 6v16c0 1.1-.9 2-2 2H2c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2h8c1.1 0 2 .9 2 2z'%3E%3C/path%3E%3C/svg%3E");
 }
 
 #web_servicesLink {
@@ -79,13 +79,13 @@ span.icon-missing {
   padding-left: 1.5rem;
   background-position: left center;
   background-repeat:no-repeat;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' version='1.1' width='16' height='16' viewBox='0 0 28 28' aria-label='Web Services' role='img'%3E%3Ctitle%3EWeb Services%3C/title%3E%3Cpath fill='%236c757d' d='M22 14.5v5a4.5 4.5 0 0 1-4.5 4.5h-13A4.5 4.5 0 0 1 0 19.5v-13A4.5 4.5 0 0 1 4.5 2h11c.28 0 .5.22.5.5v1a.5.5 0 0 1-.5.5h-11A2.5 2.5 0 0 0 2 6.5v13A2.5 2.5 0 0 0 4.5 22h13a2.5 2.5 0 0 0 2.5-2.5v-5c0-.28.22-.5.5-.5h1c.28 0 .5.22.5.5zM28 1v8a1 1 0 0 1-1 1 .99.99 0 0 1-.7-.3l-2.75-2.75-10.19 10.19c-.1.1-.23.16-.36.16s-.26-.07-.36-.16l-1.78-1.78c-.1-.1-.15-.23-.15-.36s.06-.27.15-.36L21.05 4.45 18.3 1.7A1 1 0 0 1 18 1a1 1 0 0 1 1-1h8a1 1 0 0 1 1 1z'%3E%3C/path%3E%3C/svg%3E");
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' version='1.1' width='14' height='14' viewBox='0 0 28 28' aria-label='Web Services' role='img'%3E%3Ctitle%3EWeb Services%3C/title%3E%3Cpath fill='%236c757d' d='M22 14.5v5a4.5 4.5 0 0 1-4.5 4.5h-13A4.5 4.5 0 0 1 0 19.5v-13A4.5 4.5 0 0 1 4.5 2h11c.28 0 .5.22.5.5v1a.5.5 0 0 1-.5.5h-11A2.5 2.5 0 0 0 2 6.5v13A2.5 2.5 0 0 0 4.5 22h13a2.5 2.5 0 0 0 2.5-2.5v-5c0-.28.22-.5.5-.5h1c.28 0 .5.22.5.5zM28 1v8a1 1 0 0 1-1 1 .99.99 0 0 1-.7-.3l-2.75-2.75-10.19 10.19c-.1.1-.23.16-.36.16s-.26-.07-.36-.16l-1.78-1.78c-.1-.1-.15-.23-.15-.36s.06-.27.15-.36L21.05 4.45 18.3 1.7A1 1 0 0 1 18 1a1 1 0 0 1 1-1h8a1 1 0 0 1 1 1z'%3E%3C/path%3E%3C/svg%3E");
 }
 
 #metadataLink {
-  margin-left:0rem;
+  margin-left:0.1rem;
   padding-left: 1.5rem;
   background-position: left center;
   background-repeat:no-repeat;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' version='1.1' width='16' height='16' viewBox='0 0 27 32' role='img'%3E%3Ctitle%3EMetadata%3C/title%3E%3Cpath fill='%236c757d' d='M26.217 8.503c0.171 0.171 0.343 0.389 0.491 0.64h-8.423v-8.434c0.251 0.171 0.457 0.331 0.64 0.503zM17.714 11.429h9.714v18.857c0 0.949-0.766 1.714-1.714 1.714h-24c-0.947 0-1.714-0.767-1.714-1.714v0-28.571c0-0.949 0.766-1.714 1.714-1.714h14.286v9.714c0 0.949 0.766 1.714 1.714 1.714zM20.571 24.571v-1.143c0-0.316-0.256-0.571-0.571-0.571v0h-12.571c-0.316 0-0.571 0.256-0.571 0.571v0 1.143c0 0.32 0.251 0.571 0.571 0.571h12.571c0.316 0 0.571-0.256 0.571-0.571v0zM20.571 20v-1.143c0-0.316-0.256-0.571-0.571-0.571v0h-12.571c-0.316 0-0.571 0.256-0.571 0.571v0 1.143c0 0.32 0.251 0.571 0.571 0.571h12.571c0.316 0 0.571-0.256 0.571-0.571v0zM20.571 15.429v-1.143c0-0.316-0.256-0.571-0.571-0.571v0h-12.571c-0.316 0-0.571 0.256-0.571 0.571v0 1.143c0 0.32 0.251 0.571 0.571 0.571h12.571c0.316 0 0.571-0.256 0.571-0.571v0z'%3E%3C/path%3E%3C/svg%3E");
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' version='1.1' width='14' height='14' viewBox='0 0 27 32' role='img'%3E%3Ctitle%3EMetadata%3C/title%3E%3Cpath fill='%236c757d' d='M26.217 8.503c0.171 0.171 0.343 0.389 0.491 0.64h-8.423v-8.434c0.251 0.171 0.457 0.331 0.64 0.503zM17.714 11.429h9.714v18.857c0 0.949-0.766 1.714-1.714 1.714h-24c-0.947 0-1.714-0.767-1.714-1.714v0-28.571c0-0.949 0.766-1.714 1.714-1.714h14.286v9.714c0 0.949 0.766 1.714 1.714 1.714zM20.571 24.571v-1.143c0-0.316-0.256-0.571-0.571-0.571v0h-12.571c-0.316 0-0.571 0.256-0.571 0.571v0 1.143c0 0.32 0.251 0.571 0.571 0.571h12.571c0.316 0 0.571-0.256 0.571-0.571v0zM20.571 20v-1.143c0-0.316-0.256-0.571-0.571-0.571v0h-12.571c-0.316 0-0.571 0.256-0.571 0.571v0 1.143c0 0.32 0.251 0.571 0.571 0.571h12.571c0.316 0 0.571-0.256 0.571-0.571v0zM20.571 15.429v-1.143c0-0.316-0.256-0.571-0.571-0.571v0h-12.571c-0.316 0-0.571 0.256-0.571 0.571v0 1.143c0 0.32 0.251 0.571 0.571 0.571h12.571c0.316 0 0.571-0.256 0.571-0.571v0z'%3E%3C/path%3E%3C/svg%3E");
 }

--- a/app/assets/stylesheets/geoblacklight/modules/toolbar.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/toolbar.scss
@@ -19,10 +19,16 @@
     a {
       padding: 8px 1rem 8px 0;
     }
+
+    a:hover {
+      text-decoration: underline;
+    }
   }
 
   // Spacing between Tools icons and their labels
   .blacklight-icons {
     padding-right: 2px;
+    margin-right: 0.5rem;
+    margin-left: 0.1rem;
   }
 }

--- a/app/views/catalog/_arcgis.html.erb
+++ b/app/views/catalog/_arcgis.html.erb
@@ -1,4 +1,4 @@
 <% document ||= @document %>
 <%= link_to(arcgis_link(document.arcgis_urls)) do %>
-  <%= blacklight_icon('esri-globe') %> <%= t('geoblacklight.tools.open_arcgis') %>
+  <%= blacklight_icon('esri-globe') %><%= t('geoblacklight.tools.open_arcgis') %>
 <% end %>

--- a/app/views/catalog/_data_dictionary.html.erb
+++ b/app/views/catalog/_data_dictionary.html.erb
@@ -1,6 +1,5 @@
 <% if document.data_dictionary_download.present? %>
     <%= link_to document.data_dictionary_download[:data_dictionary] do %>
-        <%= geoblacklight_icon('book', aria_hidden: true) %>
-        <%= t('geoblacklight.references.data_dictionary') %>
+        <%= geoblacklight_icon('book', aria_hidden: true) %><%= t('geoblacklight.references.data_dictionary') %>
     <% end %>
 <% end %>

--- a/app/views/catalog/_document_action.html.erb
+++ b/app/views/catalog/_document_action.html.erb
@@ -1,6 +1,0 @@
-<%= link_to document_action_path(document_action_config, (local_assigns.has_key?(:url_opts) ? url_opts : {}).merge(({id: document} if document) || {})),
-            id: document_action_config.fetch(:id, "#{document_action_config.key}Link"),
-            data: {}.merge(({blacklight_modal: "trigger"} if document_action_config.modal != false) || {}) do %>
-    <%= geoblacklight_icon(document_action_config.key, aria_hidden: true) %>
-    <%= document_action_label(document_action_config.key, document_action_config) %>
-<% end %>


### PR DESCRIPTION
To resolve two deprecation warnings (document_action_path and document_action_label), instead of overriding Blacklight's document actions partial and component render flow, we'll use decorative CSS-based icons for actions.

In the future, we should work to add icon support to BL's _document_action partial/component.

Fixes #1071, #1072