### PR TITLE
Prevent bootstrap from being imported twice

### DIFF
--- a/lib/generators/geoblacklight/templates/assets/application.js
+++ b/lib/generators/geoblacklight/templates/assets/application.js
@@ -4,14 +4,12 @@
 import "@hotwired/turbo-rails";
 import { application } from "~/controllers/application";
 
-// Bootstrap, Blacklight, Geoblacklight
-import * as bootstrap from "bootstrap";
+// Blacklight & Geoblacklight
 import githubAutoCompleteElement from "@github/auto-complete-element";
 import Blacklight from "blacklight-frontend";
 import Geoblacklight from "@geoblacklight/frontend";
 
 // Make imports available globally to your code
-window.bootstrap = bootstrap;
 window.Blacklight = Blacklight;
 window.Geoblacklight = Geoblacklight;
 


### PR DESCRIPTION
Explicitly importing and binding bootstrap to the window object
causes its javascript to be imported twice. We already bundle
bootstrap into geoblacklight's javascript, so we don't need
to explicitly import it beforehand.

Fixes #1566
