### PR TITLE
Fix invalid aardvark fixtures; Add CI job to validate them going forward

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -20,6 +20,19 @@ jobs:
     - name: Run linter
       run: bundle exec standardrb
 
+  aardvark-fixture-linter:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.7
+    - name: Install json schema validator
+      run: gem install json_schemer
+    - name: Run json_schemer against aarkvark fixtures
+      run: find spec/fixtures/solr_documents -type f -name "*.json" | xargs json_schemer schema/geoblacklight-schema-aardvark.json
+
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/spec/fixtures/solr_documents/actual-papermap1.json
+++ b/spec/fixtures/solr_documents/actual-papermap1.json
@@ -26,7 +26,7 @@
   ],
   "dct_issued_s": "1905-06-22",
   "gbl_indexYear_im": [
-    "1996"
+    1996
   ],
   "gbl_dateRange_drsim": [
     "[1996 TO 1996]"

--- a/spec/fixtures/solr_documents/actual-point1.json
+++ b/spec/fixtures/solr_documents/actual-point1.json
@@ -33,7 +33,7 @@
   ],
   "dct_issued_s": "1905-07-06",
   "gbl_indexYear_im": [
-    "1905"
+    1905
   ],
   "gbl_dateRange_drsim": [
     "[1905 TO 2014]"

--- a/spec/fixtures/solr_documents/actual-polygon1.json
+++ b/spec/fixtures/solr_documents/actual-polygon1.json
@@ -28,7 +28,7 @@
   ],
   "dct_issued_s": "1905-06-27",
   "gbl_indexYear_im": [
-    "2004"
+    2004
   ],
   "gbl_dateRange_drsim": [
     "[2004 TO 2004]"

--- a/spec/fixtures/solr_documents/actual-raster1.json
+++ b/spec/fixtures/solr_documents/actual-raster1.json
@@ -40,7 +40,7 @@
   ],
   "dct_issued_s": "1905-06-27",
   "gbl_indexYear_im": [
-    "2005"
+    2005
   ],
   "gbl_dateRange_drsim": [
     "[2005 TO 2005]"

--- a/spec/fixtures/solr_documents/baruch_ancestor1.json
+++ b/spec/fixtures/solr_documents/baruch_ancestor1.json
@@ -38,7 +38,7 @@
   ],
   "dct_issued_s": "2016-01-15",
   "gbl_indexYear_im": [
-    "2010"
+    2010
   ],
   "gbl_dateRange_drsim": [
     "[2010 TO 2016]"

--- a/spec/fixtures/solr_documents/baruch_ancestor2.json
+++ b/spec/fixtures/solr_documents/baruch_ancestor2.json
@@ -38,7 +38,7 @@
   ],
   "dct_issued_s": "2016-01-15",
   "gbl_indexYear_im": [
-    "2010"
+    2010
   ],
   "gbl_dateRange_drsim": [
     "[2010 TO 2016]"

--- a/spec/fixtures/solr_documents/baruch_documentation_download.json
+++ b/spec/fixtures/solr_documents/baruch_documentation_download.json
@@ -40,7 +40,7 @@
   ],
   "dct_issued_s": "2016-01-15",
   "gbl_indexYear_im": [
-    "2015"
+    2015
   ],
   "gbl_dateRange_drsim": [
     "[2015 TO 2015]"
@@ -59,7 +59,7 @@
   "locn_geometry": "ENVELOPE(-74.030876,-73.755405,40.903125,40.576127)",
   "dcat_centroid": "40.739626,-73.8931405",
   "dct_source_sm": [
-    "nyu_2451_34635", 
+    "nyu_2451_34635",
     "nyu_2451_34636"
   ],
   "dct_accessRights_s": "Public",

--- a/spec/fixtures/solr_documents/cornell_html_metadata.json
+++ b/spec/fixtures/solr_documents/cornell_html_metadata.json
@@ -38,7 +38,7 @@
   ],
   "dct_issued_s": "2000-06-00",
   "gbl_indexYear_im": [
-    "2000"
+    2000
   ],
   "gbl_dateRange_drsim": [
     "[2000 TO *]"

--- a/spec/fixtures/solr_documents/esri-dynamic-layer-all-layers.json
+++ b/spec/fixtures/solr_documents/esri-dynamic-layer-all-layers.json
@@ -34,7 +34,7 @@
   ],
   "dct_issued_s": "1905-06-20",
   "gbl_indexYear_im": [
-    "1998"
+    1998
   ],
   "gbl_dateRange_drsim": [
     "[1998 TO 1998]"

--- a/spec/fixtures/solr_documents/esri-dynamic-layer-single-layer.json
+++ b/spec/fixtures/solr_documents/esri-dynamic-layer-single-layer.json
@@ -35,7 +35,7 @@
   ],
   "dct_issued_s": "2003-05-30",
   "gbl_indexYear_im": [
-    "2003"
+    2003
   ],
   "gbl_dateRange_drsim": [
     "[2003 TO 2003]"

--- a/spec/fixtures/solr_documents/esri-feature-layer.json
+++ b/spec/fixtures/solr_documents/esri-feature-layer.json
@@ -34,7 +34,7 @@
   ],
   "dct_issued_s": "2016-02-16",
   "gbl_indexYear_im": [
-    "2016"
+    2016
   ],
   "gbl_dateRange_drsim": [
     "[2016 TO 2016]"

--- a/spec/fixtures/solr_documents/esri-image-map-layer.json
+++ b/spec/fixtures/solr_documents/esri-image-map-layer.json
@@ -31,7 +31,7 @@
   ],
   "dct_issued_s": "2015-10-31",
   "gbl_indexYear_im": [
-    "1929"
+    1929
   ],
   "gbl_dateRange_drsim": [
     "[1929 TO 1929]"

--- a/spec/fixtures/solr_documents/esri-tiled_map_layer.json
+++ b/spec/fixtures/solr_documents/esri-tiled_map_layer.json
@@ -27,7 +27,7 @@
     "2010"
   ],
   "gbl_indexYear_im": [
-    "2010"
+    2010
   ],
   "gbl_dateRange_drsim": [
     "[2010 TO 2010]"

--- a/spec/fixtures/solr_documents/esri-wms-layer.json
+++ b/spec/fixtures/solr_documents/esri-wms-layer.json
@@ -35,7 +35,7 @@
   ],
   "dct_issued_s": "2003-01-28",
   "gbl_indexYear_im": [
-    "1972"
+    1972
   ],
   "gbl_dateRange_drsim": [
     "[1972 TO 1997]"

--- a/spec/fixtures/solr_documents/harvard_raster.json
+++ b/spec/fixtures/solr_documents/harvard_raster.json
@@ -40,7 +40,7 @@
   ],
   "dct_issued_s": "1905-06-22",
   "gbl_indexYear_im": [
-    "1834"
+    1834
   ],
   "gbl_dateRange_drsim": [
     "[1834 TO 1834]"

--- a/spec/fixtures/solr_documents/iiif-eastern-hemisphere.json
+++ b/spec/fixtures/solr_documents/iiif-eastern-hemisphere.json
@@ -24,7 +24,7 @@
     "1750"
   ],
   "gbl_indexYear_im": [
-    "1750"
+    1750
   ],
   "gbl_dateRange_drsim": [
     "[1750 TO 1750]"

--- a/spec/fixtures/solr_documents/index-map-polygon-no-downloadurl.json
+++ b/spec/fixtures/solr_documents/index-map-polygon-no-downloadurl.json
@@ -35,7 +35,7 @@
     "1995"
   ],
   "gbl_indexYear_im": [
-    "1995"
+    1995
   ],
   "gbl_dateRange_drsim": [
     "[1995 TO 1995]"

--- a/spec/fixtures/solr_documents/index-map-polygon.json
+++ b/spec/fixtures/solr_documents/index-map-polygon.json
@@ -35,7 +35,7 @@
     "1995"
   ],
   "gbl_indexYear_im": [
-    "1995"
+    1995
   ],
   "gbl_dateRange_drsim": [
     "[1995 TO 1995]"

--- a/spec/fixtures/solr_documents/index-map-stanford.json
+++ b/spec/fixtures/solr_documents/index-map-stanford.json
@@ -40,7 +40,7 @@
   ],
   "dct_issued_s": "1905-07-08",
   "gbl_indexYear_im": [
-    "1944"
+    1944
   ],
   "gbl_dateRange_drsim": [
     "[1944 TO 1944]"

--- a/spec/fixtures/solr_documents/index_map_point.json
+++ b/spec/fixtures/solr_documents/index_map_point.json
@@ -33,7 +33,7 @@
   ],
   "dct_issued_s": "c.1960",
   "gbl_indexYear_im": [
-    "1960"
+    1960
   ],
   "gbl_dateRange_drsim": [
     "[1960 TO 1969]"

--- a/spec/fixtures/solr_documents/princeton-parent.json
+++ b/spec/fixtures/solr_documents/princeton-parent.json
@@ -29,7 +29,7 @@
     "GBL Fixture records"
   ],
   "gbl_indexYear_im": [
-    "1885"
+    1885
   ],
   "gbl_dateRange_drsim": [
     "[1885 TO 1885]"

--- a/spec/fixtures/solr_documents/public_direct_download.json
+++ b/spec/fixtures/solr_documents/public_direct_download.json
@@ -35,7 +35,7 @@
   ],
   "dct_issued_s": "1905-06-27",
   "gbl_indexYear_im": [
-    "2005"
+    2005
   ],
   "gbl_dateRange_drsim": [
     "[2005 TO 2005]"

--- a/spec/fixtures/solr_documents/public_iiif_princeton.json
+++ b/spec/fixtures/solr_documents/public_iiif_princeton.json
@@ -36,7 +36,7 @@
   ],
   "dct_issued_s": "1904-11-12",
   "gbl_indexYear_im": [
-    "1778"
+    1778
   ],
   "gbl_dateRange_drsim": [
     "[1778 TO 1778]"

--- a/spec/fixtures/solr_documents/restricted-line.json
+++ b/spec/fixtures/solr_documents/restricted-line.json
@@ -41,7 +41,7 @@
   ],
   "dct_issued_s": "2002",
   "gbl_indexYear_im": [
-    "2002"
+    2002
   ],
   "gbl_dateRange_drsim": [
     "[2002 TO 2002]"

--- a/spec/fixtures/solr_documents/tilejson.json
+++ b/spec/fixtures/solr_documents/tilejson.json
@@ -30,9 +30,9 @@
         "Balkan Peninsula",
         "Turkey"
     ],
