### PR TITLE
I18n: fix missing GeoTIFF file download translation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -70,6 +70,11 @@ RSpec/AnyInstance:
     - 'spec/models/concerns/geoblacklight/solr_document/finder_spec.rb'
     - 'spec/features/download_layer_spec.rb'
 
+RSpec/Capybara/SpecificMatcher:
+  Exclude:
+    - spec/components/geoblacklight/*
+    - spec/features/*
+
 RSpec/DescribeClass:
   Exclude:
     - spec/tasks/*

--- a/config/locales/geoblacklight.en.yml
+++ b/config/locales/geoblacklight.en.yml
@@ -20,6 +20,7 @@ en:
       export_shapefile_link: 'Shapefile'
       export_kmz_link: 'KMZ'
       export_geojson_link: 'GeoJSON'
+      export_geotiff_link: 'GeoTIFF'
     home:
       headline: 'Explore and discover...'
       search_heading: 'Find the maps and data you need'

--- a/lib/geoblacklight/download.rb
+++ b/lib/geoblacklight/download.rb
@@ -48,7 +48,7 @@ module Geoblacklight
       File.rename("#{file_path_and_name}.tmp", file_path_and_name)
       file_name
     rescue Geoblacklight::Exceptions::WrongDownloadFormat => error
-      Geoblacklight.logger.error "#{error} expected #{@options[:content_type]} "\
+      Geoblacklight.logger.error "#{error} expected #{@options[:content_type]} " \
                                  "received #{download.headers['content-type']}"
       File.delete("#{file_path_and_name}.tmp")
       raise Geoblacklight::Exceptions::ExternalDownloadFailed, message: 'Wrong download type'

--- a/lib/geoblacklight/metadata_transformer/base.rb
+++ b/lib/geoblacklight/metadata_transformer/base.rb
@@ -31,7 +31,7 @@ module Geoblacklight
       def cleaned_metadata
         transformed_doc = Nokogiri::XML(@metadata.to_html)
         if transformed_doc.xpath('//body').children.empty?
-          fail TransformError,\
+          fail TransformError, \
                'Failed to extract the <body> child elements from the transformed metadata'
         end
         transformed_doc.xpath('//body').children

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -5,7 +5,7 @@ describe CatalogController, type: :controller do
   describe '#web_services' do
     it 'returns a document based off an id' do
       get :web_services, params: { id: 'mit-f6rqs4ucovjk2' }
-      expect(response.status).to eq 200
+      expect(response).to have_http_status :ok
       expect(assigns(:documents)).not_to be_nil
     end
   end
@@ -13,14 +13,14 @@ describe CatalogController, type: :controller do
   describe '.default_solr_params' do
     it 'sets the number of rows returned by Solr to 10 and does not filter the results' do
       get :index
-      expect(response.status).to eq 200
+      expect(response).to have_http_status :ok
       expect(assigns(:response).docs).not_to be_empty
       expect(assigns(:response).docs.length).to eq 10
     end
 
     it 'sets the starting document index to 0' do
       get :index
-      expect(response.status).to eq 200
+      expect(response).to have_http_status :ok
       expect(assigns(:response).docs).not_to be_empty
       expect(assigns(:response).docs.first.id).to eq 'stanford-cg357zz0321'
     end
@@ -35,7 +35,7 @@ describe CatalogController, type: :controller do
       it 'sets the starting document index' do
         blacklight_config.default_solr_params = { start: 2, 'q.alt' => '*:*' }
         get :index
-        expect(response.status).to eq 200
+        expect(response).to have_http_status :ok
         expect(assigns(:response).docs).not_to be_empty
         expect(assigns(:response).docs.first.id).to eq 'mit-001145244'
       end
@@ -43,7 +43,7 @@ describe CatalogController, type: :controller do
       it 'filters using a default DisMax query when no query is provided by the client' do
         blacklight_config.default_solr_params = { start: 10, 'q.alt' => '{!dismax}id:nyu' }
         get :index
-        expect(response.status).to eq 200
+        expect(response).to have_http_status :ok
         expect(assigns(:response).docs).to be_empty
       end
     end
@@ -58,7 +58,7 @@ describe CatalogController, type: :controller do
       it 'alters the number of documents returned from Solr' do
         blacklight_config.default_per_page = 20
         get :index
-        expect(response.status).to eq 200
+        expect(response).to have_http_status :ok
         expect(assigns(:response).docs).not_to be_empty
         expect(assigns(:response).docs.length).to eq 20
       end
@@ -68,7 +68,7 @@ describe CatalogController, type: :controller do
   describe '#raw' do
     it 'returns a JSON representation of a Solr Document' do
       get :raw, params: { id: 'tufts-cambridgegrid100-04' }
-      expect(response.status).to eq 200
+      expect(response).to have_http_status :ok
       expect(response.body).not_to be_empty
       response_values = JSON.parse(response.body)
       expect(response_values).to include 'gbl_mdVersion_s' => 'Aardvark'

--- a/spec/controllers/download_controller_spec.rb
+++ b/spec/controllers/download_controller_spec.rb
@@ -6,7 +6,7 @@ describe DownloadController, type: :controller do
     describe 'restricted file' do
       it 'redirects to login for authentication' do
         get :file, params: { id: 'stanford-cg357zz0321-shapefile', format: 'zip' }
-        expect(response.status).to eq 401
+        expect(response).to have_http_status :unauthorized
       end
     end
     describe 'public file' do
@@ -21,7 +21,7 @@ describe DownloadController, type: :controller do
     describe 'restricted file' do
       it 'redirects to login for authentication' do
         get :show, params: { id: 'stanford-cg357zz0321', format: 'json' }
-        expect(response.status).to eq 401
+        expect(response).to have_http_status :unauthorized
       end
     end
     describe 'public file' do
@@ -34,7 +34,7 @@ describe DownloadController, type: :controller do
       it 'initiates download creation' do
         allow(shapefile_download).to receive(:get).and_return('success')
         get :show, params: { id: 'mit-f6rqs4ucovjk2', type: 'shapefile' }
-        expect(response.status).to eq 200
+        expect(response).to have_http_status :ok
       end
     end
 
@@ -85,7 +85,7 @@ describe DownloadController, type: :controller do
       allow(Geoblacklight::HglDownload).to receive(:new).and_return(hgl_download)
 
       get :hgl, params: { id: 'harvard-g7064-s2-1834-k3', email: 'foo@example.com' }
-      expect(response.status).to eq 200
+      expect(response).to have_http_status :ok
     end
 
     it 'renders form' do

--- a/spec/controllers/relation_controller_spec.rb
+++ b/spec/controllers/relation_controller_spec.rb
@@ -5,7 +5,7 @@ describe RelationController, type: :controller do
   describe '#index' do
     it 'returns a listing of related documents for a record' do
       get :index, params: { id: 'nyu_2451_34502' }
-      expect(response.status).to eq 200
+      expect(response).to have_http_status :ok
       expect(assigns(:relations)).not_to be_nil
     end
   end

--- a/spec/helpers/geoblacklight_helper_spec.rb
+++ b/spec/helpers/geoblacklight_helper_spec.rb
@@ -139,8 +139,8 @@ describe GeoblacklightHelper, type: :helper do
     context 'as a String' do
       let(:document_attributes) do
         {
-          value: 'This is a really long string that should get truncated when it gets rendered'\
-                 'in the index view to give a brief description of the contents of a particular document'\
+          value: 'This is a really long string that should get truncated when it gets rendered' \
+                 'in the index view to give a brief description of the contents of a particular document' \
                  'indexed into Solr'
         }
       end
@@ -154,8 +154,8 @@ describe GeoblacklightHelper, type: :helper do
     context 'as an Array' do
       let(:document_attributes) do
         {
-          value: ['This is a really long string that should get truncated when it gets rendered'\
-                  'in the index view to give a brief description of the contents of a particular document'\
+          value: ['This is a really long string that should get truncated when it gets rendered' \
+                  'in the index view to give a brief description of the contents of a particular document' \
                   'indexed into Solr']
         }
       end


### PR DESCRIPTION
I18n add: `export_geotiff_link: 'GeoTIFF'`

Fixes #1233