### PR TITLE
Add attribute inspection as sidebar on the map

### DIFF
--- a/app/assets/stylesheets/geoblacklight/modules/item.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/item.scss
@@ -49,13 +49,30 @@
     -webkit-line-clamp: 8;
   }
 
-  #table-container{
-    overflow: auto;
-    max-height: 450px;
+  #table-container {
     margin-bottom: 1rem;
 
     table {
       margin-bottom: 0px;
+    }
+  }
+
+  .attribute-data {
+    --bs-accordion-active-bg: none;
+  }
+
+  .sidebar-container {
+    width: 25vw;
+    overflow: scroll;
+    overscroll-behavior: contain;
+
+    img {
+      width: 100%;
+    }
+
+    @media screen and (max-width: breakpoint-max(sm)) {
+      width: calc(100vw - 100px);
+      max-height: 20vh!important;
     }
   }
 }

--- a/app/components/geoblacklight/accordion_component.html.erb
+++ b/app/components/geoblacklight/accordion_component.html.erb
@@ -1,0 +1,16 @@
+<div data-sidebar="<%= Settings.LEAFLET.SIDEBAR %>">
+  <div class="accordion attribute-data<% if Settings.LEAFLET.SIDEBAR %> sidebar-container<% end %>">
+    <div class="accordion-item">
+      <h2 class="accordion-header" id="accordionHeading">
+        <button class="accordion-button p-2 border-none bg-none" type="button" data-bs-toggle="collapse" data-bs-target="#<%= @id %>" aria-expanded="true" aria-controls="<%= @id %>">
+          <%= @title %>
+        </button>
+      </h2>
+      <div id="<%= @id %>" class="accordion-collapse collapse show" aria-labelledby="accordionHeading" data-bs-parent="#accordionHeading">
+        <div class="accordion-body p-0">
+          <%= content %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/components/geoblacklight/accordion_component.rb
+++ b/app/components/geoblacklight/accordion_component.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Geoblacklight
+  class AccordionComponent < ViewComponent::Base
+    def initialize(id:, title:)
+      @id = id
+      @title = title
+      super()
+    end
+  end
+end

--- a/app/components/geoblacklight/attribute_table_component.html.erb
+++ b/app/components/geoblacklight/attribute_table_component.html.erb
@@ -1,17 +1,15 @@
-<div class='row'>
-  <div id='table-container' class='col-md-12'>
-    <table id="attribute-table" class="table table-hover table-condensed table-striped table-bordered col-md-12">
-      <thead>
-        <tr>
-          <th><%= t('geoblacklight.show.attribute') %></th>
-          <th><%= t('geoblacklight.show.value') %></th>
-        </tr>
-      </thead>
-      <tbody class='attribute-table-body'>
-        <tr>
-          <td class='default-text' colspan='2'><em><%= t('geoblacklight.show.click_map') %></em></td>
-        </tr>
-      </tbody>
-    </table>
-  </div>
-</div>
+<%= render Geoblacklight::AccordionComponent.new(id: 'attribute-table', title: t('geoblacklight.show.table_name')) do  %>
+  <table id="attribute-table" class="table table-hover table-condensed table-striped mb-0 collapse show">
+    <thead>
+      <tr>
+        <th><%= t('geoblacklight.show.attribute') %></th>
+        <th><%= t('geoblacklight.show.value') %></th>
+      </tr>
+    </thead>
+    <tbody class='attribute-table-body'>
+      <tr>
+        <td class='default-text' colspan='2'><em><%= t('geoblacklight.show.click_map') %></em></td>
+      </tr>
+    </tbody>
+  </table>
+<% end %>

--- a/app/components/geoblacklight/index_map_inspect_component.html.erb
+++ b/app/components/geoblacklight/index_map_inspect_component.html.erb
@@ -1,4 +1,5 @@
-<div class='row'>
-  <div class='viewer-information col-sm-12'>
+<%= render Geoblacklight::AccordionComponent.new(id: 'index-map-attributes', title: t('geoblacklight.show.table_name')) do  %>
+  <div class='viewer-information px-3'>
+    <em><%= t('geoblacklight.show.click_map') %></em>
   </div>