-    "dct_issued_s": 1908,
+    "dct_issued_s": "1908",
     "gbl_indexYear_im": [
-        "1908"
+        1908
     ],
     "gbl_mdModified_dt": "2022-02-03T22:13:40Z",
     "dct_references_s": "{\"http://schema.org/url\":\"https://catalog.princeton.edu/catalog/99125413918506421\",\"http://schema.org/thumbnailUrl\":\"https://figgy-staging.princeton.edu/downloads/6b55d939-7188-4bce-9550-0ac535441f22/file/9042b887-da2e-4aa9-9ca5-d3ba77f440c4\",\"http://iiif.io/api/image\":\"https://iiif-cloud-staging.princeton.edu/iiif/2/05%2F71%2F04%2F0571046f9c7149a3b950899323f70788%2Fintermediate_file/info.json\",\"http://iiif.io/api/presentation#manifest\":\"https://figgy-staging.princeton.edu/concern/scanned_maps/2a91d82c-541c-426c-b787-cc62afe8f248/manifest\",\"https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames\":\"https://map-tiles-staging.princeton.edu/mosaicjson/tiles/WebMercatorQuad/{z}/{x}/{y}@1x.png?id=2a91d82c541c426cb787cc62afe8f248\",\"https://github.com/mapbox/tilejson-spec\":\"https://map-tiles-staging.princeton.edu/mosaicjson/tilejson.json?id=2a91d82c541c426cb787cc62afe8f248\"}",

