### PR TITLE
Ensure viewers are full-width

### DIFF
--- a/app/assets/stylesheets/geoblacklight/modules/item.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/item.scss
@@ -9,6 +9,7 @@
     .viewer {
       border: 1px solid $gray-400;
       min-height: 27.5rem;
+      width: 100%;
 
       // Ensure embeds, openlayers viewer, and IIIF viewer fit their container
       iframe, .ol-viewport, .clover-iiif-image-openseadragon {


### PR DESCRIPTION
https://github.com/geoblacklight/geoblacklight/pull/1607 removed
some styles that only affected some viewers, but the oEmbed viewer
(and maybe others) still need their width to be set. This fixes
that regression.
