### PR TITLE
show drag and drop on all items with iiif manifest

### DIFF
--- a/app/components/geoblacklight/iiif_drag_drop_component.rb
+++ b/app/components/geoblacklight/iiif_drag_drop_component.rb
@@ -4,7 +4,8 @@ module Geoblacklight
   class IiifDragDropComponent < ViewComponent::Base
     def initialize(document:)
       super
-      @manifest = document.viewer_endpoint || ""
+      manifest_ref = document.item_viewer&.iiif_manifest
+      @manifest = manifest_ref&.endpoint || ""
       @href_link = Settings.IIIF_DRAG_DROP_LINK&.gsub("@manifest", @manifest)
     end
 

--- a/app/components/geoblacklight/viewer_container_component.html.erb
+++ b/app/components/geoblacklight/viewer_container_component.html.erb
@@ -11,6 +11,6 @@
     <%= render Geoblacklight::ItemMapViewerComponent.new(@document) %>
 
     <!-- IIIF drag and drop component -->
-    <%= render Geoblacklight::IiifDragDropComponent.new(document:@document) if helpers.iiif_manifest_container? %>
+    <%= render Geoblacklight::IiifDragDropComponent.new(document:@document) %>
   </div>
 </div>

--- a/spec/components/geoblacklight/iiif_drag_drop_component_spec.rb
+++ b/spec/components/geoblacklight/iiif_drag_drop_component_spec.rb
@@ -4,7 +4,9 @@ require "spec_helper"
 
 RSpec.describe Geoblacklight::IiifDragDropComponent, type: :component do
   describe "#iiifdragdropcomponet" do
-    let(:document) { instance_double(SolrDocument, id: 123, viewer_endpoint: endpoint) }
+    let(:reference) { instance_double(Geoblacklight::Reference, endpoint: endpoint) }
+    let(:item_viewer) { instance_double(Geoblacklight::ItemViewer, iiif_manifest: reference) }
+    let(:document) { instance_double(SolrDocument, id: 123, item_viewer: item_viewer) }
     let(:component) { described_class.new(document: document) }
     let(:rendered) { render_inline_to_capybara_node(component) }
 


### PR DESCRIPTION
Lack of knowledge about how IIIF worked in geoblacklight. As I have gotten more into this I realize there is a field we can check for IIIF manifest not having to use the helper.

Adds manifest icon to http://localhost:3000/catalog/princeton-fk4544658v-tilejson and http://localhost:3000/catalog/princeton-fk4544658v-wmts