### PR TITLE
Improve default sorting options

### DIFF
--- a/lib/generators/geoblacklight/templates/catalog_controller.rb
+++ b/lib/generators/geoblacklight/templates/catalog_controller.rb
@@ -222,10 +222,11 @@ class CatalogController < ApplicationController
     # label in pulldown is followed by the name of the SOLR field to sort by and
     # whether the sort is ascending or descending (it must be asc or desc
     # except in the relevancy case).
-    config.add_sort_field 'score desc, dc_title_sort asc', :label => 'relevance'
-    config.add_sort_field "#{Settings.FIELDS.YEAR} desc, dc_title_sort asc", :label => 'year'
-    config.add_sort_field "#{Settings.FIELDS.PUBLISHER} asc, dc_title_sort asc", :label => 'publisher'
-    config.add_sort_field 'dc_title_sort asc', :label => 'title'
+    config.add_sort_field 'score desc, dc_title_sort asc', :label => 'Relevance'
+    config.add_sort_field "#{Settings.FIELDS.YEAR} desc, dc_title_sort asc", :label => 'Year (Newest first)'
+    config.add_sort_field "#{Settings.FIELDS.YEAR} asc, dc_title_sort asc", :label => 'Year (Oldest first)'
+    config.add_sort_field 'dc_title_sort asc', :label => 'Title (A-Z)'
+    config.add_sort_field 'dc_title_sort desc', :label => 'Title (Z-A)'
 
     # If there are more than this many search results, no spelling ("did you
     # mean") suggestion is offered.


### PR DESCRIPTION
Improves the default sorting options by adding directional options for Year and Title: 
Year (Newest first)
Year (Oldest first)
Title (A-Z)
Title (Z-A) 

Removes the Publisher sort option as less desirable.

Fixes #1051