### PR TITLE
Ensure the demo app builder and demo app Dockerfile use the same Ruby version

### DIFF
--- a/.github/workflows/build-demo-app.yml
+++ b/.github/workflows/build-demo-app.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.3
+          ruby-version: 3.3.4
 
       - name: Install dependencies
         run: bundle install


### PR DESCRIPTION
Fixes docker builds.

Closes #1597 