### PR TITLE
Help Text: Include help text for all JS viewer types

### DIFF
--- a/config/locales/geoblacklight.en.yml
+++ b/config/locales/geoblacklight.en.yml
@@ -132,12 +132,21 @@ en:
         tiled_map_layer:
           title: ArcGIS Tiled Map Layer
           content: An ArcGIS Tiled Map Layer Service displays set of web-accessible tiles that reside on a server.
+        tilejson:
+          title: TileJSON
+          content: A JSON format used for describing tilesets.
         tms:
-          title: Tile Map Service
+          title: Tile Map Service (TMS)
           content: A Tile Map Service displays georeferenced map tiles as an image on a map.
         wms:
           title: Web Map Service (WMS)
           content: A Web Map Service displays a geospatial dataset as map images.
+        wmts:
+          title: Web Map Tile Service (WMTS)
+          content: A Web Map Tile Service displays maps over the web using cached image tiles.
+        xyz:
+          title: XYZ Tiles
+          content: Also known as slippy map tiles, is a method of expressing map tile mosaics, indexed by (x,y) offsets and zoom levels (z).
   blacklight:
     icon:
       american-geographical-society-library-uwm-libraries: American Geographical Society Library - UWM Libraries

--- a/lib/generators/geoblacklight/templates/settings.yml
+++ b/lib/generators/geoblacklight/templates/settings.yml
@@ -273,18 +273,21 @@ LEAFLET:
 # Toggle the help text feature that offers users context
 HELP_TEXT:
   viewer_protocol:
+      - 'cog'
       - 'dynamic_map_layer'
       - 'feature_layer'
       - 'iiif'
       - 'iiif_manifest'
       - 'image_map_layer'
       - 'index_map'
-      - 'tiled_map_layer'
-      - 'wms'
-      - 'tms'
       - 'oembed'
       - 'pmtiles'
-      - 'cog'
+      - 'tiled_map_layer'
+      - 'tilejson'
+      - 'tms'
+      - 'wms'
+      - 'wmts'
+      - 'xyz'
 
 # Enable catalog#show sidebar static map for items with the following viewer protocols
 SIDEBAR_STATIC_MAP:


### PR DESCRIPTION
Adds help text entries for the newer viewer types:

* Tiled Map Layer
* TileJSON
* TMS
* WMTS
* XYZ