### PR TITLE
Relationships - Browse link for parent descendants - Example 2

### DIFF
--- a/app/views/relation/_relations.html.erb
+++ b/app/views/relation/_relations.html.erb
@@ -1,8 +1,24 @@
 <% @relations.send(rel)['docs'][0..2].each do |entry| %>
   <li class="list-group-item border-bottom-0">
     <%= link_to solr_document_path(entry[Settings.FIELDS.ID]) do %>
-      <%= relations_icon(entry, value.icon) unless value.icon.nil? %>
+      <%= relations_icon(entry, value.icon) unless value.icon.nil? || value.icon == "nil" %>
       <%= entry[Settings.FIELDS.TITLE] %>
+    <% end %>
+
+    <% # You could configure or enumerate a specific list of relationships %>
+    <% # to draw browse links for here. This is just one example. %>
+    <% if rel == :PART_OF_ANCESTORS %>
+      <%- @related_id = @relations.send(:PART_OF_ANCESTORS)['docs'].first['id'] %>
+      
+      <% # Query the inverse of the original relationship: PART_OF_ANCESTORS => PART_OF_DESCENDANTS %>
+      <%- @related = Geoblacklight::Relation::RelationResponse.new(@related_id, blacklight_config.repository_class.new(blacklight_config)) %>
+      <% if @related.send(:PART_OF_DESCENDANTS)['numFound'] > 1 %>
+        <p class="mt-2 mb-0">
+          <%= link_to search_catalog_path({f: {"#{Settings.RELATIONSHIPS_SHOWN.send(:PART_OF_DESCENDANTS).field}" => [@related_id]}}) do %>
+            <%= t('geoblacklight.relations.browse_all', count: @related.send(:PART_OF_DESCENDANTS)['numFound']) %>
+          <% end %>
+          </p>
+      <% end %>
     <% end %>
   </li>
 <% end %>


### PR DESCRIPTION
Addresses #1293

This is an example of how a browse link for "collection" relationships could be added to GBL.

* Pros: Avoids rendering a browse link for 1:1 relationships, includes browse search result count
* Cons: Adds queries for inverse relationships into the view (an anti-pattern), data would be better captured in the relationship response/query class(es).

### Child Item / Links to Parent Browse

<img width="1303" alt="Screenshot 2023-06-15 at 10 32 26 AM" src="https://github.com/geoblacklight/geoblacklight/assets/69827/2529b94a-b46c-4c31-b9ce-882c82726583">

### Parent

<img width="1303" alt="Screenshot 2023-06-15 at 10 32 22 AM" src="https://github.com/geoblacklight/geoblacklight/assets/69827/0d774581-ef76-4fdd-9be3-ca4163d13a76">
