### PR TITLE
Vite: uses local application entrypoints with an aliased path for importing engine code

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -65,7 +65,7 @@ jobs:
       run: bundle exec rake ci
       env:
         RAILS_VERSION: ${{ matrix.rails_version }}
-        ENGINE_CART_RAILS_OPTIONS: '--skip-git --skip-listen --skip-spring --skip-keeps --skip-action-cable --skip-coffee --skip-test'
+        ENGINE_CART_RAILS_OPTIONS: '--skip-git --skip-listen --skip-spring --skip-keeps --skip-action-cable --skip-coffee --skip-test --skip-webpack-install --skip-javascript'
         SOLR_URL: http://solr:SolrRocks@localhost:8983/solr/blacklight-core
     - name: Upload coverage artifacts
       uses: actions/upload-artifact@v2

--- a/app/frontend/entrypoints/application.js
+++ b/app/frontend/entrypoints/application.js
@@ -3,7 +3,7 @@
 //
 //    <%= vite_client_tag %>
 //    <%= vite_javascript_tag 'application' %>
-console.log('Vite ⚡️ Rails')
+console.log('Vite ⚡️ Rails - Engine')
 
 // If using a TypeScript entrypoint file:
 //     <%= vite_typescript_tag 'application' %>

--- a/app/frontend/openlayers/ol_initializer.js
+++ b/app/frontend/openlayers/ol_initializer.js
@@ -1,4 +1,4 @@
-import '@/stylesheets/openlayers.css'
+import '../stylesheets/openlayers.css'
 import { Map, View } from 'ol'
 import TileLayer from 'ol/layer/Tile'
 import VectorTile from 'ol/layer/VectorTile'

--- a/app/frontend/stylesheets/openlayers.css
+++ b/app/frontend/stylesheets/openlayers.css
@@ -1,1 +1,1 @@
-@import "node_modules/ol/ol.css";
+@import "../../../node_modules/ol/ol.css";

--- a/app/helpers/geoblacklight/application_helper.rb
+++ b/app/helpers/geoblacklight/application_helper.rb
@@ -1,8 +1,0 @@
-module Geoblacklight
-  module ApplicationHelper
-    # Override: Returns the engine assets manifest.
-    def vite_manifest
-      Geoblacklight::Engine.vite_ruby.manifest
-    end
-  end
-end

--- a/lib/generators/geoblacklight/install_generator.rb
+++ b/lib/generators/geoblacklight/install_generator.rb
@@ -116,17 +116,28 @@ module Geoblacklight
       copy_file "base.html.erb", "app/views/layouts/blacklight/base.html.erb"
     end
 
-    # Vite - Copy config file
-    def copy_config_vite_json
-      copy_file "vite.json", "config/vite.json"
-    end
-
     # Run bundle with vite install
     def bundle_install
       Bundler.with_clean_env do
         run "bundle install"
         run "bundle exec vite install"
       end
+    end
+
+    # Vite - Config files
+    def copy_config_vite_json
+      copy_file "vite.json", "config/vite.json"
+      copy_file "vite.rb", "config/vite.rb"
+      copy_file "vite.config.ts", "vite.config.ts"
+      copy_file "package.json", "package.json"
+
+      run "yarn install"
+    end
+
+    # Vite - Copy over the Vite entrypoints
+    def copy_vite_entrypoints
+      copy_file "clover.js", "app/frontend/entrypoints/clover.js"
+      copy_file "ol.js", "app/frontend/entrypoints/ol.js"
     end
   end
 end

--- a/lib/generators/geoblacklight/templates/clover.js
+++ b/lib/generators/geoblacklight/templates/clover.js
@@ -1,0 +1,5 @@
+import CloverInitializer from '@gbl/clover/clover_initializer'
+
+document.addEventListener('DOMContentLoaded', () => {
+  new CloverInitializer().run()
+})

--- a/lib/generators/geoblacklight/templates/ol.js
+++ b/lib/generators/geoblacklight/templates/ol.js
@@ -1,0 +1,5 @@
+import OlInitializer from '@gbl/openlayers/ol_initializer'
+
+document.addEventListener('DOMContentLoaded', () => {
+  new OlInitializer().run()
+})

