### PR TITLE
Deprecation Fix - download_link_direct

### DIFF
--- a/app/helpers/geoblacklight_helper.rb
+++ b/app/helpers/geoblacklight_helper.rb
@@ -26,21 +26,6 @@ module GeoblacklightHelper
     )
   end
 
-  def download_link_direct(text, document)
-    link_to(
-      text,
-      document.direct_download[:download],
-      'contentUrl' => document.direct_download[:download],
-      class: ['btn', 'btn-default', 'download', 'download-original'],
-      data: {
-        download: 'trigger',
-        download_type: 'direct',
-        download_id: document.id
-      }
-    )
-  end
-  deprecation_deprecate download_link_direct: 'Use download_link_file instead'
-
   def download_link_hgl(text, document)
     link_to(
       text,

--- a/app/views/catalog/_downloads_primary.html.erb
+++ b/app/views/catalog/_downloads_primary.html.erb
@@ -8,7 +8,7 @@
     <% end %>
   <% end %>
   <% if document.direct_download[:download].is_a? String %>
-    <%= render partial: 'download_link', locals: { download_link: download_link_direct(download_text(document.file_format), document) } %>
+    <%= render partial: 'download_link', locals: { download_link: download_link_file(download_text(document.file_format), document.id, document.direct_download[:download]['url']) } %>
   <% end %>
 <% end %>
 

--- a/spec/helpers/geoblacklight_helper_spec.rb
+++ b/spec/helpers/geoblacklight_helper_spec.rb
@@ -64,25 +64,6 @@ describe GeoblacklightHelper, type: :helper do
     end
   end
 
-  describe '#download_link_direct' do
-    let(:text) { 'Test Link Text' }
-    let(:references_field) { Settings.FIELDS.REFERENCES }
-    let(:document_attributes) do
-      {
-        references_field => {
-          'http://schema.org/downloadUrl' => 'http://example.com/urn:hul.harvard.edu:HARVARD.SDE2.TG10USAIANNH/data.zip'
-        }.to_json
-      }
-    end
-    let(:document) { SolrDocument.new(document_attributes) }
-    before do
-      allow_any_instance_of(Geoblacklight::Reference).to receive(:to_hash).and_return(download: 'http://example.com/urn:hul.harvard.edu:HARVARD.SDE2.TG10USAIANNH/data.zip')
-    end
-    it 'generates a link to download the original file' do
-      expect(download_link_direct(text, document)).to eq '<a contentUrl="http://example.com/urn:hul.harvard.edu:HARVARD.SDE2.TG10USAIANNH/data.zip" class="btn btn-default download download-original" data-download="trigger" data-download-type="direct" href="http://example.com/urn:hul.harvard.edu:HARVARD.SDE2.TG10USAIANNH/data.zip">Test Link Text</a>'
-    end
-  end
-
   describe '#download_link_hgl' do
     let(:text) { 'Test Link Text' }
     let(:document) { instance_double(SolrDocument) }


### PR DESCRIPTION
Removes the deprecated `download_link_direct` GBL helper method. Shifts the last usage to the preferred `download_link_file` helper method.

Fixes #1095