### PR TITLE
Move web services link out of show tools to a button

### DIFF
--- a/app/assets/stylesheets/geoblacklight/modules/downloads.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/downloads.scss
@@ -1,4 +1,4 @@
-// Styling for Download dropdown button
+// Styling for Download and Web services buttons
 .sidebar-btn {
   width: 100%;
 
@@ -7,7 +7,8 @@
   }
 }
 
-.downloads-sidebar {
+/* match bottom margin on tools card */
+.downloads-sidebar, .web-services-sidebar {
   margin-bottom: 20px;
 }
 

--- a/app/assets/stylesheets/geoblacklight/modules/downloads.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/downloads.scss
@@ -8,8 +8,12 @@
 }
 
 /* match bottom margin on tools card */
-.downloads-sidebar, .web-services-sidebar {
+.sidebar-buttons {
   margin-bottom: 20px;
+}
+
+.sidebar-buttons div + div {
+  margin-top: 10px;
 }
 
 // Styling for the Authentication card

--- a/app/assets/stylesheets/geoblacklight/modules/modal.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/modal.scss
@@ -12,3 +12,9 @@
   }
 
 }
+
+// Add some separation between web services entries
+.web-services-modal-body > div + div {
+  border-top: 1px solid #dee2e6;
+  padding-top: 1rem;
+}

--- a/app/views/catalog/_show_sidebar.html.erb
+++ b/app/views/catalog/_show_sidebar.html.erb
@@ -1,5 +1,7 @@
 <%= render :partial => 'show_tools' %>
 
+<%= render :partial => "show_web_services" %>
+
 <%= render :partial => "show_downloads" %>
 
 <% unless @document.more_like_this.empty? %>

--- a/app/views/catalog/_show_sidebar.html.erb
+++ b/app/views/catalog/_show_sidebar.html.erb
@@ -1,8 +1,9 @@
 <%= render :partial => 'show_tools' %>
 
+<div class="sidebar-buttons">
 <%= render :partial => "show_web_services" %>
-
 <%= render :partial => "show_downloads" %>
+</div>
 
 <% unless @document.more_like_this.empty? %>
   <div class="card">

--- a/app/views/catalog/_show_web_services.html.erb
+++ b/app/views/catalog/_show_web_services.html.erb
@@ -1,0 +1,11 @@
+<% document ||= @document %>
+
+<% if (Settings.WEBSERVICES_SHOWN & document.references.refs.map(&:type).map(&:to_s)).any? %>
+  <div class="web-services-sidebar">
+    <%= link_to "Web services",
+      web_services_solr_document_path(id: document.id),
+      class: ['btn', 'btn-primary', 'sidebar-btn'],
+      id: "web-services-button",
+      data: {blacklight_modal: "trigger"} %>
+  </div>
+<% end %>

--- a/app/views/catalog/_web_services.html.erb
+++ b/app/views/catalog/_web_services.html.erb
@@ -2,7 +2,8 @@
 
 <% document.references.refs.each do |reference| %>
   <% if Settings.WEBSERVICES_SHOWN.include? reference.type.to_s %>
-    <%= render_web_services(reference) %>
-    <hr>
+    <div class="web-services-modal-entry">
+      <%= render_web_services(reference) %>
+    </div>
   <% end %>
 <% end %>

--- a/app/views/catalog/web_services.html.erb
+++ b/app/views/catalog/web_services.html.erb
@@ -4,7 +4,7 @@
     <span aria-hidden="true">&times;</span>
   </button>
 </div>
-<div class="modal-body">
+<div class="modal-body web-services-modal-body">
   <%= render partial: 'web_services' %>
 </div>
 <div class="modal-footer">

--- a/lib/generators/geoblacklight/templates/catalog_controller.rb
+++ b/lib/generators/geoblacklight/templates/catalog_controller.rb
@@ -302,7 +302,6 @@ class CatalogController < ApplicationController
     config.add_show_tools_partial(:sms, if: :render_sms_action?, callback: :sms_action, validator: :validate_sms_params)
 
     # Custom tools for GeoBlacklight
-    config.add_show_tools_partial :web_services, if: proc { |_context, _config, options| options[:document] && (Settings.WEBSERVICES_SHOWN & options[:document].references.refs.map(&:type).map(&:to_s)).any? }
     config.add_show_tools_partial :metadata, if: proc { |_context, _config, options| options[:document] && (Settings.METADATA_SHOWN & options[:document].references.refs.map(&:type).map(&:to_s)).any? }
     config.add_show_tools_partial :carto, partial: 'carto', if: proc { |_context, _config, options| options[:document] && options[:document].carto_reference.present? }
     config.add_show_tools_partial :arcgis, partial: 'arcgis', if: proc { |_context, _config, options| options[:document] && options[:document].arcgis_urls.present? }
