### PR TITLE
Change tests to stop using NYU fixture

### DIFF
--- a/spec/features/bookmarks_spec.rb
+++ b/spec/features/bookmarks_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 
 feature "Blacklight Bookmarks" do
   scenario "index has created bookmarks" do
-    visit solr_document_path "nyu-2451-34564"
+    visit solr_document_path "harvard-g7064-s2-1834-k3"
     click_button "Bookmark"
     visit bookmarks_path
     expect(page).to have_css ".document", count: 1

--- a/spec/features/layer_inspection_spec.rb
+++ b/spec/features/layer_inspection_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 
 feature "Layer inspection", js: true do
   scenario "clicking map should trigger inspection" do
-    visit solr_document_path("nyu-2451-34564")
+    visit solr_document_path("tufts-cambridgegrid100-04")
     expect(page).to have_css("th", text: "Attribute")
     find("#leaflet-viewer").click
     expect(page).not_to have_css("td.default-text")


### PR DESCRIPTION
This fixes an HTTP timeout error that could arise when an NYU
fixture was queried over WMS and didn't respond in time, causing
tests to fail.

This commit switches the two tests that used the fixture to use
other, equivalent fixtures to avoid the timeouts.

See also #1492.
