### PR TITLE
Deprecation Fix - Initializing a Blacklight::Configuration::ViewConfig implicitly

### DIFF
--- a/lib/generators/geoblacklight/templates/catalog_controller.rb
+++ b/lib/generators/geoblacklight/templates/catalog_controller.rb
@@ -32,6 +32,10 @@ class CatalogController < ApplicationController
      :q => "{!raw f=#{Settings.FIELDS.ID} v=$id}"
     }
 
+    # GeoBlacklight Defaults
+    # * Adds the "map" split view for catalog#index
+    config.view.split(partials: ['index'])
+    config.view.delete_field('list')
 
     # solr field configuration for search results/index views
     # config.index.show_link = 'title_display'
@@ -92,7 +96,7 @@ class CatalogController < ApplicationController
     config.add_facet_field Settings.FIELDS.INDEX_YEAR, :label => 'Year', :limit => 10
     config.add_facet_field Settings.FIELDS.SPATIAL_COVERAGE, :label => 'Place', :limit => 8
     config.add_facet_field Settings.FIELDS.ACCESS_RIGHTS, label: 'Access', limit: 8, partial: "icon_facet"
-    config.add_facet_field Settings.FIELDS.RESOURCE_CLASS, label: 'Resource Class', :limit => 8  
+    config.add_facet_field Settings.FIELDS.RESOURCE_CLASS, label: 'Resource Class', :limit => 8
     config.add_facet_field Settings.FIELDS.RESOURCE_TYPE, label: 'Resource Type', :limit => 8
     config.add_facet_field Settings.FIELDS.FORMAT, :label => 'Format', :limit => 8
     config.add_facet_field Settings.FIELDS.SUBJECT, :label => 'Subject', :limit => 8

--- a/lib/geoblacklight/engine.rb
+++ b/lib/geoblacklight/engine.rb
@@ -11,8 +11,6 @@ require 'handlebars_assets'
 
 module Geoblacklight
   class Engine < ::Rails::Engine
-    Blacklight::Configuration.default_values[:view].split.partials = ['index']
-    Blacklight::Configuration.default_values[:view].delete_field('list')
     # GeoblacklightHelper is needed by all helpers, so we inject it
     # into action view base here.
     initializer 'geoblacklight.helpers' do


### PR DESCRIPTION
These blacklight config rules, that enable our catalog#index split view (the "map" results), are better placed into `catalog_controller.rb` than `engine.rb` -- this way they are easily found and someone could further customize them if necessary. Also, this change removes a BL deprecation warning upon app startup.

Addresses #1076 / HT @cbeer

Co-Authored-By: Chris Beer <chris@cbeer.info>