### PR TITLE
Remove unused jquery-related generator code

### DIFF
--- a/lib/generators/geoblacklight/install_generator.rb
+++ b/lib/generators/geoblacklight/install_generator.rb
@@ -81,13 +81,6 @@ module Geoblacklight
       end
     end
 
-    # Turn off JQuery animations during testing
-    def inject_disable_jquery_animations
-      inject_into_file "app/views/layouts/application.html.erb", before: "</head>" do
-        "  <%= javascript_tag '$.fx.off = true;' if Rails.env.test? %>\n"
-      end
-    end
-
     def create_downloads_directory
       FileUtils.mkdir_p("tmp/cache/downloads") unless File.directory?("tmp/cache/downloads")
     end


### PR DESCRIPTION
We don't use jQuery anymore, so no need to inject code about disabling animations.