--- a/spec/fixtures/solr_documents/umn_metro_result1.json
+++ b/spec/fixtures/solr_documents/umn_metro_result1.json
@@ -35,8 +35,8 @@
   ],
   "dct_issued_s": "2015-10-01",
   "gbl_indexYear_im": [
-    "2014",
-    "2030"
+    2014,
+    2030
   ],
   "gbl_dateRange_drsim": [
     "[2014 TO 2014]"

--- a/spec/fixtures/solr_documents/umn_state_result1.json
+++ b/spec/fixtures/solr_documents/umn_state_result1.json
@@ -34,7 +34,7 @@
   ],
   "dct_issued_s": "2015-11-18",
   "gbl_indexYear_im": [
-    "2015"
+    2015
   ],
   "gbl_dateRange_drsim": [
     "[2015 TO 2015]"

--- a/spec/fixtures/solr_documents/umn_state_result2.json
+++ b/spec/fixtures/solr_documents/umn_state_result2.json
@@ -34,7 +34,7 @@
   ],
   "dct_issued_s": "2015-11-18",
   "gbl_indexYear_im": [
-    "1998"
+    1998
   ],
   "gbl_dateRange_drsim": [
     "[1998 TO 1998]"

--- a/spec/fixtures/solr_documents/uva_slug_colon.json
+++ b/spec/fixtures/solr_documents/uva_slug_colon.json
@@ -28,7 +28,7 @@
   ],
   "dct_issued_s": "2008-10-17",
   "gbl_indexYear_im": [
-    "2015"
+    2015
   ],
   "gbl_dateRange_drsim": [
     "[2015 TO 2018]"

--- a/spec/fixtures/solr_documents/wmts-multiple.json
+++ b/spec/fixtures/solr_documents/wmts-multiple.json
@@ -23,7 +23,7 @@
         "2022"
     ],
     "gbl_indexYear_im": [
-        "2022"
+        2022
     ],
     "gbl_mdModified_dt": "2022-02-04T22:13:37Z",
     "gbl_wxsIdentifier_s": "lb2016",

