### PR TITLE
Bug fix: allow all Aardvark relationship fields to browse suppressed records

### DIFF
--- a/app/models/concerns/geoblacklight/suppressed_records_search_behavior.rb
+++ b/app/models/concerns/geoblacklight/suppressed_records_search_behavior.rb
@@ -12,8 +12,13 @@ module Geoblacklight
     # @param [Blacklight::Solr::Request]
     # @return [Blacklight::Solr::Request]
     def hide_suppressed_records(solr_params)
-      # Show child records if searching for a specific source parent
-      return unless blacklight_params.fetch(:f, {})[Settings.FIELDS.SOURCE.to_sym].nil?
+      # Show suppressed records when searching relationships
+      return if blacklight_params.fetch(:f,
+                                        {}).keys.any? do |field|
+                  Settings.RELATIONSHIPS_SHOWN.map do |_key, value|
+                    value.field
+                  end.include?(field)
+                end
 
       # Do not suppress action_documents method calls for individual documents
       # ex. CatalogController#web_services (exportable views)

--- a/config/locales/geoblacklight.en.yml
+++ b/config/locales/geoblacklight.en.yml
@@ -73,6 +73,7 @@ en:
       descendant: 'Derived Datasets'
       member_of: 'Belongs to collection...'
       part_of: 'Is part of...'
+      part_of_descendants: 'Has part...'
       relation: 'Related Records'
       replaces: 'Item replaces...'
       replaced_by: 'Item replaced by...'

--- a/lib/generators/geoblacklight/templates/catalog_controller.rb
+++ b/lib/generators/geoblacklight/templates/catalog_controller.rb
@@ -109,7 +109,6 @@ class CatalogController < ApplicationController
     config.add_facet_field Settings.FIELDS.PUBLISHER, :label => 'Publisher', :limit => 8
     config.add_facet_field Settings.FIELDS.PROVIDER, label: 'Provider', limit: 8, item_component: Geoblacklight::IconFacetItemComponent
     config.add_facet_field Settings.FIELDS.GEOREFERENCED, :label => 'Georeferenced', :limit => 3
-    config.add_facet_field Settings.FIELDS.SOURCE, :label => 'Collection', :limit => 8, :show => false
 
     # GEOBLACKLIGHT APPLICATION FACETS
 
@@ -119,6 +118,18 @@ class CatalogController < ApplicationController
     # filter_class         - Defines how to add/remove facet from query
     # label                - Defines the label used in contstraints container
     config.add_facet_field Settings.FIELDS.GEOMETRY, item_presenter: Geoblacklight::BboxItemPresenter, filter_class: Geoblacklight::BboxFilterField, filter_query_builder: Geoblacklight::BboxFilterQuery, within_boost: Settings.BBOX_WITHIN_BOOST, overlap_boost: Settings.OVERLAP_RATIO_BOOST, overlap_field: Settings.FIELDS.OVERLAP_FIELD, label: 'Bounding Box'
+
+    # Item Relationship Facets
+    # * Not displayed to end user (show: false)
+    # * Must be present for relationship "Browse all 4 records" links to work
+    # * Label value becomes the search contraint filter name
+    config.add_facet_field Settings.FIELDS.MEMBER_OF, label: 'Member Of', show: false
+    config.add_facet_field Settings.FIELDS.IS_PART_OF, label: 'Is Part Of', show: false
+    config.add_facet_field Settings.FIELDS.RELATION, label: 'Related', show: false
+    config.add_facet_field Settings.FIELDS.REPLACES, label: 'Replaces', show: false
+    config.add_facet_field Settings.FIELDS.IS_REPLACED_BY, label: 'Is Replaced By', show: false
+    config.add_facet_field Settings.FIELDS.SOURCE, label: 'Source', show: false
+    config.add_facet_field Settings.FIELDS.VERSION, label: 'Is Version Of', show: false
 
     # Have BL send all facet field names to Solr, which has been the default
     # previously. Simply remove these lines if you'd rather use Solr request
@@ -150,7 +161,7 @@ class CatalogController < ApplicationController
     # DEFAULT FIELDS
     # The following fields all feature string values. If there is a value present in the metadata, they fields will show up on the item show page.
     # The labels and order can be customed. Comment out fields to hide them.
