### PR TITLE
improved download indicator

### DIFF
--- a/app/assets/javascripts/geoblacklight/downloaders/downloader.js
+++ b/app/assets/javascripts/geoblacklight/downloaders/downloader.js
@@ -10,7 +10,7 @@
       L.Util.setOptions(this, options);
       this.$el = $(el);
       this.options.spinner.hide();
-      $('.exports .card-header').append(this.options.spinner);
+      this.$el.before(this.options.spinner);
       this.configureHandler();
     },
 
@@ -26,6 +26,9 @@
       this.downloading = true;
       var url = this.$el.data('downloadPath');
       this.options.spinner.show();
+      this.$el.removeAttr('href');
+      this.$el.prop('disabled', true);
+      this.$el.prop('innerHTML', 'Preparing download...');
       $.getJSON(url)
         .done(L.Util.bind(this.complete, this))
         .fail(L.Util.bind(this.error, this));
@@ -34,12 +37,14 @@
     complete: function(data) {
       this.downloading = false;
       this.$el.prop('disabled', false);
+      this.$el.prop('outerHTML', data[0][1]);
       this.renderMessage(data);
       this.options.spinner.hide();
     },
 
     error: function(data) {
       this.downloading = false;
+      this.$el.prop('innerHTML', 'Download failed');
       this.$el.prop('disabled', false);
       this.options.spinner.hide();
     },


### PR DESCRIPTION
Attempt at fixing #1406.  May benefit from further UI refinements (like what is shown in https://github.com/sul-dlss/earthworks/issues/1092#issuecomment-2234348441)

Here is what it looks like with this PR:

![download](https://github.com/user-attachments/assets/02222822-c60b-4221-8149-0a4120f6a07a)
