### PR TITLE
Fix viewer sizing for OpenLayers and IIIF viewers

### DIFF
--- a/app/assets/stylesheets/geoblacklight/modules/item.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/item.scss
@@ -10,14 +10,10 @@
       border: 1px solid $gray-400;
       min-height: 27.5rem;
 
-      // Ensure oembed iframe is the same height as its container
-      iframe {
+      // Ensure embeds, openlayers viewer, and IIIF viewer fit their container
+      iframe, .ol-viewport, .clover-iiif-image-openseadragon {
         min-height: 27.5rem;
       }
-    }
-
-    .clover-iiif-image-openseadragon, .ol-viewport {
-      height: 100vh!important;
     }
 
     [data-inspect="true"][data-available="true"] {

--- a/app/javascript/controllers/clover_viewer_controller.js
+++ b/app/javascript/controllers/clover_viewer_controller.js
@@ -26,10 +26,16 @@ export default class CloverViewerController extends Controller {
 
   getViewer(protocol, url) {
     if (protocol == "Iiif") {
-      return createElement(Image, {
-        src: url.replace(/\/info\.json$/, ""),
-        isTiledImage: true,
-      });
+      // Create a wrapper div with inline style, as recommended in the docs:
+      // https://samvera-labs.github.io/clover-iiif/docs/image#react
+      return createElement(
+        "div",
+        { style: { height: 400 } },
+        createElement(Image, {
+          src: url.replace(/\/info\.json$/, ""),
+          isTiledImage: true,
+        })
+      );
     }
     if (protocol == "IiifManifest")
       return createElement(Viewer, {


### PR DESCRIPTION
Setting a page-relative height with !important caused these viewers to be much larger than their container and have their content render off-center.

PMTiles:

![Screenshot 2024-07-26 at 10 25 24](https://github.com/user-attachments/assets/261cd07a-7514-4c3e-8a44-1030b1fafe95)

COG (still has a data problem?):

![Screenshot 2024-07-26 at 10 25 19](https://github.com/user-attachments/assets/7d6fff9b-16ce-4ba3-82a8-fcd7daed8306)

IIIF (now centered):

![Screenshot 2024-07-26 at 10 25 10](https://github.com/user-attachments/assets/6980444b-e30d-44bf-a4fb-fc8babb40cfe)

Notably, this doesn't fix the IIIF viewer (not the manifest one, just a single IIIF image). It seems to have some kind of height calculation problem. This might be a bug in Clover's single-image viewer, or just a configuration issue?

![Screenshot 2024-07-26 at 10 23 43](https://github.com/user-attachments/assets/8fedcad9-d110-477a-b60d-d692e62e8ef2)
