### PR TITLE
Add docker compose option for solr only and modify Rakefile

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,14 @@
+services:
+  solr:
+    image: solr:latest
+    volumes:
+      - $PWD/solr/conf:/opt/solr/conf
+    ports:
+      - 8983:8983
+    entrypoint:
+      - docker-entrypoint.sh
+      - solr-precreate
+      - blacklight-core
+      - /opt/solr/conf
+      - "-Xms256m"
+      - "-Xmx512m"


### PR DESCRIPTION
Downloading and building Solr and the rebuilding of internal test app so many times was a pain point for our dev team. This PR is meant to make development easier and is not related to production builds. It removes a redundant `engine_cart:generate` statement, adds an option to run Solr in docker, and makes it easier overall to run Solr and the application separately. I followed the pattern we used in Arclight development, another downstream-from-Blacklight rails engine, which has worked pretty well for us.

If approved, I have drafted updated documentation that I will PR in that repo.

