### PR TITLE
Build demo app in CI an push docker images

### DIFF
--- a/.github/workflows/build-demo-app.yml
+++ b/.github/workflows/build-demo-app.yml
@@ -1,0 +1,153 @@
+name: Build demo app
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "0 1 * * SUN"  # every sunday at 1AM
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+  BRANCH: ${{ github.head_ref || github.ref_name }}
+
+jobs:
+  build-app:
+    runs-on: ubuntu-latest
+    outputs:
+      artifact-url: ${{ steps.artifact-upload-step.outputs.artifact-url }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.3
+
+      - name: Install dependencies
+        run: bundle install
+        env:
+          RAILS_VERSION: 7.1.3
+
+      - name: Setup Yarn
+        run: exec "yarnpkg"
+
+      - name: Build
+        run: BRANCH=${{ env.BRANCH }} rails new build -m template.rb -a propshaft
+
+      - name: Copy Dockerfile
+        run: cp lib/generators/geoblacklight/templates/docker/demo-app-Dockerfile build/Dockerfile
+
+      - name: Copy compose.yml
+        run: cp lib/generators/geoblacklight/templates/docker/demo-app-compose.yml build/compose.yml
+
+      - name: Copy start-server script
+        run: cp lib/generators/geoblacklight/templates/docker/start-server.sh build/.
+
+      - name: Copy fixture solr documents
+        run:  mkdir -p build/spec/fixtures && cp -R spec/fixtures/solr_documents build/spec/fixtures/.
+
+      - name: Replace main image tag with pr tag
+        if: github.ref_name != 'main'
+        run: sed -i 's/main/pr-${{ github.event.number }}/g'  build/compose.yml
+
+      - name: Cleanup
+        run: rm -rf build/node_modules build/Gemfile.lock build/yarn.lock build/tmp
+
+      - name: Upload app build
+        uses: actions/upload-artifact@v4
+        id: artifact-upload-step
+        with:
+          name: build-${{ env.BRANCH }}
+          path: build/
+
+  build-docker:
+    runs-on: ubuntu-latest
+    needs:
+      - build-app
+    steps:
+      - name: Download app build
+        uses: actions/download-artifact@v4
+        with:
+          name: build-${{ env.BRANCH }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha
+        env:
+          DOCKER_METADATA_PR_HEAD_SHA: true
+
+        # Rebuild base context when updating the main branch.
+      - name: Build and push main Docker image
+        uses: docker/build-push-action@v6
+        if: github.ref_name == 'main'
+        with:
+          context: "${{ github.workspace }}"
+          file: "${{ github.workspace }}/Dockerfile"
+          push: true
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          tags: ghcr.io/geoblacklight/geoblacklight:base
+          target: "base"
+
+        # Build only the app context. Build times are faster because most
+        # gems and node packages are already installed in the base context.
+      - name: Build and push branch Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: "${{ github.workspace }}"
+          file: "${{ github.workspace }}/Dockerfile"
+          push: true
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          target: "app"
+
+  notify:
+    runs-on: ubuntu-latest
+    if: github.ref_name != 'main'
+    needs:
+      - build-app
+      - build-docker
+    permissions:
+      contents: read
+      packages: write
+      pull-requests: write
+    steps:
+      - name: Add artifact link to PR comments
+        uses: mshick/add-pr-comment@v2
+        with:
+          message: |
+            Demo app download link: ${{ needs.build-app.outputs.artifact-url }}
+
+            1. Download demo app and unzip file
+            2. Change into app directory
+                - run `docker compose pull`
+                - run `docker compose up`
+            3. Open in browser
+                - App:  http://127.0.0.1:3001
+                - Solr: http://127.0.0.1:8984

--- a/.github/workflows/prune-containers.yml
+++ b/.github/workflows/prune-containers.yml
@@ -1,0 +1,18 @@
+name: Prune containers
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * SUN"  # every sunday at midnight
+
+jobs:
+  clean:
+    runs-on: ubuntu-latest
+    name: Delete old images
+    steps:
+      - uses: snok/container-retention-policy@v3.0.0
+        with:
+          account: geoblacklight
+          token: ${{ secrets.GITHUB_TOKEN }}
+          image-tags: "!main !base"
+          cut-off: 4w

--- a/lib/generators/geoblacklight/templates/docker/demo-app-Dockerfile
+++ b/lib/generators/geoblacklight/templates/docker/demo-app-Dockerfile
@@ -1,0 +1,31 @@
+# syntax = docker/dockerfile:1
+
+# Make sure RUBY_VERSION matches the Ruby version in .ruby-version and Gemfile
+ARG RUBY_VERSION=3.3.4
+FROM registry.docker.com/library/ruby:$RUBY_VERSION-slim AS base
+
+RUN apt-get update -qq && \
+    apt-get install --no-install-recommends -y build-essential git pkg-config nodejs npm curl libsqlite3-0
+
+RUN npm install --global yarn
+
+ENV RAILS_ENV="development" \
+    BUNDLE_PATH="/usr/local/bundle"
+
+# Rails app lives here
+WORKDIR /rails
+
+# Install gems and javascript packages
+COPY Gemfile .
+RUN bundle install
+COPY package.json .
+RUN yarn install
+
+FROM ghcr.io/geoblacklight/geoblacklight:base AS app
+
+# Add application code
+COPY . .
+
+# Run the server script by default, this can be overwritten at runtime
+EXPOSE 3000
+CMD ["sh", "start-server"]

--- a/lib/generators/geoblacklight/templates/docker/demo-app-compose.yml
+++ b/lib/generators/geoblacklight/templates/docker/demo-app-compose.yml
@@ -1,0 +1,26 @@
+services:
+  app:
+    image: ghcr.io/geoblacklight/geoblacklight:main
+    ports:
+      - "3001:3000"
+    links:
+      - "solr:solr"
+    environment:
+      SOLR_URL: "http://solr:8983/solr/blacklight-core"
+      RAILS_DEVELOPMENT_HOSTS: ".githubpreview.dev,.preview.app.github.dev,.app.github.dev,.csb.app"
+    depends_on:
+      - solr
+    command: sh start-server.sh
+  solr:
+    image: "solr:latest"
+    ports:
+      - "8984:8983"
+    volumes:
+      - "./solr/conf:/opt/solr/conf"
+    entrypoint:
+      - docker-entrypoint.sh
+      - solr-precreate
+      - blacklight-core
+      - /opt/solr/conf
+      - "-Xms256m"
+      - "-Xmx512m"

--- a/lib/generators/geoblacklight/templates/docker/start-server.sh
+++ b/lib/generators/geoblacklight/templates/docker/start-server.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+bundle install
+yarn install
+bundle exec rake db:prepare
+bundle exec rake geoblacklight:index:seed
+bundle exec rails server -b 0.0.0.0


### PR DESCRIPTION
Build demo/test apps as artifacts and create docker images from them.

- On pull request and main branch push, build demo apps using the template.rb file.
- Generate a docker image from the test app and push into the GitHub package repository.
- Bundle a docker compose file with the downloadable build which runs solr and gbl app.
- Add comment to pull request with link for downloading the build.
- Prune old images monthly.
- Regenerate a new main branch image weekly.

Closes #1448 