### PR TITLE
allow for image mapping

### DIFF
--- a/app/helpers/geoblacklight_helper.rb
+++ b/app/helpers/geoblacklight_helper.rb
@@ -28,6 +28,7 @@ module GeoblacklightHelper
   # TODO: Remove linter disable after lowest supported Ruby version >= 3.2
   def geoblacklight_icon(name, **args)
     icon_name = name ? name.to_s.parameterize : "none"
+    icon_name = Settings.ICON_MAPPING && Settings.ICON_MAPPING[icon_name] || icon_name
     camel_icon = icon_name.tr("-", "_").camelize.delete(" ")
     begin
       render "Blacklight::Icons::#{camel_icon}Component".constantize.new(name: icon_name, **args)

--- a/lib/generators/geoblacklight/templates/settings.yml
+++ b/lib/generators/geoblacklight/templates/settings.yml
@@ -268,3 +268,17 @@ SIDEBAR_STATIC_MAP:
   - 'iiif_manifest'
 
 IIIF_DRAG_DROP_LINK: '@manifest?manifest=@manifest'
+
+ICON_MAPPING:
+  chicago: university-of-chicago
+  illinois: university-of-illinois-urbana-champaign
+  iowa: university-of-iowa
+  maryland: university-of-maryland
+  michigan-state: michigan-state-university
+  michigan: university-of-michigan
+  minnesota: university-of-minnesota
+  nebraska: university-of-nebraska-lincoln
+  ohio-state: the-ohio-state-university
+  penn-state: pennsylvania-state-university
+  purdue: purdue-university
+  wisconsin: university-of-wisconsin-madison

--- a/spec/helpers/geoblacklight_helper_spec.rb
+++ b/spec/helpers/geoblacklight_helper_spec.rb
@@ -23,6 +23,10 @@ describe GeoblacklightHelper, type: :helper do
       html = Capybara.string(geoblacklight_icon(nil))
       expect(html).to have_css ".icon-missing"
     end
+    it "works with settings icon mapping" do
+      html = Capybara.string(geoblacklight_icon("ohio-state"))
+      expect(html).to have_css ".blacklight-icons-the-ohio-state-university"
+    end
   end
 
   describe "#geoblacklight_basemap" do


### PR DESCRIPTION
and allow for legacy icons removed in PR #1386 to continue to render

closes #1446

This PR provides two pieces of functionality. 

1. It allows users of old versions of geoblacklight who are using old icons and don't want to update their data to continue to have icons appear.
2. It allows for icons to display when they don't match the icon name without having to create a totally new icon. For example, in the big10 geo portal there is a provider named `UW-Madison Robinson Map Library`. If the user wanted an icon to display for that provider that was the university_of_wisconsin_madison icon they would have to create a new icon component. With this PR they will just have to add a line to the settings file.
```
uw-madison-robinson-map-library: university-of-wisconsin-madison
```
