### PR TITLE
GBL permitted params

### DIFF
--- a/app/controllers/wms_controller.rb
+++ b/app/controllers/wms_controller.rb
@@ -11,6 +11,6 @@ class WmsController < ApplicationController
   private
 
   def wms_params
-    params.permit('URL', 'LAYERS', 'BBOX', 'WIDTH', 'HEIGHT', 'QUERY_LAYERS', 'X', 'Y')
+    params.permit(Settings.GBL_PARAMS)
   end
 end

--- a/lib/generators/geoblacklight/install_generator.rb
+++ b/lib/generators/geoblacklight/install_generator.rb
@@ -7,6 +7,23 @@ module Geoblacklight
 
     desc 'Install Geoblacklight'
 
+    def allow_geoblacklight_params
+      gbl_params = <<-"PARAMS"
+        before_action :allow_geoblacklight_params
+
+        def allow_geoblacklight_params
+          # Blacklight::Parameters will pass these to params.permit
+          blacklight_config.search_state_fields.append(Settings.GBL_PARAMS)
+        end
+      PARAMS
+
+      inject_into_file 'app/controllers/application_controller.rb', gbl_params, before: /^end/
+    end
+
+    def raise_unpermitted_params
+      inject_into_file 'config/environments/test.rb', "config.action_controller.action_on_unpermitted_parameters = :raise\n", before: /^end/
+    end
+
     def mount_geoblacklight_engine
       inject_into_file 'config/routes.rb', "mount Geoblacklight::Engine => 'geoblacklight'\n", before: /^end/
     end

--- a/lib/generators/geoblacklight/templates/settings.yml
+++ b/lib/generators/geoblacklight/templates/settings.yml
@@ -22,6 +22,25 @@ OVERLAP_RATIO_BOOST: '2'
 HOMEPAGE_MAP_GEOM: null
 # HOMEPAGE_MAP_GEOM: '{"type":"Polygon","coordinates":[[[-73.58,42.93],[-73.58,41.20],[-69.90,41.20],[-69.90,42.93]]]}'
 
+# Non-search-field GeoBlacklight application permitted params
+GBL_PARAMS:
+  - :bbox
+  - :email
+  - :file
+  - :format
+  - :id
+  - :logo
+  - :provider
+  - :type
+  - :BBOX
+  - :HEIGHT
+  - :LAYERS
+  - :QUERY_LAYERS
+  - :URL
+  - :WIDTH
+  - :X
+  - :Y
+
 # Solr field mappings
 FIELDS:
   :ACCESS_RIGHTS: 'dct_accessRights_s'

--- a/spec/controllers/wms_controller_spec.rb
+++ b/spec/controllers/wms_controller_spec.rb
@@ -5,7 +5,7 @@ describe WmsController, type: :controller do
   let(:wms_layer) { instance_double(Geoblacklight::WmsLayer) }
   let(:feature_info) { { values: ['fid', 'layer:example'] } }
   let(:params) do
-    { format: 'json', 'URL' => 'http://www.example.com/', 'LAYERS' => 'layer:example',
+    { 'format' => 'json', 'URL' => 'http://www.example.com/', 'LAYERS' => 'layer:example',
       'BBOX' => '-74, 40, -68, 43', 'WIDTH' => '500', 'HEIGHT' => '400',
       'QUERY_LAYERS' => 'layer:example', 'X' => '277', 'Y' => '195' }
   end
@@ -27,8 +27,6 @@ describe WmsController, type: :controller do
 
     it 'returns only permitted params' do
       get :handle, params: params
-      expect(wms_params.to_h).not_to eq(params)
-      params.delete(:format)
       expect(wms_params.to_h).to eq(params)
     end
   end


### PR DESCRIPTION
Removes unpermitted params from the application by enumerating the non-search related params used in GBL within our Settings configuration file alongside an ApplicationController before_action to permit these params.

Configures our test environment to raise an error on unpermitted params.

Fixes #1235