-</div>
+<% end %>

--- a/app/javascript/geoblacklight/controllers/leaflet_viewer_controller.js
+++ b/app/javascript/geoblacklight/controllers/leaflet_viewer_controller.js
@@ -23,6 +23,7 @@ import {
 } from "geoblacklight/leaflet/layers";
 import { geoJSONToBounds } from "geoblacklight/leaflet/utils";
 import { DEFAULT_BOUNDS, DEFAULT_OPACITY, DEFAULT_GEOM_OVERLAY_OPTIONS } from "geoblacklight/leaflet/constants";
+import sidebarControl from "geoblacklight/leaflet/controls/sidebar";
 
 export default class LeafletViewerController extends Controller {
   static values = {
@@ -146,7 +147,7 @@ export default class LeafletViewerController extends Controller {
     if (controlName == "Opacity")
       return new LayerOpacityControl(this.previewOverlay);
     if (controlName == "Fullscreen")
-      return new FullScreen({ position: "topright", ...controlOptions });
+      return new FullScreen({ position: "bottomleft", ...controlOptions });
     if (controlName == "Geosearch")
       return new GeoSearchControl({ baseUrl: this.catalogBaseUrlValue, ...controlOptions });
     console.error(`Unsupported control name: "${controlName}"`);
@@ -179,10 +180,23 @@ export default class LeafletViewerController extends Controller {
     if (this.boundsOverlay) this.overlay.removeLayer(this.boundsOverlay);
   }
 
+  setUpSidebar() {
+    const sidebar = document.querySelector('[data-sidebar]')
+    if (!sidebar || sidebar.dataset.sidebar != 'true') return;
+    const control = new sidebarControl({
+      position: 'topright',
+      sidebar
+    });
+    this.map.addControl(control);
+  }
+
   addInspection() {
+    const inspectionProtocols = ['Wms', 'FeatureLayer', 'DynamicMapLayer', 'IndexMap']
+    if (!inspectionProtocols.includes(this.protocolValue)) return;
+    this.setUpSidebar();
     if (this.protocolValue == "Wms") return wmsInspection(this.map, this.urlValue, this.layerIdValue, this.previewOverlay);
     if (this.protocolValue == "FeatureLayer") return featureLayerInspection(this.map, this.previewOverlay);
-    if (this.protocolValue  == "DynamicMapLayer") return dynamicMapLayerInspection(this.map, this.previewOverlay, this.layerIdValue)
+    if (this.protocolValue  == "DynamicMapLayer") return dynamicMapLayerInspection(this.map, this.previewOverlay, this.layerIdValue);
     // TODO: TiledMapLayer is converted but seems busted -- see layers.js. Don't know what to test it with, need a fixture.
     // if (this.protocolValue == "TiledMapLayer") return tiledMapLayerInspection(this.map, this.previewOverlay);
   }

--- a/app/javascript/geoblacklight/leaflet/controls/sidebar.js
+++ b/app/javascript/geoblacklight/leaflet/controls/sidebar.js
@@ -1,0 +1,47 @@
+import { Control } from "leaflet";
+
+export default class sidebarControl extends Control {
+  constructor(options) {
+    const _options = { ...options };
+    super(_options);
+  }
+
+  onAdd(map) {
+    var div = L.DomUtil.create('div', 'leaflet-sidebar');
+    div.setAttribute("tabindex", "0");
+    const sidebarContainer = this.options.sidebar;
+
+    // Disable zoom when the mouse enters the sidebar
+    div.addEventListener('mouseenter', function() {
+      map.scrollWheelZoom.disable();
+    });
+
+    div.addEventListener('touchstart', function() {
+      map.touchZoom.disable();
+      map.dragging.disable();
+    });
+
+    // without this the map will try to find data about whatever is behind the sidebar
+    div.addEventListener('click', function(event) {
+      event.stopPropagation();
+    });
+
+    // Enable zoom when the mouse leaves the sidebar
+    div.addEventListener('touchend', function() {
+      map.touchZoom.enable();
+      map.dragging.enable();
+    });
+
+    // Enable zoom when the mouse leaes the sidebar
+    div.addEventListener('mouseleave', function() {
+      map.scrollWheelZoom.enable();
+    });
+
+    if (!sidebarContainer) { return };
+    // Make sure table height is same as map (with a little padding)
+    sidebarContainer.children[0].style.maxHeight = `${map._container.offsetHeight - 30}px`;
+    div.innerHTML = sidebarContainer.innerHTML;
+    sidebarContainer.remove();
+    return div;
+  }
+}

--- a/config/locales/geoblacklight.en.yml
+++ b/config/locales/geoblacklight.en.yml
@@ -93,6 +93,7 @@ en:
       attribute: 'Attribute'
       value: 'Value'
       click_map: 'Click on map to inspect values'
+      table_name: 'Map data'
     help_text:
       viewer_protocol:
         cog:

--- a/lib/generators/geoblacklight/templates/settings.yml
+++ b/lib/generators/geoblacklight/templates/settings.yml
@@ -247,6 +247,7 @@ LEAFLET:
     HOVERTOWAKE: false
     MESSAGE: 'Click to Wake'
     BACKGROUND: 'rgba(214, 214, 214, .7)'
+  SIDEBAR: false # set to true to display attribute table as sidebar on map
   LAYERS:
     DETECT_RETINA: true
     INDEX:


### PR DESCRIPTION
closes #1576. Move the full screen to the lower left hand corner because it looks weird with the sidebar 

## DEFAULT
### Changes
- add map data header that is collapsible
- add instructions to index maps
- moves full screen button below opacity bar

<img width="756" height="462" alt="Screenshot 2025-07-30 at 2 50 46 PM" src="https://github.com/user-attachments/assets/a63df381-d7eb-4ecc-88d4-0db76134d0c4" />
<img width="708" height="786" alt="Screenshot 2025-07-30 at 2 50 43 PM" src="https://github.com/user-attachments/assets/96718ecb-e6a3-41e7-8c91-100615e21e19" />
<img width="735" height="579" alt="Screenshot 2025-07-30 at 2 50 38 PM" src="https://github.com/user-attachments/assets/da5dd527-7ebe-4014-950d-fdd247b8f4cf" />



## With SIDEBAR set
Mobile view
<img width="505" height="501" alt="Screenshot 2025-07-30 at 2 50 02 PM" src="https://github.com/user-attachments/assets/2930ad96-e91d-4c43-858a-6e54eb8804db" />
<img width="520" height="472" alt="Screenshot 2025-07-30 at 2 49 57 PM" src="https://github.com/user-attachments/assets/aaaad86d-5266-462a-9b78-98f39b094342" />
<img width="741" height="498" alt="Screenshot 2025-07-30 at 2 50 21 PM" src="https://github.com/user-attachments/assets/285aa4fd-bdc2-447b-84e8-3bab41e9873a" />
<img width="758" height="509" alt="Screenshot 2025-07-30 at 2 50 17 PM" src="https://github.com/user-attachments/assets/3dd4a311-5b1c-4d62-987f-781571a482ef" />
<img width="729" height="503" alt="Screenshot 2025-07-30 at 2 50 13 PM" src="https://github.com/user-attachments/assets/1e9455a9-f1a5-4968-bb63-fe19c43148db" />
<img width="772" height="514" alt="Screenshot 2025-07-30 at 2 49 49 PM" src="https://github.com/user-attachments/assets/9d677d81-2831-4c9c-b002-f8e03d668807" />
<img width="786" height="533" alt="Screenshot 2025-07-30 at 2 49 46 PM" src="https://github.com/user-attachments/assets/1249c6ac-badd-44f2-a8e9-949f95ba3368" />


