### PR TITLE
Start docker rails server on port 3001

### DIFF
--- a/lib/generators/geoblacklight/templates/demo-app/compose.yml
+++ b/lib/generators/geoblacklight/templates/demo-app/compose.yml
@@ -2,7 +2,7 @@ services:
   app:
     image: ghcr.io/geoblacklight/geoblacklight:main
     ports:
-      - "3001:3000"
+      - "3001:3001"
     links:
       - "solr:solr"
     environment:

--- a/lib/generators/geoblacklight/templates/demo-app/start-server.sh
+++ b/lib/generators/geoblacklight/templates/demo-app/start-server.sh
@@ -18,4 +18,4 @@ yarn add file:$gempath
 # Start the server
 bundle exec rake db:prepare
 bundle exec rake geoblacklight:index:seed
-bundle exec rails server -b 0.0.0.0
+bundle exec rails server -b 0.0.0.0 -p 3001


### PR DESCRIPTION
Reduce confusion when running the demo app docker. The rails server log now matches the port that compose binds to.