### PR TITLE
Move development dependencies into the gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,21 +3,6 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in geoblacklight.gemspec
 gemspec
 
-group :test do
-  gem "capybara", require: false
-  gem "database_cleaner", require: false
-  gem "engine_cart", require: false
-  gem "factory_bot_rails", require: false
-  gem "foreman", require: false
-  gem "rails-controller-testing", require: false
-  gem "rspec-rails", require: false
-  gem "simplecov", require: false
-  gem "standardrb", require: false
-  gem "webdrivers", require: false
-  gem "webmock", require: false
-  gem "axe-core-rspec", require: false
-end
-
 # BEGIN ENGINE_CART BLOCK
 # engine_cart: 2.6.0
 # engine_cart stanza: 2.5.0

--- a/geoblacklight.gemspec
+++ b/geoblacklight.gemspec
@@ -39,4 +39,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "foreman"
   spec.add_development_dependency "standardrb", "1.0.1"
   spec.add_development_dependency "webmock", "~> 3.14"
+  spec.add_development_dependency "database_cleaner"
+  spec.add_development_dependency "axe-core-rspec"
 end


### PR DESCRIPTION
This fixes warnings like:

```
A gemspec development dependency (capybara, >= 2.5.0) is being overridden by a Gemfile dependency (capybara, >= 0).
This behaviour may change in the future. Please remove either of them, or make sure they both have the same requirement
A gemspec development dependency (engine_cart, ~> 2.0) is being overridden by a Gemfile dependency (engine_cart, >= 0).
This behaviour may change in the future. Please remove either of them, or make sure they both have the same requirement
A gemspec development dependency (simplecov, ~> 0.22) is being overridden by a Gemfile dependency (simplecov, >= 0).
This behaviour may change in the future. Please remove either of them, or make sure they both have the same requirement
A gemspec development dependency (standardrb, = 1.0.1) is being overridden by a Gemfile dependency (standardrb, >= 0).
This behaviour may change in the future. Please remove either of them, or make sure they both have the same requirement
A gemspec development dependency (webmock, ~> 3.14) is being overridden by a Gemfile dependency (webmock, >= 0).
This behaviour may change in the future. Please remove either of them, or make sure they both have the same requirement
```