### PR TITLE
Force capybara to wait for relationships to fade in before running aXe

### DIFF
--- a/spec/features/axe_spec.rb
+++ b/spec/features/axe_spec.rb
@@ -17,6 +17,7 @@ feature "Accessibility testing", js: true do
 
     it "validates an item page with relationships" do
       visit solr_document_path("all-relationships")
+      sleep 0.5 # wait for relationships to be fully visible / faded in
       expect(page).to be_accessible
     end
 


### PR DESCRIPTION
Fixes #1506.

The relationships panel is inserted into the page and then faded in using an animation with a 200ms timing, so it's possible that aXe is seeing it halfway faded-in and calculating color contrast ratios off of that, since the colors are not what we actually see when loading it in the browser.
