### PR TITLE
Remove obsolete engine_cart option

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ else
   if ENV["RAILS_VERSION"]
     if ENV["RAILS_VERSION"] == "edge"
       gem "rails", github: "rails/rails"
-      ENV["ENGINE_CART_RAILS_OPTIONS"] = "--edge --skip-turbolinks"
+      ENV["ENGINE_CART_RAILS_OPTIONS"] = "--edge"
     else
       gem "rails", ENV["RAILS_VERSION"]
     end


### PR DESCRIPTION
this rails option only works for Rails 6 and before, when turbo was turbolinks. it does nothing now.