--- a/spec/fixtures/solr_documents/wmts-single-layer.json
+++ b/spec/fixtures/solr_documents/wmts-single-layer.json
@@ -1,7 +1,7 @@
 {
     "gbl_mdVersion_s": "Aardvark",
     "dct_identifier_sm": [
-      "ark:/99999/fk4544658v"
+        "ark:/99999/fk4544658v"
     ],
     "id": "princeton-fk4544658v-wmts",
     "dct_title_s": "The Balkans [and] Turkey : G.S.G.S. no. 2097 / War Office. General Staff. Geographical Section (WMTS Fixture)",
@@ -10,16 +10,16 @@
     "schema_provider_s": "Princeton",
     "dct_accessRights_s": "Public",
     "dct_description_sm": [
-      "Relief shown by contours approximately 100 feet interval, spot heights, and shading. Title varies; some sheets are titled \"Turkey\". Shows international boundaries, railways, 2 categories of roads, telegraph lines, places of worship, ruins. Constantinople latest edition map has a glossary."
+        "Relief shown by contours approximately 100 feet interval, spot heights, and shading. Title varies; some sheets are titled \"Turkey\". Shows international boundaries, railways, 2 categories of roads, telegraph lines, places of worship, ruins. Constantinople latest edition map has a glossary."
     ],
     "dct_creator_sm": [
         "Great Britain. War Office. General Staff. Geographical Section"
     ],
     "dct_language_sm": [
-      "eng"
+        "eng"
     ],
     "dct_publisher_sm": [
-      "[London] : War Office. General Staff. Geographical Section. General Staff, 1908-25."
+        "[London] : War Office. General Staff. Geographical Section. General Staff, 1908-25."
     ],
     "dct_subject_sm": [
         "Balkan Peninsula Maps",
@@ -30,9 +30,9 @@
         "Balkan Peninsula",
         "Turkey"
     ],
-    "dct_issued_s": 1908,
+    "dct_issued_s": "1908",
     "gbl_indexYear_im": [
-        "1908"
+        1908
     ],
     "gbl_mdModified_dt": "2022-02-03T22:13:40Z",
     "gbl_wxsIdentifier_s": "mosaic",

--- a/spec/fixtures/solr_documents/xyz.json
+++ b/spec/fixtures/solr_documents/xyz.json
@@ -3,7 +3,7 @@
     "6f47b103-9955-4bbe-a364-387039623106"
   ],
   "dct_title_s": "Quaternary Fault and Fold Database of the United States (XYZ)",
-  "dct_description_sm":[
+  "dct_description_sm": [
     "Quaternary Fault and Fold Database of the United States"
   ],
   "dct_accessRights_s": "Public",
@@ -28,9 +28,9 @@
     "Earthquakes",
     "Faults"
   ],
-  "dct_issued_s": 2020,
+  "dct_issued_s": "2020",
   "gbl_indexYear_im": [
-    "2020"
+    2020
   ],
   "dct_temporal_sm": [
     "2020"


### PR DESCRIPTION
References #1262 

- Create a CI job which will validate json fixtures in the `spec/fixtures/solr_documents` directory against the aardvark schema file in repo
- Update existing fixtures so that they successfully validate and pass the new CI job