### PR TITLE
Color contrast adjustments

### DIFF
--- a/lib/generators/geoblacklight/templates/assets/_customizations.scss
+++ b/lib/generators/geoblacklight/templates/assets/_customizations.scss
@@ -23,7 +23,7 @@ $yellow:  #ffc107 !default;
 $green:   #198754 !default;
 $teal:    #20c997 !default;
 $cyan:    #0dcaf0 !default;
-$dark:    $black !default;
+$dark:    #212529 !default; // $gray-900
 
 // Example: Bootstrap Link color
 $link-color: $blue;

--- a/lib/generators/geoblacklight/templates/assets/_customizations.scss
+++ b/lib/generators/geoblacklight/templates/assets/_customizations.scss
@@ -13,16 +13,17 @@ $logo-image: image_url('blacklight/logo.svg') !default;
 // Override default Bootstrap variables here
 
 // Example: Bootstrap Colors
-$blue:    #007bff !default;
+$blue:    #0d6efd !default;
 $indigo:  #6610f2 !default;
 $purple:  #6f42c1 !default;
-$pink:    #e83e8c !default;
+$pink:    #d63384 !default;
 $red:     #dc3545 !default;
 $orange:  #fd7e14 !default;
 $yellow:  #ffc107 !default;
-$green:   #28a745 !default;
+$green:   #198754 !default;
 $teal:    #20c997 !default;
-$cyan:    #17a2b8 !default;
+$cyan:    #0dcaf0 !default;
+$dark:    $black !default;
 
 // Example: Bootstrap Link color
 $link-color: $blue;


### PR DESCRIPTION
**Color contrast adjustments**
* * *

**Issue**: 
* #1137 


# What does this Pull Request do?
Updated :root color variables to match Bootstrap 5 colors, which has bumped their color contrast ratio from 3:1 to 4.5:1 and updated blue, green, cyan, and pink colors to ensure WCAG 2.1 AA contrast.

# How should this be tested?
Test case (though any page is fine to test with): http://localhost:3000/catalog/stanford-cg357zz0321
* Using inspect you can scroll to the bottom of the styles to find the :root variables. The updated colors are as follows
```
:root {
    --blue: #0d6efd;
    --pink: #d63384;
    --green: #198754;
    --cyan: #0dcaf0;
    --dark: #212529;
}
```

## Screenshots of pages using WAVE tool
### Before
![Screenshot 2022-02-23 at 14-01-04 10 Meter Contours Russian River Basin, California - GeoBlacklight](https://user-images.githubusercontent.com/13121501/155395576-2069e3d3-0996-49a5-b76c-7d5bf057f77a.png)

### After 
Note: the one remaining contrast error has to do with the linked logo because it thinks it is a blue link on gray background. Also, text that is part of a logo or brand name has no contrast requirement, so it can be ignored.
![Screenshot 2022-02-23 at 14-08-06 10 Meter Contours Russian River Basin, California - GeoBlacklight](https://user-images.githubusercontent.com/13121501/155395589-fef7aa74-8ac2-4d58-bbd2-e9e51e4e590f.png)

