### PR TITLE
change how citations are shown

### DIFF
--- a/app/models/concerns/geoblacklight/solr_document/citation.rb
+++ b/app/models/concerns/geoblacklight/solr_document/citation.rb
@@ -12,11 +12,33 @@ module Geoblacklight
           fetch(Settings.FIELDS.TITLE, nil),
           ("[#{format}]" if format),
           fetch(Settings.FIELDS.PUBLISHER, nil),
-          I18n.t("geoblacklight.citation.retrieved_from", document_url: solr_document_url)
+          citation_link(solr_document_url)
         ].flatten.compact.join(". ")
       end
 
       private
+
+      # The actual citation link varies based on what is available in the document
+      # go through a list of potential links in order of preference, ending with the solr_document_url
+      def citation_link(solr_document_url)
+        identifier_url || reference_url || solr_document_url
+      end
+
+      # identifier url in solr document (if it exists)
+      def identifier_url
+        identifiers = fetch(Settings.FIELDS.IDENTIFIER, [])
+
+        # find any identifier that look like a URL, return if found (could be DOI, Stanford PURL, etc)
+        identifiers.find { |identifier| identifier if identifier.starts_with?("https://") }
+      end
+
+      # Examine the list of references (in dct_references_s) to find a "schema.org/url"; return URL if found
+      #  References are retrieved from the SolrDocument as an array of Geoblacklight::Reference
+      #  where the "reference" attribute is an array of two elements, the first being the type and the second being the url
+      def reference_url
+        url = references.refs.find { |ref| ref.reference[0] == "http://schema.org/url" }
+        url.present? ? url.reference[1] : nil
+      end
 
       def issued
         fetch(Settings.FIELDS.DATE_ISSUED, nil)

--- a/app/views/catalog/_citation.html.erb
+++ b/app/views/catalog/_citation.html.erb
@@ -7,7 +7,6 @@
       <%= t('geoblacklight.clipboard.citation') %>
       <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
     </div>
-    <%= t('blacklight.tools.citation_info') %>
     <% citation = render Geoblacklight::Document::CitationComponent.with_collection(@documents) if @documents %>
     <div class="d-inline">
       <%= citation %>

--- a/app/views/catalog/_citation.html.erb
+++ b/app/views/catalog/_citation.html.erb
@@ -3,7 +3,7 @@
     <%= t('blacklight.tools.citation') %>
   <% end %>
   <div data-controller="clipboard">
-    <div class="alert alert-info d-none" data-clipboard-target="alert" role="alert">
+    <div class="alert alert-info alert-dismissible d-none" data-clipboard-target="alert" role="alert">
       <%= t('geoblacklight.clipboard.citation') %>
       <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
     </div>
@@ -12,7 +12,7 @@
       <%= citation %>
     </div>
     <div class="modal-footer">
-      <button type="button" class="btn btn-primary" data-action="clipboard#copyToClipboard" data-clipboard-value="<%= citation %>"><%= t('blacklight.modal.copy-citation') %></button>
+      <button type="button" class="btn btn-primary" data-action="clipboard#copyToClipboard" data-clipboard-value="<%= citation %>"><%= t('geoblacklight.modal.copy-citation') %></button>
       <button type="button" class="btn btn-secondary" data-bl-dismiss="modal"><%= t('blacklight.modal.close') %></button>
     </div>
   </div>

--- a/config/locales/geoblacklight.en.yml
+++ b/config/locales/geoblacklight.en.yml
@@ -85,7 +85,8 @@ en:
       version_of_descendants: 'Has version...'
       browse_all_no_count: "Browse all records..."
       browse_all: "Browse all %{count} records..."
-
+    modal:
+      copy-citation: "Copy Citation"
     metadata:
       toggle_summary: 'Toggle summary'
       view_metadata: 'View Metadata'

--- a/config/locales/geoblacklight.en.yml
+++ b/config/locales/geoblacklight.en.yml
@@ -2,8 +2,6 @@ en:
   geoblacklight:
     bbox_label: 'Bounding Box'
     location: 'Location'
