### PR TITLE
Relationships - Browse link for parent descendants - Example 1

### DIFF
--- a/app/views/relation/_relations.html.erb
+++ b/app/views/relation/_relations.html.erb
@@ -1,8 +1,16 @@
 <% @relations.send(rel)['docs'][0..2].each do |entry| %>
   <li class="list-group-item border-bottom-0">
     <%= link_to solr_document_path(entry[Settings.FIELDS.ID]) do %>
-      <%= relations_icon(entry, value.icon) unless value.icon.nil? %>
+      <%= relations_icon(entry, value.icon) unless value.icon.nil? || value.icon == "nil" %>
       <%= entry[Settings.FIELDS.TITLE] %>
+    <% end %>
+  
+    <% if value.query_type == "ancestors" %>
+      <p class="mt-2 mb-0">
+        <%= link_to search_catalog_path({f: {"#{value.field}" => [entry[Settings.FIELDS.ID]]}}) do %>
+          <%= t('geoblacklight.relations.browse_all_no_count') %>
+        <% end %>
+      </p>
     <% end %>
   </li>
 <% end %>


### PR DESCRIPTION
Addresses #1293

This is an example of how a browse link for "collection" relationships could be added to GBL.

* Pros: very simple implementation, no model or logic changes necessary
* Cons: exposes "Browse link" for 1:1 relations, too

### Child Item / Links to Parent Browse
<img width="1303" alt="Screenshot 2023-06-15 at 10 10 31 AM" src="https://github.com/geoblacklight/geoblacklight/assets/69827/ffbf694f-afc2-44a3-bd6a-880a23b914db">

### Parent / Links to Child 1:1 relationships, too
<img width="1303" alt="Screenshot 2023-06-15 at 10 09 58 AM" src="https://github.com/geoblacklight/geoblacklight/assets/69827/b859da50-945e-496d-83e4-019de407754b">
