### PR TITLE
add more specific icons for dataset docs

### DIFF
--- a/app/components/geoblacklight/header_icons_component.rb
+++ b/app/components/geoblacklight/header_icons_component.rb
@@ -12,7 +12,12 @@ module Geoblacklight
 
     def get_icon(field)
       icon_name = @document[field]
+      if icon_name&.include?("Datasets")
+        field = Settings.FIELDS.RESOURCE_TYPE
+        icon_name = @document[field]
+      end
       icon_name = icon_name.is_a?(Array) ? icon_name.first : icon_name
+      icon_name = icon_name.gsub(" data", "") if field == Settings.FIELDS.RESOURCE_TYPE
       geoblacklight_icon(icon_name, classes: "svg_tooltip")
     end
   end

--- a/app/helpers/geoblacklight_helper.rb
+++ b/app/helpers/geoblacklight_helper.rb
@@ -216,11 +216,9 @@ module GeoblacklightHelper
 
   ## Returns the icon used based off a Settings strategy
   def relations_icon(document, icon)
-    icon_name = document[Settings.FIELDS.GEOM_TYPE] if Settings.USE_GEOM_FOR_RELATIONS_ICON
-    icon_name = icon if icon_name.blank?
-    icon_options = {}
-    icon_options = {classes: "svg_tooltip"} if Settings.USE_GEOM_FOR_RELATIONS_ICON
-    geoblacklight_icon(icon_name, **icon_options)
+    icon_html = render Geoblacklight::HeaderIconsComponent.new(document: document, fields: [Settings.FIELDS.GEOM_TYPE]) if Settings.USE_GEOM_FOR_RELATIONS_ICON
+    return icon_html unless !Settings.USE_GEOM_FOR_RELATIONS_ICON || icon_html.include?("icon-missing")
+    geoblacklight_icon(icon, **{})
   end
 
   ## Returns the data-map attribute value used as the JS map selector

--- a/spec/features/search_results_icons_spec.rb
+++ b/spec/features/search_results_icons_spec.rb
@@ -10,7 +10,7 @@ feature "search results display document iconography" do
       q: "stanford-cg357zz0321"
     )
     first_result = page.all("span.status-icons > span")
-    expect(first_result[0][:class]).to include "blacklight-icon-dataset"
+    expect(first_result[0][:class]).to include "blacklight-icon-line"
     expect(first_result[1][:class]).to include "blacklight-icon-stanford"
     expect(first_result[2][:class]).to include "blacklight-icon-restricted"
   end


### PR DESCRIPTION
Closes https://github.com/sul-dlss/earthworks/issues/1045
Closes https://github.com/geoblacklight/geoblacklight/issues/1402

Before search results | After search results

<img width="49%" alt="before" src="https://github.com/geoblacklight/geoblacklight/assets/19173991/56fc0743-4b2b-4c62-a7e4-498b9c8f73ef"><img width="49%" alt="after" src="https://github.com/geoblacklight/geoblacklight/assets/19173991/80aa631f-f838-47fb-9fec-4486dd45b715">


After collection data with Settings.USE_GEOM_FOR_RELATIONS_ICON = true and Settings.FIELDS.GEOM_TYPE = 'gbl_resourceType_sm'

<img width="278" alt="Screenshot 2024-07-08 at 2 55 12 PM" src="https://github.com/geoblacklight/geoblacklight/assets/19173991/00981bae-0df9-4421-80cd-a8c87e6a7828">
<img width="307" alt="Screenshot 2024-07-08 at 2 54 36 PM" src="https://github.com/geoblacklight/geoblacklight/assets/19173991/69bd60df-ad54-416f-8bbb-2df63f4c9da4">
