### PR TITLE
Bump frontend package version to 5.0.0-alpha.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@geoblacklight/frontend",
   "type": "module",
-  "version": "5.0.0-alpha.4",
+  "version": "5.0.0-alpha.7",
   "license": "Apache-2.0",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
This is the next non-private package number available for publishing (via semver) because I `npm publish`ed the preceding few without doing `--access public` 🤦🏻 