### PR TITLE
Bug fix for Aardvark relationship browse links

### DIFF
--- a/app/views/relation/_relations.html.erb
+++ b/app/views/relation/_relations.html.erb
@@ -8,7 +8,7 @@
 <% end %>
 <% unless (@relations.send(rel)['numFound'].to_i <= 3) %>
   <li class="list-group-item border-bottom-0">
-    <%= link_to search_catalog_path({f: {"#{Settings.FIELDS.SOURCE}" => [@relations.link_id]}}) do %>
+    <%= link_to search_catalog_path({f: {"#{Settings.RELATIONSHIPS_SHOWN.send(rel).field}" => [@relations.link_id]}}) do %>
       <%= t('geoblacklight.relations.browse_all', count: @relations.send(rel)['numFound']) %>
     <% end %>
   </li>

--- a/app/views/relation/index.html.erb
+++ b/app/views/relation/index.html.erb
@@ -1,6 +1,6 @@
 <%- Settings.RELATIONSHIPS_SHOWN.each do |rel, value| %>
   <% unless @relations.send(rel)['numFound'].to_i.zero? %>
-    <div class="card relations">
+    <div class="card relations relationship-<%= rel.downcase %>">
       <div class="card-header">
         <h2 class="mb-0 h6"><%= t("#{value.label}") %></h2>
       </div>

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -9,6 +9,11 @@ feature 'Search' do
 
   scenario 'When searching child records from a parent record, supressed records are not hidden', js: true do
     visit '/catalog/princeton-1r66j405w'
+
+    within('.card.relations.relationship-source_descendants') do
+      expect(page).to have_link(href: /f%5Bdct_source_sm%5D/)
+    end
+
     click_link 'Browse all 4 records...'
     expect(page).to have_css '.document', count: 4
   end


### PR DESCRIPTION
The relationship "Browse" link should query Solr for the related field from the relationship: pcdm_memberOf_sm, dct_isPartOf_sm, dct_relation_sm, dct_source_sm, etc.

This PR adds a relationship selector to the relationship div.card, ex. "relationship-source_descendants", to easily see what relationship is rendered. And, it scopes the Solr query to the relationship's proper, associated field.

Fixes #1099