### PR TITLE
Vite/JS - Updates to run successfully in EngineCart and from template.rb

### DIFF
--- a/app/frontend/stylesheets/openlayers.css
+++ b/app/frontend/stylesheets/openlayers.css
@@ -1,1 +1,0 @@
-// @import "../../../node_modules/ol/ol.css";

--- a/app/frontend/stylesheets/openlayers.css
+++ b/app/frontend/stylesheets/openlayers.css
@@ -1,1 +1,1 @@
-@import "../../../node_modules/ol/ol.css";
+@import "ol/ol.css";

--- a/app/frontend/stylesheets/openlayers.css
+++ b/app/frontend/stylesheets/openlayers.css
@@ -1,1 +1,0 @@
-@import "../../../node_modules/ol/ol.css";

--- a/app/frontend/stylesheets/openlayers.css
+++ b/app/frontend/stylesheets/openlayers.css
@@ -1,0 +1,1 @@
+@import "../../../node_modules/ol/ol.css";

--- a/app/frontend/stylesheets/openlayers.css
+++ b/app/frontend/stylesheets/openlayers.css
@@ -1,1 +1,1 @@
-@import "../../../node_modules/ol/ol.css";
+// @import "../../../node_modules/ol/ol.css";

--- a/app/frontend/stylesheets/openlayers.css
+++ b/app/frontend/stylesheets/openlayers.css
@@ -1,1 +1,1 @@
-@import "ol/ol.css";
+@import "../../../node_modules/ol/ol.css";

--- a/lib/generators/geoblacklight/install_generator.rb
+++ b/lib/generators/geoblacklight/install_generator.rb
@@ -139,5 +139,9 @@ module Geoblacklight
       copy_file "clover.js", "app/frontend/entrypoints/clover.js"
       copy_file "ol.js", "app/frontend/entrypoints/ol.js"
     end
+
+    def copy_vite_stylesheets
+      copy_file "openlayers.css", "app/frontend/stylesheets/openlayers.css"
+    end
   end
 end

--- a/lib/generators/geoblacklight/templates/clover.js
+++ b/lib/generators/geoblacklight/templates/clover.js
@@ -1,3 +1,7 @@
+import { createElement } from 'react'
+import { createRoot } from 'react-dom/client'
+import Viewer from '@samvera/clover-iiif/viewer'
+
 import CloverInitializer from '@gbl/clover/clover_initializer'
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/lib/generators/geoblacklight/templates/ol.js
+++ b/lib/generators/geoblacklight/templates/ol.js
@@ -1,3 +1,19 @@
+import '../stylesheets/openlayers.css'
+import { Map, View } from 'ol'
+import TileLayer from 'ol/layer/Tile'
+import VectorTile from 'ol/layer/VectorTile'
+import XYZ from 'ol/source/XYZ'
+import GeoJSON from 'ol/format/GeoJSON'
+import { useGeographic } from 'ol/proj'
+import {
+  Style, Stroke, Fill, Circle
+} from 'ol/style'
+import GeoTIFF from 'ol/source/GeoTIFF'
+import WebGLTileLayer from 'ol/layer/WebGLTile'
+import { FullScreen, defaults as defaultControls } from 'ol/control'
+import { PMTilesVectorSource } from 'ol-pmtiles'
+//import { openLayersBasemaps }  from './basemaps'
+
 import OlInitializer from '@gbl/openlayers/ol_initializer'
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/lib/generators/geoblacklight/templates/openlayers.css
+++ b/lib/generators/geoblacklight/templates/openlayers.css
@@ -1,0 +1,1 @@
+@import "../../../node_modules/ol/ol.css";

--- a/lib/generators/geoblacklight/templates/package.json
+++ b/lib/generators/geoblacklight/templates/package.json
@@ -1,7 +1,13 @@
 {
   "devDependencies": {
     "vite": "^5.1.5",
-    "vite-plugin-ruby": "^5.0.0",
-    "vite-plugin-rails": "^0.5.0"
+    "vite-plugin-rails": "^0.5.0",
+    "vite-plugin-ruby": "^5.0.0"
+  },
+  "dependencies": {
+    "@samvera/clover-iiif": "^2.3.2",
+    "ol": "8.1.0",
+    "ol-pmtiles": "^0.3.0",
+    "react": "^18.2.0"
   }
 }


### PR DESCRIPTION
Working to resolve adoption issues with the new Vite/JS features in GBL v4.2 and v4.3 releases.

These changes appear to resolve issues with running Vite/JS inside of EngineCart's .internal_test_app and via a GBL application built by our template.rb script.

The crux here is that pulling JS dependencies and dependency/import paths out of a Rails Engine and into the top-level Rails application is hard.

JS features/functionality would be best packaged into a NPM release for consuming at that top-level application — this is how Blacklight does it and also seems to be the best practice from Webpacker, too:
https://github.com/rails/webpacker/issues/21

