### PR TITLE
Publish unbundled versions of JS assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,7 @@ package-lock.json
 /public/vite*
 /public/geoblacklight-vite*
 node_modules
-dist
+app/assets/javascripts/geoblacklight
 # Vite uses dotenv and suggests to ignore local-only env files. See
 # https://vitejs.dev/guide/env-and-mode.html#env-files
 *.local

--- a/lib/generators/geoblacklight/templates/assets/_customizations.scss
+++ b/lib/generators/geoblacklight/templates/assets/_customizations.scss
@@ -1,7 +1,7 @@
 // Local Application Customizations
 
 // Set Header Logo
-$logo-image: url('@geoblacklight/frontend/dist/images/blacklight/logo.svg');
+$logo-image: url('@geoblacklight/frontend/app/assets/images/blacklight/logo.svg');
 
 .navbar-brand {  /* The main logo image for the Blacklight instance */
   @if $logo-image {

--- a/package.json
+++ b/package.json
@@ -13,10 +13,11 @@
     "test": "vitest"
   },
   "files": [
-    "dist"
+    "app/assets",
+    "app/javascript"
   ],
-  "module": "./dist/geoblacklight.js",
-  "main": "./dist/geoblacklight.umd.cjs",
+  "module": "app/assets/javascripts/geoblacklight/geoblacklight.js",
+  "main": "app/assets/javascripts/geoblacklight/geoblacklight.umd.cjs",
   "dependencies": {
     "@hotwired/stimulus": "^3.2.2",
     "@samvera/clover-iiif": "^2.3.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@geoblacklight/frontend",
   "type": "module",
-  "version": "5.0.0-alpha.7",
+  "version": "5.0.0-alpha.8",
   "license": "Apache-2.0",
   "publishConfig": {
     "access": "public"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,10 +4,8 @@ import { exec } from "child_process";
 
 export default defineConfig(() => {
   return {
-    publicDir: 'app/assets',
     build: {
-      outDir: 'dist',
-      copyPublicDir: true,
+      outDir: 'app/assets/javascripts/geoblacklight',
       emptyOutDir: true,
       manifest: true,
       minify: false,


### PR DESCRIPTION
Closes #1514 

This uses the same strategy as blacklight: bundle things into `app/assets/javascripts` but gitignore it, and then ship everything in `app/assets` (including the bundled `app/assets/javascripts`) _and_ `app/javascript` (unbundled).

This way, the paths inside the package match where things go in your built app, and there's no `copyPublicDir` magic needed to make sure that images or other assets in `app/assets` get included in the npm package: they will always have the same path in the package that they do in the gem.