### PR TITLE
Bump max Rails version to 7.2 in GBL 4

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       matrix:
         ruby_version: ['3.2', '3.3']
-        rails_version: [6.1.7.6, 7.1.3]
+        rails_version: [6.1.7.6, 7.1.3, 7.2.0]
 
     name: test ruby ${{ matrix.ruby_version }} / rails ${{ matrix.rails_version }}
     steps:

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -6,6 +6,6 @@ module BlacklightHelper
   include Blacklight::CatalogHelperBehavior
 
   def render_document_sidebar_partial(document = @document)
-    super(document) + (render "relations_container", document: document)
+    super + (render "relations_container", document: document)
   end
 end

--- a/geoblacklight.gemspec
+++ b/geoblacklight.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.required_rubygems_version = ">= 2.5.2"
 
-  spec.add_dependency "rails", ">= 6.1", "< 7.2"
+  spec.add_dependency "rails", ">= 6.1", "< 7.3"
   spec.add_dependency "blacklight", "~> 7.0"
   spec.add_dependency "config"
   spec.add_dependency "faraday", "~> 2.0"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,10 +20,10 @@ SimpleCov.start "rails" do
   minimum_coverage 100
 end
 
-require "factory_bot"
 require "database_cleaner"
 require "action_cable/engine"
 require "engine_cart"
+require "factory_bot"
 EngineCart.load_application!
 
 require "rails-controller-testing" if Rails::VERSION::MAJOR >= 5


### PR DESCRIPTION
Rails 6.1 is EOL in October 2024 and Rails 7.0 is EOL April 2025. In order to allow implementers more flexibility, this PR bumps the max Rails version to 7.2.