### PR TITLE
Force engine_cart and template.rb builds to use propshaft

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -13,6 +13,10 @@ require "solr_wrapper/rake_task"
 require "engine_cart/rake_task"
 require "rspec/core/rake_task"
 
+# Ensure the app generates with Propshaft; sprockets is no longer supported
+# https://github.com/geoblacklight/geoblacklight/issues/1265
+ENV["ENGINE_CART_RAILS_OPTIONS"] = ENV["ENGINE_CART_RAILS_OPTIONS"].to_s + " -a propshaft"
+
 task(:spec).clear
 RSpec::Core::RakeTask.new(:spec) do |t|
   t.verbose = false

--- a/template.rb
+++ b/template.rb
@@ -2,6 +2,10 @@
 
 gem "blacklight", "~> 8.0"
 
+# Ensure the app generates with Propshaft; sprockets is no longer supported
+# https://github.com/geoblacklight/geoblacklight/issues/1265
+ENV["ENGINE_CART_RAILS_OPTIONS"] = ENV["ENGINE_CART_RAILS_OPTIONS"].to_s + " -a propshaft"
+
 # Install latest version of geoblacklight gem if running
 # generator with a development branch.
 if ENV["BRANCH"]


### PR DESCRIPTION
See #1265 

This avoids warnings in the generated app about `config/manifest.js` being missing, assets not being precompiled, etc, etc. that arise when sprockets gets used, which is still the default in Rails unless you tell it not to.

It's easier to make sure that rails uses the `-a propshaft` option early on in the build process than to remove and replace sprockets later on in the build process (in a geoblacklight generator) because there's a lot more you have to tear out.