### PR TITLE
pin solr_wrapper version.

### DIFF
--- a/.solr_wrapper
+++ b/.solr_wrapper
@@ -4,3 +4,4 @@ download_dir: tmp/solr
 collection:
   dir: solr/conf/
   name: blacklight-core
+version: '9.6.1'


### PR DESCRIPTION
Solr 9.7.0 doesn't work with SolrWrapper. Pinning to get CI to work again.