### PR TITLE
Update item view fields on catalog_controller.rb

### DIFF
--- a/lib/generators/geoblacklight/templates/catalog_controller.rb
+++ b/lib/generators/geoblacklight/templates/catalog_controller.rb
@@ -148,13 +148,28 @@ class CatalogController < ApplicationController
     # helper_method: [Symbol] method that can be used to render the value
 
     # DEFAULT FIELDS
-    config.add_show_field Settings.FIELDS.CREATOR, label: 'Creator(s)', itemprop: 'creator'
+    # The following fields all feature string values. If there is a value present in the metadata, they fields will show up on the item show page.
+    # The labels and order can be customed. Comment out fields to hide them.
+    
+    config.add_show_field Settings.FIELDS.ALTERNATIVE_TITLE, label: 'Alternative Title', itemprop: 'alt_title'
     config.add_show_field Settings.FIELDS.DESCRIPTION, label: 'Description', itemprop: 'description', helper_method: :render_value_as_truncate_abstract
+    config.add_show_field Settings.FIELDS.CREATOR, label: 'Creator', itemprop: 'creator'
     config.add_show_field Settings.FIELDS.PUBLISHER, label: 'Publisher', itemprop: 'publisher'
-    config.add_show_field Settings.FIELDS.SPATIAL_COVERAGE, label: 'Place(s)', itemprop: 'spatial', link_to_facet: true
-    config.add_show_field Settings.FIELDS.SUBJECT, label: 'Subject(s)', itemprop: 'keywords', link_to_facet: true
-    config.add_show_field Settings.FIELDS.TEMPORAL_COVERAGE, label: 'Year', itemprop: 'temporal'
     config.add_show_field Settings.FIELDS.PROVIDER, label: 'Provider', link_to_facet: true
+	config.add_show_field Settings.FIELDS.RESOURCE_CLASS, label: 'Resource Class', itemprop: 'class'
+    config.add_show_field Settings.FIELDS.RESOURCE_TYPE, label: 'Resource Type', itemprop: 'type'
+    config.add_show_field Settings.FIELDS.SUBJECT, label: 'Subject', itemprop: 'keywords', link_to_facet: true
+    config.add_show_field Settings.FIELDS.THEME, label: 'Theme', itemprop: 'theme'
+    config.add_show_field Settings.FIELDS.TEMPORAL_COVERAGE, label: 'Temporal Coverage', itemprop: 'temporal'
+    config.add_show_field Settings.FIELDS.DATE_ISSUED, label: 'Date Issued', itemprop: 'issued'
+    config.add_show_field Settings.FIELDS.SPATIAL_COVERAGE, label: 'Spatial Coverage', itemprop: 'spatial', link_to_facet: true
+    config.add_show_field Settings.FIELDS.RIGHTS, label: 'Rights', itemprop: 'rights'
+    config.add_show_field Settings.FIELDS.RIGHTS_HOLDER, label: 'Rights Holder', itemprop: 'rights_holder'
+    config.add_show_field Settings.FIELDS.LICENSE, label: 'License', itemprop: 'license'
+    config.add_show_field Settings.FIELDS.ACCESS_RIGHTS, label: 'Access Rights', itemprop: 'access_rights'
+    config.add_show_field Settings.FIELDS.FORMAT, label: 'Format', itemprop: 'format'
+    config.add_show_field Settings.FIELDS.FILE_SIZE, label: 'File Size', itemprop: 'file_size'
+    config.add_show_field Settings.FIELDS.GEOREFERENCED, label: 'Georeferenced', itemprop: 'georeferenced'    
     config.add_show_field(
       Settings.FIELDS.REFERENCES,
       label: 'More details at',
@@ -163,50 +178,35 @@ class CatalogController < ApplicationController
       helper_method: :render_references_url
     )
 
