### PR TITLE
Bump GeoCombine dependency to v0.9

### DIFF
--- a/geoblacklight.gemspec
+++ b/geoblacklight.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "faraday", "~> 2.0"
   spec.add_dependency "coderay"
   spec.add_dependency "deprecation"
-  spec.add_dependency "geo_combine", "~> 0.8"
+  spec.add_dependency "geo_combine", "~> 0.9"
   spec.add_dependency "mime-types"
   spec.add_dependency "handlebars_assets"
   spec.add_dependency "rgeo-geojson"


### PR DESCRIPTION
This version adds some logging and speeds up harvesting/indexing from OpenGeoMetadata, as well as making the automated v1 -> Aardvark migrator available.