### PR TITLE
add `gbl_displayNote_sm` to validation file

### DIFF
--- a/schema/geoblacklight-schema-aardvark.json
+++ b/schema/geoblacklight-schema-aardvark.json
@@ -24,6 +24,12 @@
         "type": "string"
       }
     },
+    "gbl_displayNote_sm": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
     "dct_creator_sm": {
       "type": "array",
       "items": {


### PR DESCRIPTION
I also made this change in the JSON validation file stored on the OpenGeoMetadata site (https://github.com/OpenGeoMetadata/opengeometadata.github.io/tree/main/schema).

Related question: is there a reason why there are two copies of these validation files?