### PR TITLE
GitHub Actions: Bump Ruby to 2.7

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -25,18 +25,9 @@ jobs:
     strategy:
       matrix:
         ruby_version: ['3.0', 2.7]
-        rails_version: [6.1]
+        rails_version: [7.0.2.2, 6.1]
         bundler_version: [2.1.1]
         faraday_version: ['>= 2', '~> 1.0']
-        include:
-          - ruby_version: 2.6
-            rails_version: 6.1
-            bundler_version: 2.1.1
-            faraday_version: '~> 1.0'
-          - ruby_version: '3.0'
-            rails_version: '7.0.2.2'
-            bundler_version: 2.1.1
-            faraday_version: '>= 2'
 
     name: test ruby ${{ matrix.ruby_version }} / rails ${{ matrix.rails_version }} / faraday ${{ matrix.faraday_version }}
     steps:


### PR DESCRIPTION
Latest capybara release requires Ruby 2.7 minimum. Bumping our matrix requirement to match.