### PR TITLE
Web services: add copy to clipboard feature

### DIFF
--- a/app/views/catalog/_citation.html.erb
+++ b/app/views/catalog/_citation.html.erb
@@ -7,7 +7,7 @@
   </div>
   <div class="modal-body" data-clipboard-target="source">
     <div class="alert alert-info d-none" role="alert">
-      Citation copied to clipboard
+      <%= t('geoblacklight.clipboard.citation') %>
       <button type="button" class="close" data-dismiss="alert" aria-label="Close">
         <span aria-hidden="true">&times;</span>
       </button>

--- a/app/views/catalog/_web_services_default.html.erb
+++ b/app/views/catalog/_web_services_default.html.erb
@@ -4,5 +4,10 @@
   <label for='<%= reference.type%>_webservice'>
     <%= "#{formatted_name_reference(reference.type)}" %>
   </label>
-  <input type='text' id='<%= reference.type%>_webservice' value='<%= reference.endpoint %>' readonly='readonly' class='form-control'>
+  <div class='input-group'>  
+    <input type='text' id='<%= reference.type%>_webservice' value='<%= reference.endpoint %>' readonly='readonly' class='form-control'>
+    <div class="input-group-append">
+      <button button type="button" class="btn btn-primary" data-action="copyToClipboard" data-clipboard-value='<%= reference.endpoint %>'><%= t('blacklight.modal.copy') %></button>
+    </div>
+  </div>
 </div>

--- a/app/views/catalog/_web_services_wfs.html.erb
+++ b/app/views/catalog/_web_services_wfs.html.erb
@@ -4,5 +4,10 @@
 
 <div class="form-group form-inline">
   <label for="wfs_abv_webservice" class="mr-2"><%= t('geoblacklight.references.wfs_abv')%> <code><%= t('geoblacklight.references.wfs_label')%></code></label>
-  <input id="wfs_abv_webservice" type='text' value='<%= document.wxs_identifier %>' readonly='readonly' class="form-control">
+  <div class='input-group'>
+    <input id="wfs_abv_webservice" type='text' value='<%= document.wxs_identifier %>' readonly='readonly' class="form-control">
+    <div class="input-group-append">
+      <button button type="button" class="btn btn-primary"  data-action="copyToClipboard" data-clipboard-value='<%= document.wxs_identifier %>'><%= t('blacklight.modal.copy') %></button>
+    </div>
+  </div>
 </div>

--- a/app/views/catalog/_web_services_wms.html.erb
+++ b/app/views/catalog/_web_services_wms.html.erb
@@ -4,5 +4,10 @@
 
 <div class="form-group form-inline">
   <label for="wms_abv_webservice" class="mr-2"><%= t('geoblacklight.references.wms_abv')%> <code><%= t('geoblacklight.references.wms_label')%></code></label>
-  <input id="wms_abv_webservice" type='text' value='<%= document.wxs_identifier %>' readonly='readonly' class="form-control">
+  <div class='input-group'>
+    <input id="wms_abv_webservice" type='text' value='<%= document.wxs_identifier %>' readonly='readonly' class="form-control" data-action="copyToClipboard" data-clipboard-value='<%= document.wxs_identifier %>'>
+    <div class="input-group-append">
+      <button button type="button" class="btn btn-primary"  data-action="copyToClipboard" data-clipboard-value='<%= document.wxs_identifier %>'><%= t('blacklight.modal.copy') %></button>
+    </div>
+  </div>
 </div>

--- a/app/views/catalog/web_services.html.erb
+++ b/app/views/catalog/web_services.html.erb
@@ -5,8 +5,24 @@
   </button>
 </div>
 <div class="modal-body web-services-modal-body">
+  <div class="alert alert-info d-none" role="alert">
+  <%= t('geoblacklight.clipboard.web_service') %>
+    <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+      <span aria-hidden="true">&times;</span>
+    </button>
+  </div>
   <%= render partial: 'web_services' %>
 </div>
 <div class="modal-footer">
   <button type="button" class="btn btn-default hide-without-js" data-dismiss="modal"><%= t('geoblacklight.references.services_close')%></button>
 </div>
+
+<script>
+    $('[data-action="copyToClipboard"]').on('click', function() {
+        let text = $(this).data('clipboard-value');       
+        navigator.clipboard.writeText(text)
+            .then(() => {
+                $('.alert').removeClass('d-none');
+            })
+    });
+</script>

--- a/config/locales/geoblacklight.en.yml
+++ b/config/locales/geoblacklight.en.yml
@@ -4,6 +4,9 @@ en:
     location: 'Location'
     citation:
       retrieved_from: 'Retrieved from %{document_url}'
+    clipboard:
+      citation: Citation copied to clipboard
+      web_service: Web service copied to clipboard
     download:
       download: 'Download'
       download_link: 'Original %{download_format}'

--- a/spec/features/web_services_modal_spec.rb
+++ b/spec/features/web_services_modal_spec.rb
@@ -79,4 +79,12 @@ feature "web services tools" do
       end
     end
   end
+  feature "copy to clipboard is provided", js: true do
+    scenario "shows up in tools" do
+      visit solr_document_path "princeton-dc7h14b252v"
+      expect(page).to have_css "div.web-services-sidebar a", text: "Web services"
+      click_link "Web services"
+      expect(page).to have_text "Copy"
+    end
+  end
 end


### PR DESCRIPTION
Adds a copy to the clipboard feature for our Web services to match our "Copy citation" feature.

* The web service URL is copy-able
* The layer id is too

Fixes #1209

![Screenshot 2024-02-09 at 2 24 59 PM](https://github.com/geoblacklight/geoblacklight/assets/69827/34a35a52-ba66-4158-b4cd-0d137faa6778)

