### PR TITLE
don't allow leaflet_options to be updated

### DIFF
--- a/app/components/geoblacklight/location_leaflet_map_component.rb
+++ b/app/components/geoblacklight/location_leaflet_map_component.rb
@@ -26,7 +26,7 @@ module Geoblacklight
 
     # Add top-level geosearch control to leaflet options if configured
     def leaflet_options
-      options = helpers.leaflet_options
+      options = helpers.leaflet_options.deep_dup
       options["CONTROLS"] = {"Geosearch" => @geosearch} if @geosearch
       options.to_json
     end


### PR DESCRIPTION
The will update [the SETTINGS](https://github.com/geoblacklight/geoblacklight/blob/200d4ab704630d5b53206ffc107c420f6cba4172/app/helpers/geoblacklight_helper.rb#L64) without the duplication.

closes #1591