-    # OPTIONAL FIELDS
-    #optional fields to add to the item view display
-
-    # config.add_show_field Settings.FIELDS.ACCESS_RIGHTS, label: 'Access Rights', itemprop: 'access_rights'
-    # config.add_show_field Settings.FIELDS.ALTERNATIVE_TITLE, label: 'Alternative Title', itemprop: 'alt_title'
-    # config.add_show_field Settings.FIELDS.CENTROID, label: 'Centroid', itemprop: 'centroid'
-    # config.add_show_field Settings.FIELDS.CREATOR, label: 'Creator(s)', itemprop: 'creator'
-    # config.add_show_field Settings.FIELDS.DATE_ISSUED, label: 'Date Issued', itemprop: 'issued'
+    # ADDITIONAL FIELDS
+    # The following fields are not user friendly and are not set to appear on the item show page. They contain non-literal values, codes, URIs, or are otherwise designed to power features in the interface.
+    # These values might need a translations to be readable by users.
+    
+    # config.add_show_field Settings.FIELDS.LANGUAGE, label: 'Language', itemprop: 'language'
+    # config.add_show_field Settings.FIELDS.KEYWORD, label: 'Keyword(s)', itemprop: 'keyword'
+    
+    # config.add_show_field Settings.FIELDS.INDEX_YEAR, label: 'Year', itemprop: 'year'
     # config.add_show_field Settings.FIELDS.DATE_RANGE, label: 'Date Range', itemprop: 'date_range'
-    # config.add_show_field Settings.FIELDS.DESCRIPTION, label: 'Description', itemprop: 'description', helper_method: :render_value_as_truncate_abstract
-    # config.add_show_field Settings.FIELDS.FORMAT, label: 'Format', itemprop: 'format'
-    # config.add_show_field Settings.FIELDS.FILE_SIZE, label: 'File Size', itemprop: 'file_size'
-    # config.add_show_field Settings.FIELDS.GEOREFERENCED, label: 'Georeferenced', itemprop: 'georeferenced'
+    
+    # config.add_show_field Settings.FIELDS.CENTROID, label: 'Centroid', itemprop: 'centroid'
+    # config.add_show_field Settings.FIELDS.OVERLAP_FIELD, label: 'Overlap BBox', itemprop: 'overlap_field'
+    
+    # config.add_show_field Settings.FIELDS.RELATION, label: 'Relation', itemprop: 'relation'
+    # config.add_show_field Settings.FIELDS.MEMBER_OF, label: 'Member Of', itemprop: 'member_of'
+    # config.add_show_field Settings.FIELDS.IS_PART_OF, label: 'Is Part Of', itemprop: 'is_part_of'
+    # config.add_show_field Settings.FIELDS.VERSION, label: 'Version', itemprop: 'version'
+    # config.add_show_field Settings.FIELDS.REPLACES, label: 'Replaces', itemprop: 'replaces'
+    # config.add_show_field Settings.FIELDS.IS_REPLACED_BY, label: 'Is Replaced By', itemprop: 'is_replaced_by'
+    
+    # config.add_show_field Settings.FIELDS.WXS_IDENTIFIER, label: 'Web Service Layer', itemprop: 'wxs_identifier'
     # config.add_show_field Settings.FIELDS.ID, label: 'ID', itemprop: 'id'
     # config.add_show_field Settings.FIELDS.IDENTIFIER, label: 'Identifier', itemprop: 'identifier'
