### PR TITLE
Refactor truncation for abstracts

### DIFF
--- a/app/assets/stylesheets/geoblacklight/modules/item.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/item.scss
@@ -31,6 +31,11 @@
     cursor: pointer;
   }
 
+  // Remove bootstrap transition delay since we're not animating it
+  .truncate-abstract {
+    transition: none;
+  }
+
   .truncate-abstract.collapse:not(.show),
   .truncate-abstract.collapsing {
     display: block;

--- a/app/javascript/geoblacklight/initializers/truncation.js
+++ b/app/javascript/geoblacklight/initializers/truncation.js
@@ -1,27 +1,45 @@
 // Truncate and expand/collapse abstracts (descriptions) on show page
+
+// Class that handles adding a button to expand/collapse a description
+// Uses bootstrap's built-in collapse functionality; CSS is used to do the truncation
+class Truncator {
+  constructor(element, { lines, id }) {
+    // if the element is already small enough, don't truncate it
+    const minHeight = lines * parseFloat(window.getComputedStyle(element).fontSize);
+    if (element.getBoundingClientRect().height < minHeight) return;
+
+    // set a unique ID for the element if it doesn't have one
+    this.element = element;
+    this.element.id ||= id;
+
+    // add the button
+    this.button = document.createElement("button");
+    this.button.classList.add("btn", "btn-link", "p-0", "border-0");
+    this.button.dataset.bsToggle = "collapse";
+    this.button.dataset.bsTarget = `#${this.element.id}`;
+    this.button.setAttribute("aria-expanded", "false");
+    this.button.setAttribute("aria-controls", this.element.id);
+    this.button.textContent = "Read more";
+    this.button.addEventListener("click", this.toggle.bind(this));
+    element.parentNode.insertBefore(this.button, element.nextSibling);
+
+    // start collapsed
+    this.element.classList.add("collapse");
+  }
+
+  toggle() {
+    if (this.button.textContent == "Read more") this.button.textContent = "Close";
+    else this.button.textContent = "Read more";
+  }
+}
+
+// Initialize truncation for all elements with class "truncate-abstract"
+// Ensure they have unique IDs because bootstrap requires this
 export default function initializeTruncation() {
   document.querySelectorAll(".truncate-abstract").forEach((element, i) => {
-    let lines = 12 * parseFloat(window.getComputedStyle(element).fontSize);
-    if (element.getBoundingClientRect().height < lines) return;
-    let id = element.id || "truncate-" + i;
-
-    element.id = id;
-    element.classList.add("collapse");
-
-    let control = document.createElement("button");
-    control.className = "btn btn-link p-0 border-0";
-    control.setAttribute("data-bs-toggle", "collapse");
-    control.setAttribute("aria-expanded", "false");
-    control.setAttribute("data-bs-target", `#${id}`);
-    control.setAttribute("aria-controls", id);
-    control.textContent = "Read more";
-
-    control.addEventListener("click", function () {
-      let isExpanded = control.getAttribute("aria-expanded") === "true";
-      control.textContent = isExpanded ? "Read more" : "Close";
-      control.setAttribute("aria-expanded", !isExpanded);
+    new Truncator(element, {
+      lines: 12,
+      id: `truncate-${i}`,
     });
-
-    element.parentNode.insertBefore(control, element.nextSibling);
   });
 }


### PR DESCRIPTION
This refactors the truncation logic we have that builds on bootstrap's
collapse functionality. It fixes a problem where the button had the
wrong text after expanding/collapsing.

Also removes a delay that was present because bootstrap sets an
animation length, but we were not actually doing any animation.

Closes #1592
