### PR TITLE
Adjust GitHub actions matrix build

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -24,93 +24,49 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [2.7, '3.0']
-        faraday_version: ['']
+        ruby_version: [2.7, '3.0']
+        rails_version: [7.0.1]
+        bundler_version: [2.1.1]
+        faraday_version: ['>= 2', '~> 1.0']
         include:
-          - ruby: 2.7
+          - ruby_version: 2.6
+            rails_version: 6.1.4.4
+            bundler_version: 2.1.1
             faraday_version: '~> 1.0'
+    name: test ruby ${{ matrix.ruby_version }} / rails ${{ matrix.rails_version }} / faraday ${{ matrix.faraday_version }}
     steps:
     - uses: actions/checkout@v2
-
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: ${{ matrix.ruby }}
-
+        ruby-version: ${{ matrix.ruby_version }}
     - name: Create Solr container
       run: docker run -d -p 8983:8983 geoblacklight/solr:8.9-v1.0.0 server/scripts/ci-start.sh
-
     - name: Install bundler
-      run: gem install bundler -v 2.1.1
-
+      run: gem install bundler -v ${{ matrix.bundler_version }}
     - name: Install dependencies
-      run: bundle _2.1.1_ install
+      run: bundle _${{ matrix.bundler_version }}_ install
       env:
-        rails_version: 7.0.1
+        RAILS_VERSION: ${{ matrix.rails_version }}
         FARADAY_VERSION: ${{ matrix.faraday_version }}
-
     - name: Setup Yarn
       run: exec "yarnpkg"
-
     - name: Load config into solr
       run: |
           cd solr/conf
           zip -1 -r solr_config.zip ./*
           curl -H "Content-type:application/octet-stream" --data-binary @solr_config.zip "http://solr:SolrRocks@127.0.0.1:8983/solr/admin/configs?action=UPLOAD&name=blacklight"
           curl -H 'Content-type: application/json' http://solr:SolrRocks@127.0.0.1:8983/api/collections/  -d '{create: {name: blacklight-core, config: blacklight, numShards: 1}}'
-
     - name: Run tests
       run: bundle exec rake ci
       env:
-        rails_version: 7.0.1
+        RAILS_VERSION: ${{ matrix.rails_version }}
+        FARADAY_VERSION: ${{ matrix.faraday_version }}
         ENGINE_CART_RAILS_OPTIONS: '--skip-git --skip-listen --skip-spring --skip-keeps --skip-action-cable --skip-coffee --skip-test'
         SOLR_URL: http://solr:SolrRocks@localhost:8983/solr/blacklight-core
-        FARADAY_VERSION: ${{ matrix.faraday_version }}
-
     - name: Upload coverage artifacts
       uses: actions/upload-artifact@v2
       if: always()
       with:
         name: coverage
         path: coverage/
-
-  test_rails6_1:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        ruby: [2.6]
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ matrix.ruby }}
-
-    - name: Create Solr container
-      run: docker run -d -p 8983:8983 geoblacklight/solr:8.9-v1.0.0 server/scripts/ci-start.sh
-
-    - name: Install bundler
-      run: gem install bundler -v 2.1.1
-
-    - name: Install dependencies
-      run: bundle _2.1.1_ install
-      env:
-        RAILS_VERSION: 6.1.4.4
-
-    - name: Setup Yarn
-      run: exec "yarnpkg"
-
-    - name: Load config into solr
-      run: |
-          cd solr/conf
-          zip -1 -r solr_config.zip ./*
-          curl -H "Content-type:application/octet-stream" --data-binary @solr_config.zip "http://solr:SolrRocks@127.0.0.1:8983/solr/admin/configs?action=UPLOAD&name=blacklight"
-          curl -H 'Content-type: application/json' http://solr:SolrRocks@127.0.0.1:8983/api/collections/  -d '{create: {name: blacklight-core, config: blacklight, numShards: 1}}'
-
-    - name: Run tests
-      run: bundle exec rake ci
-      env:
-        RAILS_VERSION: 6.1.4.4
-        ENGINE_CART_RAILS_OPTIONS: '--skip-git --skip-listen --skip-spring --skip-keeps --skip-action-cable --skip-coffee --skip-test'
-        SOLR_URL: http://solr:SolrRocks@localhost:8983/solr/blacklight-core

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -24,13 +24,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby_version: [2.7, '3.0']
-        rails_version: [7.0.1]
+        ruby_version: ['3.0', 2.7]
+        rails_version: [6.1]
         bundler_version: [2.1.1]
         faraday_version: ['>= 2', '~> 1.0']
         include:
           - ruby_version: 2.6
-            rails_version: 6.1.4.4
+            rails_version: 6.1
             bundler_version: 2.1.1
             faraday_version: '~> 1.0'
     name: test ruby ${{ matrix.ruby_version }} / rails ${{ matrix.rails_version }} / faraday ${{ matrix.faraday_version }}

--- a/geoblacklight.gemspec
+++ b/geoblacklight.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_rubygems_version = '>= 2.5.2'
 
-  spec.add_dependency 'rails', '>= 5.2.4', '< 6.2'
+  spec.add_dependency 'rails', '>= 6.1', '< 7'
   spec.add_dependency 'blacklight', '~> 7.12'
   spec.add_dependency 'config'
   spec.add_dependency 'faraday', '>= 1.0'


### PR DESCRIPTION
* Collapse extra rails 6 job into include
* Specify bundler version in matrix
* Include matrix versions in job names
* Change rails versions in gemspec to match tested versions

See #1177

I'm a little unfamiliar with bundler dependency syntax, but I think this more accurately captures what we want to test/say we support.

- We allowed Rails 5 in the gemspec, but didn't test it. Testing it failed, so I don't think we should support it.
- There was some stuff related to testing Rails 7, but our required version of Blacklight doesn't support it, so we can't support it. I think it wasn't actually getting used because the environment variable wasn't named correctly (?)
