### PR TITLE
Configure the logo rather than overriding

### DIFF
--- a/app/assets/stylesheets/geoblacklight/modules/_blacklight_overrides.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/_blacklight_overrides.scss
@@ -2,15 +2,6 @@
   Stylesheet for overriding styles inherited from Blacklight proper
 **/
 
-$logo-image: image_url("blacklight/logo.svg") !default;
-
-.navbar-logo {
-  /* The main logo image for the Blacklight instance */
-  @if $logo-image {
-    background: transparent $logo-image no-repeat top left;
-  }
-}
-
 // Begin - Addresses GBL issue #639
 .facet-limit {
   margin-bottom: 0;

--- a/lib/generators/geoblacklight/templates/assets/_customizations.scss
+++ b/lib/generators/geoblacklight/templates/assets/_customizations.scss
@@ -1,13 +1,7 @@
 // Local Application Customizations
 
 // Set Header Logo
-$logo-image: url('@geoblacklight/frontend/app/assets/images/blacklight/logo.svg');
-
-.navbar-brand {  /* The main logo image for the Blacklight instance */
-  @if $logo-image {
-    background: transparent $logo-image no-repeat top left;
-  }
-}
+$logo-image: url("@geoblacklight/frontend/app/assets/images/blacklight/logo.svg");
 
 // Optional
 // Override default Bootstrap variables here

--- a/lib/generators/geoblacklight/templates/vite.config.ts
+++ b/lib/generators/geoblacklight/templates/vite.config.ts
@@ -1,15 +1,23 @@
-import { defineConfig } from 'vite'
-import rails from 'vite-plugin-rails'
+import { defineConfig, searchForWorkspaceRoot } from "vite";
+import rails from "vite-plugin-rails";
 
 export default defineConfig(({ mode }) => {
   return {
     build: {
-      minify: mode === 'production',
+      minify: mode === "production",
       manifest: true,
       sourcemap: true,
     },
-    plugins: [
-      rails(),
-    ],
-  }
-})
+    server: {
+      fs: {
+        allow: [
+          // search up for workspace root
+          searchForWorkspaceRoot(process.cwd()),
+          // One directory up (from .internal_test_app where we do `yarn link @geoblacklight`)
+          `${process.cwd()}/..`,
+        ],
+      },
+    },
+    plugins: [rails()],
+  };
+});


### PR DESCRIPTION
This makes it easier for downstream apps to configure their own logos and results in less overall css.