--- a/lib/generators/geoblacklight/templates/package.json
+++ b/lib/generators/geoblacklight/templates/package.json
@@ -1,0 +1,7 @@
+{
+  "devDependencies": {
+    "vite": "^5.1.5",
+    "vite-plugin-ruby": "^5.0.0",
+    "vite-plugin-rails": "^0.5.0"
+  }
+}

--- a/lib/generators/geoblacklight/templates/vite.config.ts
+++ b/lib/generators/geoblacklight/templates/vite.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vite'
+import rails from 'vite-plugin-rails'
+
+export default defineConfig({
+  plugins: [
+    rails(),
+  ],
+  // GeoBlacklight: Import assets from arbitrary paths.
+  resolve: {
+    alias: {
+      '@gbl/': `${process.env.GBL_ASSETS_PATH}/`,
+    },
+  },
+  server: {
+    fs: {
+      allow: [process.env.GBL_ASSETS_PATH!],
+    },
+  },
+})

--- a/lib/generators/geoblacklight/templates/vite.rb
+++ b/lib/generators/geoblacklight/templates/vite.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+ViteRuby.env['GBL_ASSETS_PATH'] =
+  "#{ Gem.loaded_specs['geoblacklight'].full_gem_path }/app/frontend"

--- a/lib/generators/geoblacklight/templates/vite.rb
+++ b/lib/generators/geoblacklight/templates/vite.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
-ViteRuby.env['GBL_ASSETS_PATH'] =
-  "#{ Gem.loaded_specs['geoblacklight'].full_gem_path }/app/frontend"
+ViteRuby.env["GBL_ASSETS_PATH"] =
+  "#{Gem.loaded_specs["geoblacklight"].full_gem_path}/app/frontend"

--- a/lib/geoblacklight/engine.rb
+++ b/lib/geoblacklight/engine.rb
@@ -8,33 +8,9 @@ require "geoblacklight/version"
 require "nokogiri"
 require "mime/types"
 require "handlebars_assets"
-require "vite_ruby"
 
 module Geoblacklight
   class Engine < ::Rails::Engine
-    delegate :vite_ruby, to: :class
-
-    def self.vite_ruby
-      @vite_ruby ||= ViteRuby.new(root: root)
-    end
-
-    # Expose compiled assets via Rack::Static when running in the host app.
-    config.app_middleware.use(Rack::Static,
-      urls: ["/#{vite_ruby.config.public_output_dir}"],
-      root: root.join(vite_ruby.config.public_dir))
-
-    initializer "vite_rails_engine.proxy" do |app|
-      if vite_ruby.run_proxy?
-        app.middleware.insert_before 0, ViteRuby::DevServerProxy, ssl_verify_none: true, vite_ruby: vite_ruby
-      end
-    end
-
-    initializer "vite_rails_engine.logger" do
-      config.after_initialize do
-        vite_ruby.logger = Rails.logger
-      end
-    end
-
     # GeoblacklightHelper is needed by all helpers, so we inject it
     # into action view base here.
     initializer "geoblacklight.helpers" do

--- a/spec/test_app_templates/lib/generators/test_app_generator.rb
+++ b/spec/test_app_templates/lib/generators/test_app_generator.rb
@@ -7,6 +7,15 @@ class TestAppGenerator < Rails::Generators::Base
 
   def add_gems
     gem "blacklight"
+
+    # In CI, Javascript and Webpacker are removed when generating Rails 6.x
+    # applications to enable Vite. Disabling javascript during test app
+    # generation removes Turbolinks. This gem is required and needs to be
+    # re-added.
+    if ENV["RAILS_VERSION"] && Gem::Version.new(ENV["RAILS_VERSION"]) < Gem::Version.new("7.0")
+      gem "turbolinks"
+    end
+
     Bundler.with_clean_env do
       run "bundle install"
     end


### PR DESCRIPTION
Uses vite.config.ts resolve[:alias] to provide path to Rails engine code.

Addresses #1352