### PR TITLE
Updated index map colors to an accessible color palette

### DIFF
--- a/app/assets/stylesheets/geoblacklight/modules/index_maps.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/index_maps.scss
@@ -5,3 +5,11 @@
     margin: 5px 0;
   }
 }
+
+
+#map[data-protocol="IndexMap"] {
+  .leaflet-interactive {
+    stroke: black;
+    fill-opacity: 0.65;
+  }
+}

--- a/lib/generators/geoblacklight/templates/settings.gbl_v1.yml
+++ b/lib/generators/geoblacklight/templates/settings.gbl_v1.yml
@@ -159,15 +159,15 @@ LEAFLET:
     DETECT_RETINA: true
     INDEX:
       DEFAULT: &default
-        color: "#1eb300"
+        color: "#7FCDBB"
         weight: "1"
         radius: "4"
       UNAVAILABLE:
         <<: *default
-        color: "#b3001e"
+        color: "#EDF8B1"
       SELECTED:
         <<: *default
-        color: "#006bde"
+        color: "#2C7FB8"
   VIEWERS:
     WMS:
       <<: *opacity_control

--- a/lib/generators/geoblacklight/templates/settings.yml
+++ b/lib/generators/geoblacklight/templates/settings.yml
@@ -167,15 +167,15 @@ LEAFLET:
     DETECT_RETINA: true
     INDEX:
       DEFAULT: &default
-        color: "#1eb300"
+        color: "#7FCDBB"
         weight: "1"
         radius: "4"
       UNAVAILABLE:
         <<: *default
-        color: "#b3001e"
+        color: "#EDF8B1"
       SELECTED:
         <<: *default
-        color: "#006bde"
+        color: "#2C7FB8"
   VIEWERS:
     WMS:
       <<: *opacity_control

--- a/spec/features/index_map_spec.rb
+++ b/spec/features/index_map_spec.rb
@@ -3,8 +3,8 @@ require 'spec_helper'
 
 feature 'Index map' do
   # Colors
-  default_color = '#1eb300'
-  selected_color = '#006bde'
+  default_color = '#7FCDBB'
+  selected_color = '#2C7FB8'
   scenario 'displays index map viewer (polygon)', js: true do
     visit solr_document_path('stanford-fb897vt9938')
     # Wait until SVG elements are added


### PR DESCRIPTION
**Updated index map colors to an accessible color palette**
* * *

**Issue**: 
* #1137 


# What does this Pull Request do?
Incorporates new accessible color palette for leaflet index maps.

# How should this be tested?
Test case: http://localhost:3000/catalog/stanford-fb897vt9938

The interactive paths on index maps will now have the following:
* Black stroke color around every tile path
* Fill-opacity of each tile is now darker (from 0.2 to 0.65), but you can still see outlines/words on the map underneath the colors
* Default color (used to be green): #7FCDBB
* Unavailable color (used to be red): #EDF8B1
* Selected color (used to be blue): #2C7FB8 (still blue, just a different shade)

Notes: 
* If curious, the accessibility tool for firefox has a [color blind simulator](https://developer.mozilla.org/en-US/docs/Tools/Accessibility_inspector/Simulation) to confirm the color combinations are appropriate

Screenshot:
![Screen Shot 2022-02-16 at 3 28 54 PM](https://user-images.githubusercontent.com/13121501/154351626-6d2d20ba-7c92-4897-8c6a-d6264d2b26b2.png)

