### PR TITLE
Create index map legend to indicate what each color means

### DIFF
--- a/app/assets/stylesheets/geoblacklight/modules/index_maps.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/index_maps.scss
@@ -6,10 +6,67 @@
   }
 }
 
-
 #map[data-protocol="IndexMap"] {
   .leaflet-interactive {
     stroke: black;
     fill-opacity: 0.65;
+  }
+}
+
+.index-map-legend {
+  font-size: 15px;
+  display: flex;
+  position: absolute;
+  right: 15px;
+  top: -2px;
+  left: 90px;
+
+  &-info {
+    display: flex;
+    flex-wrap: nowrap;
+    align-items: center;
+    margin-left: 15px;
+  }
+
+  span {
+    display: inline-block;
+    border: 1px solid black;
+    margin-right: 10px;
+    height: 24px;
+    width: 24px;
+    min-height: 24px;
+    min-width: 24px;
+  }
+
+  p {
+    margin-bottom: 0;
+  }
+
+  &-default {
+    background: #7FCDBB;
+  }
+  &-unavailable {
+    background: #EDF8B1;
+  }
+  &-selected {
+    background: #2C7FB8;
+  }
+
+  @media(max-width: 768px){
+    position: revert;
+    margin-bottom: 1.25rem;
+
+    :first-child {
+      margin-left: 0;
+    }
+  }
+
+  @media(max-width: 480px){
+    display: block;
+
+    .index-map-legend-info {
+      margin-left: 0;
+      margin-bottom: 10px;
+    }
   }
 }

--- a/app/assets/stylesheets/geoblacklight/modules/index_maps.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/index_maps.scss
@@ -51,6 +51,9 @@
   &-selected {
     background: #2C7FB8;
   }
+  &-default, &-unavailable, &-selected {
+    opacity: 0.65;
+  }
 
   @media(max-width: 768px){
     position: revert;

--- a/app/views/catalog/_show_default_viewer_container.html.erb
+++ b/app/views/catalog/_show_default_viewer_container.html.erb
@@ -6,6 +6,23 @@
       <%= render_help_text_entry('viewer_protocol', document.viewer_protocol) %>
     <% end %>
 
+    <% if document.item_viewer.index_map %>
+      <div class="index-map-legend">
+        <div class="index-map-legend-info">
+          <span class="index-map-legend-default"></span>
+          <p><span class="sr-only">Green tile indicates </span>Map held by collection</p>
+        </div>
+        <div class="index-map-legend-info">
+          <span class="index-map-legend-unavailable"></span>
+          <p><span class="sr-only">Yellow tile indicates </span>Map not held by collection</p>
+        </div>
+        <div class="index-map-legend-info">
+          <span class="index-map-legend-selected"></span>
+          <p><span class="sr-only">Blue tile indicates </span>Selected map tile</p>
+        </div>
+      </div>
+    <% end %>
+
     <%= content_tag :div, id: 'map', aria: { label: t('geoblacklight.map.label') }, data: { map: 'item', protocol: document.viewer_protocol.camelize, url: document.viewer_endpoint, 'layer-id' => document.wxs_identifier, 'map-geom' => document.geometry.geojson, 'catalog-path'=> search_catalog_path, available: document_available?, inspect: show_attribute_table?, basemap: geoblacklight_basemap, leaflet_options: leaflet_options } do %>
     <% end %>
   </div>


### PR DESCRIPTION
**Create index map legend to indicate what each color means**
* * *

**Issue**: 
* #1156 


# What does this Pull Request do?
Incorporates a static legend above index map to indicate what each tile color means.

# How should this be tested?
Test case (index map): http://localhost:3000/catalog/stanford-fb897vt9938
Test case (non-index map for comparison): http://localhost:3000/catalog/stanford-dp018hs9766
* A legend should appear above index maps but not appear above any other type of map (added opacity to the colors to more closely resemble what see on the map)
   - Default (green): Map held by collection
   - Unavailable (yellow): Map not held by collection
   - Selected (blue): Selected map tile

Screenshots demonstrating responsiveness:
![Screen Shot 2022-02-17 at 12 06 40 PM](https://user-images.githubusercontent.com/13121501/154533615-2447253f-df96-49ad-973b-1b3ee7867e74.png)

![Screen Shot 2022-02-17 at 12 06 57 PM](https://user-images.githubusercontent.com/13121501/154533580-38bc9d20-7661-4999-837a-595db4f98568.png)

![Screen Shot 2022-02-17 at 12 07 16 PM](https://user-images.githubusercontent.com/13121501/154533637-4e199b94-d7bf-4e5b-b774-af72406d91ca.png)

Screenshot of legend with opacity applied
![Screen Shot 2022-02-22 at 10 48 43 AM](https://user-images.githubusercontent.com/13121501/155168787-c20a9e78-18bf-481d-96fe-46b4b1a9b50e.png)

