### PR TITLE
Settings: prepend the new v4.1 settings.yml additions

### DIFF
--- a/config/initializers/new_gbl_settings_defaults_3_4.yml
+++ b/config/initializers/new_gbl_settings_defaults_3_4.yml
@@ -1,6 +1,0 @@
-# New GeoBlacklight v3.4
-# Homepage Map Geometry
-# Leave null to default to entire world
-# Add a stringified GeoJSON object to scope initial render (example from UMass)
-HOMEPAGE_MAP_GEOM: null
-# HOMEPAGE_MAP_GEOM: '{"type":"Polygon","coordinates":[[[-73.58,42.93],[-73.58,41.20],[-69.90,41.20],[-69.90,42.93]]]}'

--- a/config/initializers/new_gbl_settings_defaults_4.1.yml
+++ b/config/initializers/new_gbl_settings_defaults_4.1.yml
@@ -1,0 +1,104 @@
+# New GeoBlacklight v4.1 Settings
+
+# Display Notes to display / Non-prefixed default bootstrap class is alert-secondary
+DISPLAY_NOTES_SHOWN:
+  danger:
+    bootstrap_alert_class: alert-danger
+    icon: fire-solid
+    note_prefix: "Danger: "
+  info:
+    bootstrap_alert_class: alert-info
+    icon: circle-info-solid
+    note_prefix: "Info: "
+  tip:
+    bootstrap_alert_class: alert-success
+    icon: lightbulb-solid
+    note_prefix: "Tip: "
+  warning:
+    bootstrap_alert_class: alert-warning
+    icon: triangle-exclamation-solid
+    note_prefix: "Warning: "
+
+# Solr field mappings (Added DISPLAY_NOTE)
+FIELDS:
+  :DISPLAY_NOTE: 'gbl_displayNote_sm'
+
+# Relationships to display
+RELATIONSHIPS_SHOWN:
+  MEMBER_OF_ANCESTORS:
+    field: pcdm_memberOf_sm
+    icon: parent-item
+    inverse: :MEMBER_OF_DESCENDANTS
+    label: geoblacklight.relations.member_of_ancestors
+    query_type: ancestors
+  MEMBER_OF_DESCENDANTS:
+    field: pcdm_memberOf_sm
+    icon: child-item
+    inverse: :MEMBER_OF_ANCESTORS
+    label: geoblacklight.relations.member_of_descendants
+    query_type: descendants
+  PART_OF_ANCESTORS:
+    field: dct_isPartOf_sm
+    icon: parent-item
+    inverse: :PART_OF_DESCENDANTS
+    label: geoblacklight.relations.part_of_ancestors
+    query_type: ancestors
+  PART_OF_DESCENDANTS:
+    field: dct_isPartOf_sm
+    icon: child-item
+    inverse: :PART_OF_ANCESTORS
+    label: geoblacklight.relations.part_of_descendants
+    query_type: descendants
+  RELATION_ANCESTORS:
+    field: dct_relation_sm
+    icon: nil
+    inverse: :RELATION_DESCENDANTS
+    label: geoblacklight.relations.relation_ancestors
+    query_type: ancestors
+  RELATION_DESCENDANTS:
+    field: dct_relation_sm
+    icon: nil
+    inverse: :RELATION_ANCESTORS
+    label: geoblacklight.relations.relation_descendants
+    query_type: descendants
+  REPLACES_ANCESTORS:
+    field: dct_replaces_sm
+    icon: nil
+    inverse: :REPLACES_DESCENDANTS
+    label: geoblacklight.relations.replaces_ancestors
+    query_type: ancestors
+  REPLACES_DESCENDANTS:
+    field: dct_replaces_sm
+    icon: nil
+    inverse: :REPLACES_ANCESTORS
+    label: geoblacklight.relations.replaces_descendants
+    query_type: descendants
+  SOURCE_ANCESTORS:
+    field: dct_source_sm
+    icon: parent-item
+    inverse: :SOURCE_DESCENDANTS
+    label: geoblacklight.relations.source_ancestors
+    query_type: ancestors
+  SOURCE_DESCENDANTS:
+    field: dct_source_sm
+    icon: child-item
+    inverse: :SOURCE_ANCESTORS
+    label: geoblacklight.relations.source_descendants
+    query_type: descendants
+  VERSION_OF_ANCESTORS:
+    field: dct_isVersionOf_sm
+    icon: parent-item
+    inverse: :VERSION_OF_DESCENDANTS
+    label: geoblacklight.relations.version_of_ancestors
+    query_type: ancestors
+  VERSION_OF_DESCENDANTS:
+    field: dct_isVersionOf_sm
+    icon: child-item
+    inverse: :VERSION_OF_ANCESTORS
+    label: geoblacklight.relations.version_of_descendants
+    query_type: descendants
+
+# Enable catalog#show sidebar static map for items with the following viewer protocols
+SIDEBAR_STATIC_MAP:
+  - 'iiif'
+  - 'iiif_manifest'

--- a/config/initializers/rails_config.rb
+++ b/config/initializers/rails_config.rb
@@ -3,3 +3,6 @@
 Config.setup do |config|
   config.const_name = "Settings"
 end
+
+Settings.prepend_source!(File.expand_path("new_gbl_settings_defaults_4_1.yml", __dir__))
+Settings.reload!

--- a/spec/config/initializers/rails_config_spec.rb
+++ b/spec/config/initializers/rails_config_spec.rb
@@ -3,14 +3,14 @@
 require "spec_helper"
 
 describe "Config" do
-  it "Loads new Aardvark relationships" do
+  it "Loads new v4.1 Settings defaults" do
     expect(Settings).to respond_to("RELATIONSHIPS_SHOWN")
+    expect(Settings.FIELDS.DISPLAY_NOTE).to be_present
+    expect(Settings.DISPLAY_NOTES_SHOWN).to respond_to(:danger)
+    expect(Settings.SIDEBAR_STATIC_MAP).to include("iiif")
+
     [:field, :query_type, :icon, :label].each do |method|
       expect(Settings.RELATIONSHIPS_SHOWN.MEMBER_OF_ANCESTORS).to respond_to(method)
     end
-  end
-
-  it "Loads new v3.4 Settings.FIELDS defaults" do
-    expect(Settings.HOMEPAGE_MAP_GEOM).to be_nil
   end
 end


### PR DESCRIPTION
This will help keep the v4+ upgrade path as smooth as possible.

Also, this drops the old v3.4 settings file additions. We only need v4 updates here.