### PR TITLE
Revert to using `yarn link` so changes are picked up in development

### DIFF
--- a/lib/generators/geoblacklight/install_generator.rb
+++ b/lib/generators/geoblacklight/install_generator.rb
@@ -110,19 +110,35 @@ module Geoblacklight
       copy_file "package.json", "package.json"
     end
 
+    # Pick a version of the frontend asset package and install it.
+    def add_frontend
+      # If in local development or CI, install the version we made linkable in
+      # the test app generator. This will make it so changes made in the outer
+      # directory are picked up automatically, like a symlink. Note that this
+      # does NOT install the dependencies of the package, so we have to make
+      # sure to install those separately. See:
+      # https://classic.yarnpkg.com/lang/en/docs/cli/link/
+      # https://github.com/yarnpkg/yarn/issues/2914
+      if options[:test]
+        run "yarn link @geoblacklight/frontend"
+
+      # If a branch was specified (e.g. you are running a template.rb build
+      # against a test branch), use the latest version available on npm
+      elsif ENV["BRANCH"]
+        run "yarn add @geoblacklight/frontend@latest"
+
+      # Otherwise, pick the version from npm that matches our Geoblacklight
+      # gem version
+      else
+        run "yarn add @geoblacklight/frontend@#{Geoblacklight::VERSION}"
+      end
+    end
+
     # Vite - Config files
     def copy_config_vite_json
       copy_file "vite.json", "config/vite.json"
       copy_file "vite.config.ts", "vite.config.ts"
       run "yarn install"
-    end
-
-    def add_frontend
-      if options[:test]
-        run "yarn add file:#{Geoblacklight::Engine.root}"
-      else
-        run "yarn add @geoblacklight/frontend@#{Geoblacklight::VERSION}"
-      end
     end
 
     # Run bundle with vite install

--- a/spec/test_app_templates/lib/generators/test_app_generator.rb
+++ b/spec/test_app_templates/lib/generators/test_app_generator.rb
@@ -17,10 +17,10 @@ class TestAppGenerator < Rails::Generators::Base
     run "yarn install && yarn build"
   end
 
-  # Ensure local frontend build is linked so internal test app
-  # can use local javascript instead of npm package.
+  # This makes the assets available in the test app so that changes made in
+  # local development can be picked up automatically
   def link_frontend
-    run "yarn add #{Blacklight::Engine.root}"
+    run "yarn link"
   end
 
   def run_blacklight_generator


### PR DESCRIPTION
This fixes an issue introduced with https://github.com/geoblacklight/geoblacklight/pull/1433 where changes to frontend assets (JS, CSS) don't get picked up in local development and require fully rebuilding the `.internal_test_app`.

The problem is that:
- `yarn add` adds the outer assets directory, which ensures that @geoblacklight/frontend gets added with all its dependencies, but doesn't pick up any change thereafter
- `yarn link` links the outer assets directory, which adds @geoblacklight/frontend _without_ its dependencies, but does pick up changes made later

This PR reverts to the latter strategy and adds a note to make sure that we always include all the dependencies of `@geoblacklight/frontend` in the _generated app's_ package.json, not just geoblacklight's package.json, so that they get installed for use in local dev.

Not a perfect solution, but #1452 might improve it further.