### PR TITLE
increase timeout for downloads

### DIFF
--- a/lib/generators/geoblacklight/templates/settings.yml
+++ b/lib/generators/geoblacklight/templates/settings.yml
@@ -98,7 +98,7 @@ METADATA_SHOWN:
   - 'html'
 
 # (For external Download) timeout and open_timeout parameters for Faraday
-TIMEOUT_DOWNLOAD: 16
+TIMEOUT_DOWNLOAD: 180
 
 # (For WMS inspection) timeout and open_timeout parameters for Faraday
 TIMEOUT_WMS: 4
@@ -215,7 +215,7 @@ RELATIONSHIPS_SHOWN:
     inverse: :VERSION_OF_ANCESTORS
     label: geoblacklight.relations.version_of_descendants
     query_type: descendants
-    
+
 # WMS Parameters
 WMS_PARAMS:
   :SERVICE: 'WMS'


### PR DESCRIPTION
Closes: https://github.com/geoblacklight/geoblacklight/issues/1403

Large files (like the shapefile for https://earthworks.stanford.edu/catalog/stanford-kr064yh0964, which is over 700 MB) take a long time to be generated by the geoserver.  See https://github.com/sul-dlss/earthworks/issues/272  The default timeout of 16 seconds is too short (that file takes nearly 2 minutes to generate).  This bumps the default timeout much higher, which allows it to work.

I'd recommend we should separately
1. provide some user indication that something is happening -- even at 16 seconds, it's a long time after clicking a link to get the alert telling you the download is ready.  For two minutes, people will definitely think nothing has happened.
2. perhaps try to prevent a user from clicking the link twice (maybe something as simple as disable after first click, re-enable when done creating?) ... it's too easy to click the link multiple times and start multiple expensive calls to generate to the geoserver