-    
+
     config.add_show_field Settings.FIELDS.ALTERNATIVE_TITLE, label: 'Alternative Title', itemprop: 'alt_title'
     config.add_show_field Settings.FIELDS.DESCRIPTION, label: 'Description', itemprop: 'description', helper_method: :render_value_as_truncate_abstract
     config.add_show_field Settings.FIELDS.CREATOR, label: 'Creator', itemprop: 'creator'
@@ -169,7 +180,7 @@ class CatalogController < ApplicationController
     config.add_show_field Settings.FIELDS.ACCESS_RIGHTS, label: 'Access Rights', itemprop: 'access_rights'
     config.add_show_field Settings.FIELDS.FORMAT, label: 'Format', itemprop: 'format'
     config.add_show_field Settings.FIELDS.FILE_SIZE, label: 'File Size', itemprop: 'file_size'
-    config.add_show_field Settings.FIELDS.GEOREFERENCED, label: 'Georeferenced', itemprop: 'georeferenced'    
+    config.add_show_field Settings.FIELDS.GEOREFERENCED, label: 'Georeferenced', itemprop: 'georeferenced'
     config.add_show_field(
       Settings.FIELDS.REFERENCES,
       label: 'More details at',
@@ -181,23 +192,23 @@ class CatalogController < ApplicationController
     # ADDITIONAL FIELDS
     # The following fields are not user friendly and are not set to appear on the item show page. They contain non-literal values, codes, URIs, or are otherwise designed to power features in the interface.
     # These values might need a translations to be readable by users.
-    
+
     # config.add_show_field Settings.FIELDS.LANGUAGE, label: 'Language', itemprop: 'language'
     # config.add_show_field Settings.FIELDS.KEYWORD, label: 'Keyword(s)', itemprop: 'keyword'
-    
+
     # config.add_show_field Settings.FIELDS.INDEX_YEAR, label: 'Year', itemprop: 'year'
     # config.add_show_field Settings.FIELDS.DATE_RANGE, label: 'Date Range', itemprop: 'date_range'
-    
+
     # config.add_show_field Settings.FIELDS.CENTROID, label: 'Centroid', itemprop: 'centroid'
     # config.add_show_field Settings.FIELDS.OVERLAP_FIELD, label: 'Overlap BBox', itemprop: 'overlap_field'
-    
+
     # config.add_show_field Settings.FIELDS.RELATION, label: 'Relation', itemprop: 'relation'
     # config.add_show_field Settings.FIELDS.MEMBER_OF, label: 'Member Of', itemprop: 'member_of'
     # config.add_show_field Settings.FIELDS.IS_PART_OF, label: 'Is Part Of', itemprop: 'is_part_of'
     # config.add_show_field Settings.FIELDS.VERSION, label: 'Version', itemprop: 'version'
     # config.add_show_field Settings.FIELDS.REPLACES, label: 'Replaces', itemprop: 'replaces'
     # config.add_show_field Settings.FIELDS.IS_REPLACED_BY, label: 'Is Replaced By', itemprop: 'is_replaced_by'
-    
+
     # config.add_show_field Settings.FIELDS.WXS_IDENTIFIER, label: 'Web Service Layer', itemprop: 'wxs_identifier'
     # config.add_show_field Settings.FIELDS.ID, label: 'ID', itemprop: 'id'
     # config.add_show_field Settings.FIELDS.IDENTIFIER, label: 'Identifier', itemprop: 'identifier'
@@ -205,8 +216,8 @@ class CatalogController < ApplicationController
     # config.add_show_field Settings.FIELDS.MODIFIED, label: 'Date Modified', itemprop: 'modified'
     # config.add_show_field Settings.FIELDS.METADATA_VERSION, label: 'Metadata Version', itemprop: 'metadata_version'
     # config.add_show_field Settings.FIELDS.SUPPRESSED, label: 'Suppressed', itemprop: 'suppresed'
-    
-    
+
+
     # "fielded" search configuration. Used by pulldown among other places.
     # For supported keys in hash, see rdoc for Blacklight::SearchFields
     #

--- a/lib/generators/geoblacklight/templates/settings.yml
+++ b/lib/generators/geoblacklight/templates/settings.yml
@@ -107,11 +107,16 @@ RELATIONSHIPS_SHOWN:
     query_type: ancestors
     icon: nil
     label: geoblacklight.relations.member_of
-  PART_OF:
+  PART_OF_ANCESTORS:
     field: dct_isPartOf_sm
     query_type: ancestors
     icon: nil
-    label: geoblacklight.relations.part_of
+    label: geoblacklight.relations.part_of_ancestors
+  PART_OF_DESCENDANTS:
+    field: dct_isPartOf_sm
+    query_type: descendants
+    icon: child-item
+    label: geoblacklight.relations.part_of_descendants
   RELATION:
     field: dct_relation_sm
     query_type: ancestors

--- a/spec/features/relations_spec.rb
+++ b/spec/features/relations_spec.rb
@@ -30,4 +30,15 @@ feature 'Display related documents' do
     visit solr_document_path('harvard-g7064-s2-1834-k3')
     expect(page).to have_no_css('.card.relations')
   end
+
+  scenario 'Relationship browse link returns relationship-scoped results', js: true do
+    # Wabash Topo parent record
+    visit solr_document_path('88cc9b19-3294-4da9-9edd-775c81fb1c59')
+
+    expect(page).to have_content('Has part...')
+    expect(page).to have_link('Browse all 4 records...')
+    click_link('Browse all 4 records...')
+
+    expect(page).not_to have_content('No results found for your search')
+  end
 end

--- a/spec/fixtures/solr_documents/b1g_wabash_child_15.json
+++ b/spec/fixtures/solr_documents/b1g_wabash_child_15.json
@@ -1,0 +1,62 @@
+{
+  "id": "b5857bb0-2819-49cf-a6da-fdb39d50c529",
+  "gbl_mdVersion_s": "Aardvark",
+  "dct_title_s": "Wabash Topo (15): Indiana, 1929",
+  "dct_description_sm": [
+    "The maps represented here are on tiff files owned by EAS library. The topos were scanned in color and are up to 550MB each. These images can be viewed and performed in the using either ArcGIS Desktop or QGIS (user choice), referencing against a number of known mapsets like the 2005 Indiana Orthophoto setand USGS DRGs. The geographic coordinate system reference of the maps included are applied in GCS_WGS_1984."
+  ],
+  "dct_language_sm": [
+    "eng"
+  ],
+  "dct_creator_sm": [
+    "Brock & Weymouth Inc.",
+    "United States Engineer Office"
+  ],
+  "dct_publisher_sm": [
+    "Purdue University Libraries"
+  ],
+  "gbl_resourceClass_sm": [
+    "Maps"
+  ],
+  "dcat_keyword_sm": [
+    "Topography",
+    "Purdue Georeferenced Imagery"
+  ],
+  "dcat_theme_sm": [
+    "Imagery and Base Maps"
+  ],
+  "dct_issued_s": "2015-10-31",
+  "dct_temporal_sm": [
+    "1929"
+  ],
+  "gbl_dateRange_drsim": [
+    "[1929 TO 1929]"
+  ],
+  "gbl_indexYear_im": [
+    1929
+  ],
+  "dct_spatial_sm": [
+    "Indiana"
+  ],
+  "locn_geometry": "ENVELOPE(-87.5071,-87.3597,39.539,39.4622)",
+  "dcat_bbox": "ENVELOPE(-87.5071,-87.3597,39.539,39.4622)",
+  "dcat_centroid": "39.500600000000006,-87.4334",
+  "pcdm_memberOf_sm": [
+    "09d-01"
+  ],
+  "gbl_resourceType_sm": [
+    "Topographic maps"
+  ],
+  "dct_format_s": "GeoTIFF",
+  "dct_references_s": "{\"http://schema.org/downloadUrl\":\"https://mapsweb.lib.purdue.edu/datasets/Wabash1929/wabash_topo_15.tif.zip\",\"urn:x-esri:serviceType:ArcGIS#ImageMapLayer\":\"https://mapsweb.lib.purdue.edu/arcgis/rest/services/Purdue/wabashtopo/ImageServer\",\"http://schema.org/url\":\"https://mapsweb.lib.purdue.edu/wabashriver/\"}",
+  "dct_identifier_sm": [
+    "b5857bb0-2819-49cf-a6da-fdb39d50c529"
+  ],
+  "schema_provider_s": "Purdue University",
+  "dct_isPartOf_sm": [
+    "88cc9b19-3294-4da9-9edd-775c81fb1c59"
+  ],
+  "dct_accessRights_s": "Public",
+  "gbl_suppressed_b": true,
+  "gbl_mdModified_dt": "2021-05-07T23:00:10Z"
+}

--- a/spec/fixtures/solr_documents/b1g_wabash_child_16.json
+++ b/spec/fixtures/solr_documents/b1g_wabash_child_16.json
@@ -1,0 +1,64 @@
+{
+  "id": "d8906fc8-92bb-4ced-bcd5-9ce9a4701c25",
+  "gbl_mdVersion_s": "Aardvark",
+  "dct_title_s": "Wabash Topo (16): Indiana, 1929",
+  "dct_description_sm": [
+    "The maps represented here are on tiff files owned by EAS library. The topos were scanned in color and are up to 550MB each. These images can be viewed and performed in the using either ArcGIS Desktop or QGIS (user choice), referencing against a number of known mapsets like the 2005 Indiana Orthophoto setand USGS DRGs. The geographic coordinate system reference of the maps included are applied in GCS_WGS_1984."
+  ],
+  "dct_language_sm": [
+    "eng"
+  ],
+  "dct_creator_sm": [
+    "Brock & Weymouth Inc.",
+    "United States Engineer Office"
+  ],
+  "dct_publisher_sm": [
+    "Purdue University Libraries"
+  ],
+  "gbl_resourceClass_sm": [
+    "Maps"
+  ],
+  "dcat_keyword_sm": [
+    "Topography",
+    "Purdue Georeferenced Imagery"
+  ],
+  "dcat_theme_sm": [
+    "Imagery and Base Maps"
+  ],
+  "dct_issued_s": "2015-10-31",
+  "dct_temporal_sm": [
+    "1929"
+  ],
+  "gbl_dateRange_drsim": [
+    "[1929 TO 1929]"
+  ],
+  "gbl_indexYear_im": [
+    1929
+  ],
+  "dct_spatial_sm": [
+    "Indiana",
+    "Tippecano County, Indiana",
+    "Wabash River, Indiana"
+  ],
+  "locn_geometry": "ENVELOPE(-87.4831,-87.336,39.606,39.5301)",
+  "dcat_bbox": "ENVELOPE(-87.4831,-87.336,39.606,39.5301)",
+  "dcat_centroid": "39.56805,-87.40955",
+  "pcdm_memberOf_sm": [
+    "09d-01"
+  ],
+  "gbl_resourceType_sm": [
+    "Topographic maps"
+  ],
+  "dct_format_s": "GeoTIFF",
+  "dct_references_s": "{\"http://schema.org/downloadUrl\":\"https://mapsweb.lib.purdue.edu/datasets/Wabash1929/wabash_topo_16.tif.zip\",\"urn:x-esri:serviceType:ArcGIS#ImageMapLayer\":\"https://mapsweb.lib.purdue.edu/arcgis/rest/services/Purdue/wabashtopo/ImageServer\",\"http://schema.org/url\":\"https://mapsweb.lib.purdue.edu/wabashriver/\"}",
+  "dct_identifier_sm": [
+    "d8906fc8-92bb-4ced-bcd5-9ce9a4701c25"
+  ],
+  "schema_provider_s": "Purdue University",
+  "dct_isPartOf_sm": [
+    "88cc9b19-3294-4da9-9edd-775c81fb1c59"
+  ],
+  "dct_accessRights_s": "Public",
+  "gbl_suppressed_b": true,
+  "gbl_mdModified_dt": "2021-05-07T23:00:10Z"
+}

--- a/spec/fixtures/solr_documents/b1g_wabash_child_17.json
+++ b/spec/fixtures/solr_documents/b1g_wabash_child_17.json
@@ -1,0 +1,62 @@
+{
+  "id": "55d9f193-9f29-4cbf-860d-23c1cff11691",
+  "gbl_mdVersion_s": "Aardvark",
+  "dct_title_s": "Wabash Topo (17): Indiana, 1929",
+  "dct_description_sm": [
+    "The maps represented here are on tiff files owned by EAS library. The topos were scanned in color and are up to 550MB each. These images can be viewed and performed in the using either ArcGIS Desktop or QGIS (user choice), referencing against a number of known mapsets like the 2005 Indiana Orthophoto setand USGS DRGs. The geographic coordinate system reference of the maps included are applied in GCS_WGS_1984."
+  ],
+  "dct_language_sm": [
+    "eng"
+  ],
+  "dct_creator_sm": [
+    "Brock & Weymouth Inc.",
+    "United States Engineer Office"
+  ],
+  "dct_publisher_sm": [
+    "Purdue University Libraries"
+  ],
+  "gbl_resourceClass_sm": [
+    "Maps"
+  ],
+  "dcat_keyword_sm": [
+    "Topography",
+    "Purdue Georeferenced Imagery"
+  ],
+  "dcat_theme_sm": [
+    "Imagery and Base Maps"
+  ],
+  "dct_issued_s": "2015-10-31",
+  "dct_temporal_sm": [
+    "1929"
+  ],
+  "gbl_dateRange_drsim": [
+    "[1929 TO 1929]"
+  ],
+  "gbl_indexYear_im": [
+    1929
+  ],
+  "dct_spatial_sm": [
+    "Indiana"
+  ],
+  "locn_geometry": "ENVELOPE(-87.4665,-87.3179,39.6748,39.5982)",
+  "dcat_bbox": "ENVELOPE(-87.4665,-87.3179,39.6748,39.5982)",
+  "dcat_centroid": "39.6365,-87.3922",
+  "pcdm_memberOf_sm": [
+    "09d-01"
+  ],
+  "gbl_resourceType_sm": [
+    "Topographic maps"
+  ],
+  "dct_format_s": "GeoTIFF",
+  "dct_references_s": "{\"http://schema.org/downloadUrl\":\"https://mapsweb.lib.purdue.edu/datasets/Wabash1929/wabash_topo_17.tif.zip\",\"urn:x-esri:serviceType:ArcGIS#ImageMapLayer\":\"https://mapsweb.lib.purdue.edu/arcgis/rest/services/Purdue/wabashtopo/ImageServer\",\"http://schema.org/url\":\"https://mapsweb.lib.purdue.edu/wabashriver/\"}",
+  "dct_identifier_sm": [
+    "55d9f193-9f29-4cbf-860d-23c1cff11691"
+  ],
+  "schema_provider_s": "Purdue University",
+  "dct_isPartOf_sm": [
+    "88cc9b19-3294-4da9-9edd-775c81fb1c59"
+  ],
+  "dct_accessRights_s": "Public",
+  "gbl_suppressed_b": true,
+  "gbl_mdModified_dt": "2021-05-07T23:00:10Z"
+}

--- a/spec/fixtures/solr_documents/b1g_wabash_child_18.json
+++ b/spec/fixtures/solr_documents/b1g_wabash_child_18.json
@@ -1,0 +1,62 @@
+{
+  "id": "b835efbd-ca27-41af-bae2-c22210e58a89",
+  "gbl_mdVersion_s": "Aardvark",
+  "dct_title_s": "Wabash Topo (18): Indiana, 1929",
+  "dct_description_sm": [
+    "The maps represented here are on tiff files owned by EAS library. The topos were scanned in color and are up to 550MB each. These images can be viewed and performed in the using either ArcGIS Desktop or QGIS (user choice), referencing against a number of known mapsets like the 2005 Indiana Orthophoto setand USGS DRGs. The geographic coordinate system reference of the maps included are applied in GCS_WGS_1984."
+  ],
+  "dct_language_sm": [
+    "eng"
+  ],
+  "dct_creator_sm": [
+    "Brock & Weymouth Inc.",
+    "United States Engineer Office"
+  ],
+  "dct_publisher_sm": [
+    "Purdue University Libraries"
+  ],
+  "gbl_resourceClass_sm": [
+    "Maps"
+  ],
+  "dcat_keyword_sm": [
+    "Topography",
+    "Purdue Georeferenced Imagery"
+  ],
+  "dcat_theme_sm": [
+    "Imagery and Base Maps"
+  ],
+  "dct_issued_s": "2015-10-30",
+  "dct_temporal_sm": [
+    "1929"
+  ],
+  "gbl_dateRange_drsim": [
+    "[1929 TO 1929]"
+  ],
+  "gbl_indexYear_im": [
+    1929
+  ],
+  "dct_spatial_sm": [
+    "Indiana"
+  ],
+  "locn_geometry": "ENVELOPE(-87.4407,-87.2936,39.7429,39.6653)",
+  "dcat_bbox": "ENVELOPE(-87.4407,-87.2936,39.7429,39.6653)",
+  "dcat_centroid": "39.7041,-87.36715000000001",
+  "pcdm_memberOf_sm": [
+    "09d-01"
+  ],
+  "gbl_resourceType_sm": [
+    "Topographic maps"
+  ],
+  "dct_format_s": "GeoTIFF",
+  "dct_references_s": "{\"http://schema.org/downloadUrl\":\"https://mapsweb.lib.purdue.edu/datasets/Wabash1929/wabash_topo_18.tif.zip\",\"urn:x-esri:serviceType:ArcGIS#ImageMapLayer\":\"https://mapsweb.lib.purdue.edu/arcgis/rest/services/Purdue/wabashtopo/ImageServer\",\"http://schema.org/url\":\"https://mapsweb.lib.purdue.edu/wabashriver/\"}",
+  "dct_identifier_sm": [
+    "b835efbd-ca27-41af-bae2-c22210e58a89"
+  ],
+  "schema_provider_s": "Purdue University",
+  "dct_isPartOf_sm": [
+    "88cc9b19-3294-4da9-9edd-775c81fb1c59"
+  ],
+  "dct_accessRights_s": "Public",
+  "gbl_suppressed_b": true,
+  "gbl_mdModified_dt": "2021-05-07T23:00:10Z"
+}

--- a/spec/fixtures/solr_documents/b1g_wabash_parent.json
+++ b/spec/fixtures/solr_documents/b1g_wabash_parent.json
@@ -1,0 +1,59 @@
+{
+  "id": "88cc9b19-3294-4da9-9edd-775c81fb1c59",
+  "gbl_mdVersion_s": "Aardvark",
+  "dct_title_s": "Wabash River Topographic Maps: Indiana, 1929",
+  "dct_description_sm": [
+    "See Related Records below to download individual GeoTIFFs. The maps represented here are tiff files owned by Purdue University's EAS library. The topos were scanned in color and are up to 550MB each. These images can be viewed and performed in the using either ArcGIS Desktop or QGIS (user choice), referencing against a number of known mapsets like the 2005 Indiana Orthophoto setand USGS DRGs. The geographic coordinate system reference of the maps included are applied in GCS_WGS_1984."
+  ],
+  "dct_language_sm": [
+    "eng"
+  ],
+  "dct_creator_sm": [
+    "Brock & Weymouth Inc.",
+    "United States Engineer Office"
+  ],
+  "dct_publisher_sm": [
+    "Purdue University Libraries"
+  ],
+  "gbl_resourceClass_sm": [
+    "Maps"
+  ],
+  "dcat_keyword_sm": [
+    "Topography",
+    "Purdue Georeferenced Imagery"
+  ],
+  "dcat_theme_sm": [
+    "Imagery and Base Maps"
+  ],
+  "dct_issued_s": "2015-10-17",
+  "dct_temporal_sm": [
+    "1929"
+  ],
+  "gbl_dateRange_drsim": [
+    "[1929 TO 1929]"
+  ],
+  "gbl_indexYear_im": [
+    1929
+  ],
+  "dct_spatial_sm": [
+    "Indiana"
+  ],
+  "locn_geometry": "ENVELOPE(-87.5291,-86.2066,40.8009,39.3999)",
+  "dcat_bbox": "ENVELOPE(-87.5291,-86.2066,40.8009,39.3999)",
+  "dcat_centroid": "40.1004,-86.86785",
+  "pcdm_memberOf_sm": [
+    "09d-01"
+  ],
+  "gbl_resourceType_sm": [
+    "Topographic maps"
+  ],
+  "dct_format_s": "Image Service",
+  "dct_references_s": "{\"urn:x-esri:serviceType:ArcGIS#ImageMapLayer\":\"https://mapsweb.lib.purdue.edu/arcgis/rest/services/Purdue/wabashtopo/ImageServer\",\"http://schema.org/url\":\"https://mapsweb.lib.purdue.edu/wabashriver/\"}",
+  "dct_identifier_sm": [
+    "88cc9b19-3294-4da9-9edd-775c81fb1c59"
+  ],
+  "schema_provider_s": "Purdue University",
+  "dct_accessRights_s": "Public",
+  "gbl_suppressed_b": false,
+  "gbl_mdModified_dt": "2021-05-07T23:00:10Z"
+}


### PR DESCRIPTION
We need to allow all the new Aardvark relationship fields to bypass our suppressed records filter. This PR adds additional non-Source field relationship fixtures (the Wabash Topo docs) and a feature test to ensure our "Browse all X" link is working correctly.

Fixes #1221