-    citation:
-      retrieved_from: 'Retrieved from %{document_url}'
     clipboard:
       citation: Citation copied to clipboard
       web_service: Web service copied to clipboard

--- a/spec/components/geoblacklight/citation_component_spec.rb
+++ b/spec/components/geoblacklight/citation_component_spec.rb
@@ -4,13 +4,35 @@ require "spec_helper"
 
 RSpec.describe Geoblacklight::Document::CitationComponent, type: :component do
   describe "#geoblacklight_citation" do
-    let(:fixture) { JSON.parse(read_fixture("solr_documents/restricted-line.json")) }
     let(:document) { SolrDocument.new(fixture) }
     let(:rendered) { render_inline_to_capybara_node(described_class.new(document: document)) }
 
-    it "creates a citation" do
-      expect(rendered)
-        .to have_text "United States. National Oceanic and Atmospheric Administration. Circuit Rider Productions. (2002). 10 Meter Contours: Russian River Basin, California. [Shapefile]. Circuit Rider Productions. Retrieved from http://test.host/catalog/stanford-cg357zz0321"
+    context "when the identifier is a URL" do
+      let(:fixture) { JSON.parse(read_fixture("solr_documents/restricted-line.json")) }
+
+      it "creates a citation with the identifier link" do
+        expect(rendered)
+          .to have_text "United States. National Oceanic and Atmospheric Administration. Circuit Rider Productions. (2002). 10 Meter Contours: Russian River Basin, California. [Shapefile]. Circuit Rider Productions. http://purl.stanford.edu/cg357zz032"
+      end
+    end
+
+    context "when the identifier is not a URL but a reference schema.org URL is available" do
+      let(:fixture) { JSON.parse(read_fixture("solr_documents/tilejson.json")) }
+
+      it "creates a citation with the schema.org references link" do
+        expect(rendered)
+          .to have_text "Great Britain. War Office. General Staff. Geographical Section. (1908). The Balkans [and] Turkey : G.S.G.S. no. 2097 / War Office. General Staff. Geographical Section (TileJSON Fixture). [London] : War Office. General Staff. Geographical Section. General Staff, 1908-25.. https://catalog.princeton.edu/catalog/99125413918506421"
+      end
+    end
+
+    context "when the identifier is not a URL and no reference schema.org URL is available" do
+      let(:fixture) { JSON.parse(read_fixture("solr_documents/no_spatial.json")) }
+
+      it "creates a citation with the solr document link" do
+        puts rendered.native
+        expect(rendered)
+          .to have_text "ASTER Global Emissivity Dataset 1-kilometer V003 - AG1KM. http://test.host/catalog/aster-global-emissivity-dataset-1-kilometer-v003-ag1kmcad20"
+      end
     end
   end
 end

--- a/spec/models/concerns/geoblacklight/solr_document/citation_spec.rb
+++ b/spec/models/concerns/geoblacklight/solr_document/citation_spec.rb
@@ -9,7 +9,7 @@ describe Geoblacklight::SolrDocument::Citation do
 
     it "creates a citation" do
       expect(document.geoblacklight_citation("http://example.com"))
-        .to eq "United States. National Oceanic and Atmospheric Administration. Circuit Rider Productions. (2002). 10 Meter Contours: Russian River Basin, California. [Shapefile]. Circuit Rider Productions. Retrieved from http://example.com"
+        .to eq "United States. National Oceanic and Atmospheric Administration. Circuit Rider Productions. (2002). 10 Meter Contours: Russian River Basin, California. [Shapefile]. Circuit Rider Productions. http://purl.stanford.edu/cg357zz0321"
     end
   end
 end


### PR DESCRIPTION
Removes "Citation info" text from the beginning.

Link shown at the end now varies instead of being a link to the solr document (e.g. earthworks).  Instead, it will look to see if the identifier looks like a URL (could be a DOI or a PURL) and use that if found.  If not found, it will look in the references for a schema.org/url link.  If found, it will use that.  If not, back the current (solr document url)

Fixes #1500

Example:

![Screenshot 2024-08-13 at 3 59 04 PM](https://github.com/user-attachments/assets/af6fe9c7-d284-4392-8fb5-7da578d5e8f9)
