### PR TITLE
Always publish coverage data

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -59,6 +59,7 @@ jobs:
 
     - name: Upload coverage artifacts
       uses: actions/upload-artifact@v2
+      if: always()
       with:
         name: coverage
         path: coverage/


### PR DESCRIPTION
Otherwise, if the build fails because the coverage is too low, the coverage step is skipped and the artifacts aren't published.