### PR TITLE
Remove special handling for stimulus and turbo gems

### DIFF
--- a/spec/test_app_templates/lib/generators/test_app_generator.rb
+++ b/spec/test_app_templates/lib/generators/test_app_generator.rb
@@ -8,22 +8,9 @@ class TestAppGenerator < Rails::Generators::Base
   def add_gems
     gem "blacklight"
 
-    # In CI, Javascript and Webpacker are removed when generating Rails 6.x
-    # applications to enable Vite. Disabling javascript during test app
-    # generation removes Turbolinks. This gem is required and needs to be
-    # re-added.
-    if ENV["RAILS_VERSION"] && Gem::Version.new(ENV["RAILS_VERSION"]) < Gem::Version.new("7.0")
-      gem "turbo-rails"
-      gem "stimulus-rails"
-    end
-
     Bundler.with_clean_env do
       run "bundle install"
     end
-  end
-
-  def stimulus_generator
-    rails_command "stimulus:install"
   end
 
   def build_frontend


### PR DESCRIPTION
We now only support Rails 7, and no longer build the test app
without javascript, so these Hotwire libraries will always be
installed automatically and don't need special handling.
