### PR TITLE
Center the search bar

### DIFF
--- a/app/assets/stylesheets/geoblacklight/modules/_blacklight_overrides.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/_blacklight_overrides.scss
@@ -41,3 +41,8 @@ auto-complete {
 #main-container {
   padding-top: 1rem;
 }
+
+// center contents of the container that holds the search bar
+.navbar-search.navbar > .container {
+  justify-content: center;
+}

--- a/app/assets/stylesheets/geoblacklight/modules/_blacklight_overrides.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/_blacklight_overrides.scss
@@ -42,7 +42,12 @@ auto-complete {
   padding-top: 1rem;
 }
 
-// center contents of the container that holds the search bar
-.navbar-search.navbar > .container {
+// center contents of the container that holds the search bar on the home page
+.jumbotron ~ .navbar-search.navbar .container {
   justify-content: center;
+}
+
+// add padding around the container that holds the search bar (on all pages)
+.navbar-search.navbar .container {
+  padding: 1rem;
 }

--- a/app/components/geoblacklight/header_component.html.erb
+++ b/app/components/geoblacklight/header_component.html.erb
@@ -1,8 +1,7 @@
 <header>
   <%= top_bar %>
-  <%= search_bar %>
   <% if landing_page? %>
-  <div class='p-5 mb-4 bg-light'>
+  <div class='p-5 bg-light jumbotron'>
     <div class='d-flex justify-content-center'>
       <%= content_tag :h1, t('geoblacklight.home.headline'), class: 'text-center display-5 fw-bold' %>
     </div>
@@ -10,5 +9,6 @@
       <%= content_tag :h2, t('geoblacklight.home.search_heading'), class: 'text-center fs-4' %>
     </div>
   </div>
-  <% end %>
+  <% end %>  
+  <%= search_bar %>
 </header>


### PR DESCRIPTION
According to the screenshots in the thread for PR #1441, the search bar should be centered, but correct me if I am wrong@!

### Before

<img width="1507" alt="Screenshot 2024-08-07 at 10 00 51" src="https://github.com/user-attachments/assets/851c4eed-4cf8-467f-b3c5-93476fa4ce3e">
<img width="1379" alt="Screenshot 2024-08-07 at 10 09 16" src="https://github.com/user-attachments/assets/b8dda5ab-272f-4bef-bc95-647449d7ed5f">



### After

<img width="1512" alt="Screenshot 2024-08-14 at 13 53 11" src="https://github.com/user-attachments/assets/3f0352ee-f76a-439c-b79e-65ad8f9d08d2">
<img width="1501" alt="Screenshot 2024-08-14 at 13 53 19" src="https://github.com/user-attachments/assets/2876548a-60ca-43bb-bf3e-4ff43cc308f5">

