### PR TITLE
Bump max Rails version to 7.2 in 4-x release

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       matrix:
         ruby_version: ['3.2', '3.3']
-        rails_version: [6.1.7.6, 7.1.3]
+        rails_version: [6.1.7.6, 7.1.3, 7.2.0]
 
     name: test ruby ${{ matrix.ruby_version }} / rails ${{ matrix.rails_version }}
     steps:

--- a/geoblacklight.gemspec
+++ b/geoblacklight.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.required_rubygems_version = ">= 2.5.2"
 
-  spec.add_dependency "rails", ">= 6.1", "< 7.2"
+  spec.add_dependency "rails", ">= 6.1", "< 7.3"
   spec.add_dependency "blacklight", "~> 7.0"
   spec.add_dependency "config"
   spec.add_dependency "faraday", "~> 2.0"


### PR DESCRIPTION
- Bump max Rails version to 7.2
- Add Rails 7.2 to CI text matrix
