### PR TITLE
Use bundler.with_unbundled_env

### DIFF
--- a/spec/test_app_templates/lib/generators/test_app_generator.rb
+++ b/spec/test_app_templates/lib/generators/test_app_generator.rb
@@ -8,7 +8,7 @@ class TestAppGenerator < Rails::Generators::Base
   def add_gems
     gem "blacklight"
 
-    Bundler.with_clean_env do
+    Bundler.with_unbundled_env do
       run "bundle install"
     end
   end


### PR DESCRIPTION
This fixes a deprecation warning; `.with_clean_env` was deprecated: https://github.com/castwide/solargraph/issues/252