### PR TITLE
Move rules about iiif-icons out of the blacklight_overrides.scss

### DIFF
--- a/app/assets/stylesheets/geoblacklight/modules/_blacklight_overrides.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/_blacklight_overrides.scss
@@ -11,12 +11,6 @@ $logo-image: image_url("blacklight/logo.svg") !default;
   }
 }
 
-.blacklight-icons-iiif-drag-drop,
-.blacklight-icons-iiif-drag-drop svg {
-  height: 2rem;
-  width: 2rem;
-}
-
 // Begin - Addresses GBL issue #639
 .facet-limit {
   margin-bottom: 0;

--- a/app/assets/stylesheets/geoblacklight/modules/icon-customization.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/icon-customization.scss
@@ -46,6 +46,12 @@ span.icon-missing {
   }
 }
 
+.blacklight-icons-iiif-drag-drop,
+.blacklight-icons-iiif-drag-drop svg {
+  height: 2rem;
+  width: 2rem;
+}
+
 // Begin - Addresses GBL issue #634
 // Emulates font-size for SVG icons and aligns to baseline
 .status-icons,


### PR DESCRIPTION
This rule was not overriding blacklight, so it is misleading to put it in there