@@ -328,6 +327,14 @@ class CatalogController < ApplicationController
     config.autocomplete_path = 'suggest'
   end
 
+  def web_services
+    @response, @documents = action_documents
 
-
+    respond_to do |format|
+      format.html do
+        return render layout: false if request.xhr?
+        # Otherwise draw the full page
+      end
+    end
+  end
 end

--- a/spec/features/web_services_modal_spec.rb
+++ b/spec/features/web_services_modal_spec.rb
@@ -5,7 +5,7 @@ feature 'web services tools' do
   feature 'when wms/wfs are provided', js: true do
     scenario 'shows up in tools' do
       visit solr_document_path 'stanford-cg357zz0321'
-      expect(page).to have_css 'li.web_services a', text: 'Web services'
+      expect(page).to have_css 'div.web-services-sidebar a', text: 'Web services'
       click_link 'Web services'
       within '.modal-body' do
         expect(page).to have_css 'input', count: 4
@@ -20,13 +20,13 @@ feature 'web services tools' do
   feature 'no wms or wfs provided' do
     scenario 'does not show up in tools' do
       visit solr_document_path 'mit-001145244'
-      expect(page).not_to have_css 'li.web_services a', text: 'Web services'
+      expect(page).not_to have_css 'div.web-services-sidebar a', text: 'Web services'
     end
   end
   feature 'when xyz tile reference is provided', js: true do
     scenario 'shows up in tools' do
       visit solr_document_path '6f47b103-9955-4bbe-a364-387039623106-xyz'
-      expect(page).to have_css 'li.web_services a', text: 'Web services'
+      expect(page).to have_css 'div.web-services-sidebar a', text: 'Web services'
       click_link 'Web services'
       within '.modal-body' do
         expect(page).to have_css 'label', text: 'XYZ Tiles'
@@ -37,7 +37,7 @@ feature 'web services tools' do
   feature 'when wmts tile reference is provided', js: true do
     scenario 'shows up in tools' do
       visit solr_document_path 'princeton-fk4544658v-wmts'
-      expect(page).to have_css 'li.web_services a', text: 'Web services'
+      expect(page).to have_css 'div.web-services-sidebar a', text: 'Web services'
       click_link 'Web services'
       within '.modal-body' do
         expect(page).to have_css 'label', text: 'Web Map Tile Service'
@@ -48,7 +48,7 @@ feature 'web services tools' do
   feature 'when tilejson reference is provided', js: true do
     scenario 'shows up in tools' do
       visit solr_document_path 'princeton-fk4544658v-tilejson'
-      expect(page).to have_css 'li.web_services a', text: 'Web services'
+      expect(page).to have_css 'div.web-services-sidebar a', text: 'Web services'
       click_link 'Web services'
       within '.modal-body' do
         expect(page).to have_css 'label', text: 'TileJSON Document'


### PR DESCRIPTION
Moves the web services link to give it visual symmetry with the download button, since they serve similar use cases (namely, using the data).

It also updates the web services modal to remove a trailing line separator.

### Upgrade notes
If you take no action (on an unmodified geoblacklight instance) you will have both web services links. To remove the link from the tool versions and keep the new button working:
* In your app's catalog controller
   * Remove the line beginning `config.add_show_tools_partial :web_services`
   * Add a small controller action to keep the web services modal working. This code was previously generated as part of blacklight's `add_show_tools_partial` functionality. The method you need can be copied from the updated catalog controller template and is called `web_services`.

### Screenshots

#### Button
![Screen Shot 2022-02-25 at 9 56 51 AM](https://user-images.githubusercontent.com/845363/155737055-6eaa52dd-a69f-4aef-bcbf-bb08b3017ae0.png)
![Screen Shot 2022-02-25 at 9 57 06 AM](https://user-images.githubusercontent.com/845363/155737061-6ac284f1-e7fc-46ac-8940-23c888183bc2.png)


#### Modal before

![Screen Shot 2022-02-25 at 9 29 02 AM](https://user-images.githubusercontent.com/845363/155732186-93be09b7-7e1f-4df1-beae-826e3106798c.png)

#### Modal after

![Screen Shot 2022-02-25 at 9 28 00 AM](https://user-images.githubusercontent.com/845363/155732061-8766147b-518a-43d9-ba99-1131b9998d28.png)