### PR TITLE
Adjust style paths so Vite aliases aren't needed

### DIFF
--- a/app/assets/stylesheets/geoblacklight/geoblacklight.scss
+++ b/app/assets/stylesheets/geoblacklight/geoblacklight.scss
@@ -1,9 +1,2 @@
-// Leaflet
-@import "../../../node_modules/leaflet/dist/leaflet.css";
-@import "../../../node_modules/leaflet-fullscreen/dist/leaflet.fullscreen.css";
-
-// OpenLayers
-@import "../../../node_modules/ol/ol.css";
-
-// GeoBlacklight
+// GeoBlacklight styles entrypoint
 @import 'modules/base';

--- a/lib/generators/geoblacklight/assets_generator.rb
+++ b/lib/generators/geoblacklight/assets_generator.rb
@@ -16,7 +16,8 @@ module Geoblacklight
 
     # Add our own stylesheets that reference the versions from npm
     def add_stylesheets
-      copy_file "assets/_customizations.scss", "app/javascript/entrypoints/_customizations.scss"
+      copy_file "assets/_customizations.scss", "app/javascript/stylesheets/_customizations.scss"
+      copy_file "assets/geoblacklight.scss", "app/javascript/stylesheets/geoblacklight.scss"
       copy_file "assets/application.scss", "app/javascript/entrypoints/application.scss"
     end
 

--- a/lib/generators/geoblacklight/templates/assets/_customizations.scss
+++ b/lib/generators/geoblacklight/templates/assets/_customizations.scss
@@ -1,8 +1,7 @@
 // Local Application Customizations
 
 // Set Header Logo
-// @geoblacklight_images is a vite path alias set in vite.config.js
-$logo-image: url('@geoblacklight_images/blacklight/logo.svg');
+$logo-image: url('@geoblacklight/frontend/dist/images/blacklight/logo.svg');
 
 .navbar-brand {  /* The main logo image for the Blacklight instance */
   @if $logo-image {

--- a/lib/generators/geoblacklight/templates/assets/application.scss
+++ b/lib/generators/geoblacklight/templates/assets/application.scss
@@ -1,11 +1,9 @@
-// Local customizations (import first, so that variables take precedence)
-@import 'customizations';
+/* Main application styles entrypoint */
 
-// Bootstrap (will use variables defined in customizations, if present)
-@import '../../../node_modules/bootstrap/scss/bootstrap.scss';
+// Leaflet, OpenLayers, GeoBlacklight (includes Blacklight and Bootstrap)
+@import "leaflet/dist/leaflet.css";
+@import "leaflet-fullscreen/dist/leaflet.fullscreen.css";
+@import "ol/ol.css";
+@import "~/stylesheets/geoblacklight.scss";
 
-// Blacklight, imported from blacklight-frontend package
-@import '../../../node_modules/blacklight-frontend/app/assets/stylesheets/blacklight/blacklight.scss';
-
-// Geoblacklight, imported from @geoblacklight/frontend package
-@import '../../../node_modules/@geoblacklight/frontend/dist/stylesheets/geoblacklight/geoblacklight.scss';
+// Your styles here!

--- a/lib/generators/geoblacklight/templates/assets/geoblacklight.scss
+++ b/lib/generators/geoblacklight/templates/assets/geoblacklight.scss
@@ -1,0 +1,11 @@
+// Local customizations (import first, so that variables take precedence)
+@import 'customizations.scss';
+
+// Bootstrap (will use variables defined in customizations, if present)
+@import 'bootstrap/scss/bootstrap.scss';
+
+// Blacklight, imported from blacklight-frontend package
+@import 'blacklight-frontend/app/assets/stylesheets/blacklight/blacklight.scss';
+
+// Geoblacklight, imported from @geoblacklight/frontend package
+@import '@geoblacklight/frontend/app/assets/stylesheets/geoblacklight/geoblacklight.scss';

--- a/lib/generators/geoblacklight/templates/vite.config.ts
+++ b/lib/generators/geoblacklight/templates/vite.config.ts
@@ -1,6 +1,5 @@
 import { defineConfig } from 'vite'
 import rails from 'vite-plugin-rails'
-import path from 'path'
 
 export default defineConfig(({ mode }) => {
   return {
@@ -12,11 +11,5 @@ export default defineConfig(({ mode }) => {
     plugins: [
       rails(),
     ],
-    resolve: {
-      alias: {
-        '@leaflet_images': path.resolve(__dirname, './node_modules/@geoblacklight/frontend/node_modules/leaflet/dist/images'),
-        '@geoblacklight_images': path.resolve(__dirname, './node_modules/@geoblacklight/frontend/dist/images')
-      }
-    }
   }
 })


### PR DESCRIPTION
This shifts the structure of the stylesheet to separate building
Geoblacklight's styles from the application itself, so it's a
little more clear where things are coming from.

By taking the imports out of the stylesheet in the gem and moving
them into the generated app, we can get rid of some weird-looking
paths and aliases in Vite.
