### PR TITLE
Drop Faraday v1

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -39,27 +39,20 @@ jobs:
       matrix:
         ruby_version: ['3.2', '3.3']
         rails_version: [6.1.7.6, 7.1.3]
-        faraday_version: ['>= 2', '~> 1.0']
 
-    name: test ruby ${{ matrix.ruby_version }} / rails ${{ matrix.rails_version }} / faraday ${{ matrix.faraday_version }}
+    name: test ruby ${{ matrix.ruby_version }} / rails ${{ matrix.rails_version }}
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby_version }}
-    # required to avoid https://github.com/actions/runner-images/issues/37
-    # because faraday depends on patron, which requires curl headers to build
-    - name: Install cURL Headers
-      run: sudo apt-get update && sudo apt-get install libcurl4-openssl-dev
-      if: matrix.faraday_version == '~> 1.0'
     - name: Create Solr container
       run: docker run -d -p 8983:8983 geoblacklight/solr:8.9-v1.0.0 server/scripts/ci-start.sh
     - name: Install dependencies
       run: bundle install
       env:
         RAILS_VERSION: ${{ matrix.rails_version }}
-        FARADAY_VERSION: ${{ matrix.faraday_version }}
     - name: Setup Yarn
       run: exec "yarnpkg"
     - name: Load config into solr
@@ -72,7 +65,6 @@ jobs:
       run: bundle exec rake ci
       env:
         RAILS_VERSION: ${{ matrix.rails_version }}
-        FARADAY_VERSION: ${{ matrix.faraday_version }}
         ENGINE_CART_RAILS_OPTIONS: '--skip-git --skip-listen --skip-spring --skip-keeps --skip-action-cable --skip-coffee --skip-test'
         SOLR_URL: http://solr:SolrRocks@localhost:8983/solr/blacklight-core
     - name: Upload coverage artifacts

--- a/geoblacklight.gemspec
+++ b/geoblacklight.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rails", ">= 6.1", "< 7.2"
   spec.add_dependency "blacklight", "~> 7.0"
   spec.add_dependency "config"
-  spec.add_dependency "faraday", ">= 1.0"
+  spec.add_dependency "faraday", "~> 2.0"
   spec.add_dependency "coderay"
   spec.add_dependency "deprecation"
   spec.add_dependency "geo_combine", "~> 0.8"

--- a/spec/test_app_templates/Gemfile.extra
+++ b/spec/test_app_templates/Gemfile.extra
@@ -1,3 +1,2 @@
 gem 'sprockets', '< 4'
 gem 'view_component', '!= 2.26.0'
-gem 'faraday', ENV["FARADAY_VERSION"].to_s != "" ? ENV["FARADAY_VERSION"] : '>= 1.0'


### PR DESCRIPTION
This PR removes official support for Faraday v1 from future GeoBlacklight v4 releases.

Fixes #1334