-    # config.add_show_field Settings.FIELDS.INDEX_YEAR, label: 'Year', itemprop: 'year'
-    # config.add_show_field Settings.FIELDS.IS_PART_OF, label: 'Is Part Of', itemprop: 'is_part_of'
-    # config.add_show_field Settings.FIELDS.IS_REPLACED_BY, label: 'Is Replaced By', itemprop: 'is_replaced_by'
-    # config.add_show_field Settings.FIELDS.THEME, label: 'Theme', itemprop: 'theme'
-    # config.add_show_field Settings.FIELDS.KEYWORD, label: 'Keyword(s)', itemprop: 'keyword'
-    # config.add_show_field Settings.FIELDS.LANGUAGE, label: 'Language', itemprop: 'language'
-    # config.add_show_field Settings.FIELDS.LICENSE, label: 'License', itemprop: 'license'
-    # config.add_show_field Settings.FIELDS.MEMBER_OF, label: 'Member Of', itemprop: 'member_of'
-    # config.add_show_field Settings.FIELDS.METADATA_VERSION, label: 'Metadata Version', itemprop: 'metadata_version'
-    # config.add_show_field Settings.FIELDS.MODIFIED, label: 'Date Modified', itemprop: 'modified'
-    # config.add_show_field Settings.FIELDS.OVERLAP_FIELD, label: 'Overlap BBox', itemprop: 'overlap_field'
-    # config.add_show_field Settings.FIELDS.PUBLISHER, label: 'Publisher', itemprop: 'publisher'
-    # config.add_show_field Settings.FIELDS.PROVIDER, label: 'Provider', itemprop: 'provider'
-    # config.add_show_field Settings.FIELDS.REFERENCES, label: 'References', itemprop: 'references'
-    # config.add_show_field Settings.FIELDS.RELATION, label: 'Relation', itemprop: 'relation'
-    # config.add_show_field Settings.FIELDS.REPLACES, label: 'Replaces', itemprop: 'replaces'
-    # config.add_show_field Settings.FIELDS.RESOURCE_CLASS, label: 'Resource Class', itemprop: 'class'
-    # config.add_show_field Settings.FIELDS.RESOURCE_TYPE, label: 'Resource Type', itemprop: 'type'
-    # config.add_show_field Settings.FIELDS.RIGHTS, label: 'Rights', itemprop: 'rights'
-    # config.add_show_field Settings.FIELDS.RIGHTS_HOLDER, label: 'Rights Holder', itemprop: 'rights_holder'
-    # config.add_show_field Settings.FIELDS.SPATIAL_COVERAGE, label: 'Place(s)', itemprop: 'spatial_coverage'
-    # config.add_show_field Settings.FIELDS.GEOMETRY, label: 'Spatial Extent', itemprop: 'geometry'
-    # config.add_show_field Settings.FIELDS.SUBJECT, label: 'Subject', itemprop: 'subject'
-    # config.add_show_field Settings.FIELDS.SUPPRESSED, label: 'Suppressed', itemprop: 'suppresed'
-    # config.add_show_field Settings.FIELDS.TEMPORAL_COVERAGE, label: 'Temporal Coverage', itemprop: 'temporal'
-    # config.add_show_field Settings.FIELDS.TITLE, label: 'Title', itemprop: 'title'
-    # config.add_show_field Settings.FIELDS.VERSION, label: 'Version', itemprop: 'version'
-    # config.add_show_field Settings.FIELDS.WXS_IDENTIFIER, label: 'Web Service Layer', itemprop: 'wxs_identifier'
 
+    # config.add_show_field Settings.FIELDS.MODIFIED, label: 'Date Modified', itemprop: 'modified'
+    # config.add_show_field Settings.FIELDS.METADATA_VERSION, label: 'Metadata Version', itemprop: 'metadata_version'
+    # config.add_show_field Settings.FIELDS.SUPPRESSED, label: 'Suppressed', itemprop: 'suppresed'
+    
+    
     # "fielded" search configuration. Used by pulldown among other places.
     # For supported keys in hash, see rdoc for Blacklight::SearchFields
     #

--- a/spec/features/show_page_metadata_spec.rb
+++ b/spec/features/show_page_metadata_spec.rb
@@ -5,8 +5,8 @@ feature 'Metadata display on show page' do
   scenario 'with default CatalogController specified fields' do
     visit solr_document_path 'stanford-dp018hs9766'
     within '.document-metadata' do
-      expect(page).to have_css 'dt', count: 8
-      expect(page).to have_css 'dd', count: 8
+      expect(page).to have_css 'dt', count: 16
+      expect(page).to have_css 'dd', count: 16
       expect(page).to have_css 'div.truncate-abstract', count: 1
     end
   end


### PR DESCRIPTION
This branch:

1. Cleans up the ITEM VIEW FIELDS. There were some duplicated lines in the commented-out code.
2. Turns on all of the descriptive/ string value fields by default
3. Re-orders the fields to match the Aardvark schema order.

Addresses #1052 In the previous version, we had been more conservative about only showing a few fields. However, I think it is better to display them all by default. This allows adopters to evaluate the fields and the examples shown in the fixtures. It would be easier for adopters to see extraneous fields and hide them rather than not know they existed.
