### PR TITLE
Use selenium-webdriver directly without webdrivers gem

### DIFF
--- a/geoblacklight.gemspec
+++ b/geoblacklight.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec-rails"
   spec.add_development_dependency "engine_cart", "~> 2.0"
   spec.add_development_dependency "capybara", ">= 2.5.0"
-  spec.add_development_dependency "webdrivers"
+  spec.add_development_dependency "selenium-webdriver"
   spec.add_development_dependency "factory_bot_rails"
   spec.add_development_dependency "simplecov", "~> 0.22"
   spec.add_development_dependency "foreman"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,7 +30,6 @@ require "rails-controller-testing" if Rails::VERSION::MAJOR >= 5
 require "rspec/rails"
 require "capybara/rspec"
 require "selenium-webdriver"
-require "webdrivers"
 
 # Setup webmock for specific tests
 require "webmock/rspec"


### PR DESCRIPTION
As of https://github.com/rails/rails/pull/48847, Ruby 3 Rails apps
don't need the webdrivers gem because the selenium manager handles
managing and installing browser versions on its own.

This removes a deprecation warning that occurs during the build.
