### PR TITLE
Update CI to use new ghrc image and solr 9.6

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby_version }}
       - name: Create Solr container
-        run: docker run -d -p 8983:8983 geoblacklight/solr:8.9-v1.0.0 server/scripts/ci-start.sh
+        run: docker run -d -p 8983:8983 ghcr.io/geoblacklight/solr:latest server/scripts/ci-start.sh
       - name: Install dependencies
         run: bundle install
         env:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -60,7 +60,7 @@ jobs:
           cd solr/conf
           zip -1 -r solr_config.zip ./*
           curl -H "Content-type:application/octet-stream" --data-binary @solr_config.zip "http://solr:SolrRocks@127.0.0.1:8983/solr/admin/configs?action=UPLOAD&name=blacklight"
-          curl -H 'Content-type: application/json' http://solr:SolrRocks@127.0.0.1:8983/api/collections/  -d '{create: {name: blacklight-core, config: blacklight, numShards: 1}}'
+          curl -H 'Content-type: application/json' http://solr:SolrRocks@127.0.0.1:8983/api/collections/ -d '{"name": "blacklight-core", "config": "blacklight", "numShards": 1}'
       - name: Run tests
         run: bundle exec rake ci
         env:


### PR DESCRIPTION
Update to the latest Solr version and use auto-built images saved in the GitHub package repo instead of Docker Hub.
https://github.com/geoblacklight/geoblacklight-docker/pkgs/container/solr