### PR TITLE
Multivalued year sorting: specs and schema change to sort missing values last

### DIFF
--- a/solr/conf/schema.xml
+++ b/solr/conf/schema.xml
@@ -17,7 +17,7 @@
     <dynamicField name="*_dt"   type="date"    stored="true"  indexed="true"/>
     <dynamicField name="*_f"    type="float"   stored="true"  indexed="true"/>
     <dynamicField name="*_i"    type="int"     stored="true"  indexed="true"/>
-    <dynamicField name="*_im"   type="int"     stored="true"  indexed="true" multiValued="true" />
+    <dynamicField name="*_im"   type="int"     stored="true"  indexed="true" multiValued="true" sortMissingLast="true" />
     <dynamicField name="*_l"    type="long"    stored="true"  indexed="true"/>
     <dynamicField name="*_s"    type="string"  stored="true"  indexed="true"/>
     <dynamicField name="*_ss"   type="string"  stored="true"  indexed="false"/>

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -21,7 +21,7 @@ feature 'Search' do
   scenario 'When sorting by year desc, highest value sorts first' do
     visit '/?f%5Bschema_provider_s%5D%5B%5D=University+of+Minnesota&sort=gbl_indexYear_im+desc%2C+dct_title_sort+asc'
 
-    first_doc = find(".document", match: :first)
+    first_doc = find('.document', match: :first)
 
     # Doc with gbl_indexYear_im value: [2014, 2030]
     expect(first_doc['data-document-id']).to eq('02236876-9c21-42f6-9870-d2562da8e44f')
@@ -29,7 +29,7 @@ feature 'Search' do
 
   scenario 'When sorting by year, missing values sort last' do
     visit '/?f%5Bschema_provider_s%5D%5B%5D=University+of+Minnesota&sort=gbl_indexYear_im+desc%2C+dct_title_sort+asc'
-    last_doc = find_all(".document").last
+    last_doc = find_all('.document').last
 
     # Doc without gbl_indexYear_im value
     expect(last_doc['data-document-id']).to eq('05d-03-nogeomtype')

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -17,4 +17,21 @@ feature 'Search' do
     click_link 'Browse all 4 records...'
     expect(page).to have_css '.document', count: 4
   end
+
+  scenario 'When sorting by year desc, highest value sorts first' do
+    visit '/?f%5Bschema_provider_s%5D%5B%5D=University+of+Minnesota&sort=gbl_indexYear_im+desc%2C+dct_title_sort+asc'
+
+    first_doc = find(".document", match: :first)
+
+    # Doc with gbl_indexYear_im value: [2014, 2030]
+    expect(first_doc['data-document-id']).to eq('02236876-9c21-42f6-9870-d2562da8e44f')
+  end
+
+  scenario 'When sorting by year, missing values sort last' do
+    visit '/?f%5Bschema_provider_s%5D%5B%5D=University+of+Minnesota&sort=gbl_indexYear_im+desc%2C+dct_title_sort+asc'
+    last_doc = find_all(".document").last
+
+    # Doc without gbl_indexYear_im value
+    expect(last_doc['data-document-id']).to eq('05d-03-nogeomtype')
+  end
 end

--- a/spec/fixtures/solr_documents/umn_metro_result1.json
+++ b/spec/fixtures/solr_documents/umn_metro_result1.json
@@ -35,7 +35,8 @@
   ],
   "dct_issued_s": "2015-10-01",
   "gbl_indexYear_im": [
-    "2014"
+    "2014",
+    "2030"
   ],
   "gbl_dateRange_drsim": [
     "[2014 TO 2014]"


### PR DESCRIPTION
This PR adds a small fixture change and a couple specs to test that multivalued year sorting does indeed work. It also adds the `sortMissingLast=true` option to *_im dynamic fields in our Solr schema.xml file. Aardvark only has one *_im field: gbl_indexYear_im.

Closes #1045 