### PR TITLE
Update GeoCombine to v0.8.0

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -48,6 +48,11 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby_version }}
+    # required to avoid https://github.com/actions/runner-images/issues/37
+    # because faraday depends on patron, which requires curl headers to build
+    - name: Install cURL Headers
+      run: sudo apt-get update && sudo apt-get install libcurl4-openssl-dev
+      if: matrix.faraday_version == '~> 1.0'
     - name: Create Solr container
       run: docker run -d -p 8983:8983 geoblacklight/solr:8.9-v1.0.0 server/scripts/ci-start.sh
     - name: Install dependencies

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -39,7 +39,6 @@ jobs:
       matrix:
         ruby_version: ['3.0', 2.7]
         rails_version: [7.0.2.2, 6.1]
-        bundler_version: [2.1.1]
         faraday_version: ['>= 2', '~> 1.0']
 
     name: test ruby ${{ matrix.ruby_version }} / rails ${{ matrix.rails_version }} / faraday ${{ matrix.faraday_version }}
@@ -51,10 +50,8 @@ jobs:
         ruby-version: ${{ matrix.ruby_version }}
     - name: Create Solr container
       run: docker run -d -p 8983:8983 geoblacklight/solr:8.9-v1.0.0 server/scripts/ci-start.sh
-    - name: Install bundler
-      run: gem install bundler -v ${{ matrix.bundler_version }}
     - name: Install dependencies
-      run: bundle _${{ matrix.bundler_version }}_ install
+      run: bundle install
       env:
         RAILS_VERSION: ${{ matrix.rails_version }}
         FARADAY_VERSION: ${{ matrix.faraday_version }}

--- a/geoblacklight.gemspec
+++ b/geoblacklight.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "faraday", ">= 1.0"
   spec.add_dependency "coderay"
   spec.add_dependency "deprecation"
-  spec.add_dependency "geo_combine", "~> 0.4"
+  spec.add_dependency "geo_combine", "~> 0.8"
   spec.add_dependency "mime-types"
   spec.add_dependency "handlebars_assets"
   spec.add_dependency "rgeo-geojson"


### PR DESCRIPTION
I saw some dependency conflicts involving faraday, and so tried letting bundler update itself to newer versions to see if that would resolve them. It did, except for the odd case of trying to build native extensions for `patron`, which is a downstream dependency of faraday 1.x and needs some headers that apparently aren't on GitHub CI runners (see https://github.com/actions/runner-images/issues/37). This problem only affects faraday 1.x builds.