### PR TITLE
Update resource type icon logic

### DIFF
--- a/app/components/geoblacklight/header_icons_component.html.erb
+++ b/app/components/geoblacklight/header_icons_component.html.erb
@@ -1,3 +1,3 @@
 <% @fields.each do |field| %>
-  <%= get_icon(field) %>
+  <%= icon(field) %>
 <% end %>

--- a/app/components/geoblacklight/header_icons_component.rb
+++ b/app/components/geoblacklight/header_icons_component.rb
@@ -10,17 +10,20 @@ module Geoblacklight
       super
     end
 
-    def get_icon(field)
-      icon_name = @document[field]
-      if icon_name&.include?("Datasets") && @document.resource_type
-        specific_icon = @document.resource_type
-        specific_icon = specific_icon.is_a?(Array) ? specific_icon.first : specific_icon
-        specific_icon = specific_icon&.gsub(" data", "")
-        icon = geoblacklight_icon(specific_icon, classes: "svg_tooltip")
-        return icon unless icon.include?("icon-missing")
-      end
-      icon_name = icon_name.is_a?(Array) ? icon_name.first : icon_name
-      geoblacklight_icon(icon_name, classes: "svg_tooltip")
+    def icon(field)
+      return resource_icon if field == Settings.FIELDS.RESOURCE_CLASS
+
+      geoblacklight_icon(@document[field], classes: "svg_tooltip")
+    end
+
+    # If the item has a resource type of "X data" where "X" is an existing icon, use that icon
+    # Otherwise just use the resource class icon
+    def resource_icon
+      dataset_type = @document.resource_type.find { |type| type.include?(" data") }&.gsub(" data", "")
+      resource_type_icon = geoblacklight_icon(dataset_type, classes: "svg_tooltip")
+      return resource_type_icon unless resource_type_icon.include?("icon-missing")
+
+      geoblacklight_icon(@document.resource_class.first, classes: "svg_tooltip")
     end
   end
 end

--- a/app/models/concerns/geoblacklight/solr_document.rb
+++ b/app/models/concerns/geoblacklight/solr_document.rb
@@ -21,7 +21,8 @@ module Geoblacklight
       attribute :file_format, :string, Settings.FIELDS.FORMAT
       attribute :rights_field_data, :string, Settings.FIELDS.ACCESS_RIGHTS
       attribute :provider, :string, Settings.FIELDS.PROVIDER
-      attribute :resource_type, :string, Settings.FIELDS.RESOURCE_TYPE
+      attribute :resource_type, :array, Settings.FIELDS.RESOURCE_TYPE
+      attribute :resource_class, :array, Settings.FIELDS.RESOURCE_CLASS
       attribute :title, :string, Settings.FIELDS.TITLE
       attribute :creator, :array, Settings.FIELDS.CREATOR
       attribute :publisher, :string, Settings.FIELDS.PUBLISHER

--- a/spec/components/geoblacklight/header_icons_component_spec.rb
+++ b/spec/components/geoblacklight/header_icons_component_spec.rb
@@ -6,40 +6,51 @@ RSpec.describe Geoblacklight::HeaderIconsComponent, type: :component do
   subject(:rendered) do
     render_inline_to_capybara_node(described_class.new(document: document))
   end
+
   let(:document) { SolrDocument.new(document_attributes) }
+  let(:resource_class) { [] }
+  let(:resource_type) { [] }
   let(:document_attributes) do
     {
-      "gbl_resourceClass_sm" => ["Datasets"].to_json,
-      "gbl_resourceType_sm" => resource_type_list.to_json,
+      "gbl_resourceClass_sm" => resource_class,
+      "gbl_resourceType_sm" => resource_type,
       "schema_provider_s" => "Stanford",
       "dct_accessRights_s" => "Public"
     }
   end
 
-  context "when there is a resource type with icon" do
-    let(:resource_type_list) { ["Polygon"] }
-    it "renders 3 icons" do
-      expect(rendered).to have_css(".blacklight-icons-polygon")
-      expect(rendered).to have_css(".blacklight-icons-stanford")
-      expect(rendered).to have_css(".blacklight-icons-public")
+  it "renders the provider icon" do
+    expect(rendered).to have_css(".blacklight-icons-stanford")
+  end
+
+  it "renders the access rights icon" do
+    expect(rendered).to have_css(".blacklight-icons-public")
+  end
+
+  context "when there are no resource types with icons" do
+    let(:resource_class) { ["Datasets"] }
+    let(:resource_type) { ["Census data", "Statistical maps"] }
+
+    it "renders the resource class icon" do
+      expect(rendered).to have_css(".blacklight-icons-datasets")
     end
   end
 
-  context "when there is a resource type without icon" do
-    let(:resource_type_list) { ["Index Maps"] }
-    it "renders 3 icons" do
-      expect(rendered).to have_css(".blacklight-icons-datasets")
-      expect(rendered).to have_css(".blacklight-icons-stanford")
-      expect(rendered).to have_css(".blacklight-icons-public")
+  context "when there is a 'data' resource type with an icon" do
+    let(:resource_class) { ["Datasets"] }
+    let(:resource_type) { ["Raster data"] }
+
+    it "renders the resource type icon" do
+      expect(rendered).to have_css(".blacklight-icons-raster")
     end
   end
 
-  context "when the resource type is nil" do
-    let(:resource_type_list) { [nil] }
-    it "renders 3 icons without errors" do
-      expect(rendered).to have_css(".blacklight-icons-datasets")
-      expect(rendered).to have_css(".blacklight-icons-stanford")
-      expect(rendered).to have_css(".blacklight-icons-public")
+  context "when there are multiple resource types and one has an icon" do
+    let(:resource_class) { ["Datasets"] }
+    let(:resource_type) { ["Nautical charts", "Raster data"] }
+
+    it "renders the resource type that has an icon" do
+      expect(rendered).to have_css(".blacklight-icons-raster")
     end
   end
 end


### PR DESCRIPTION
This slightly refactors the logic in the header icons component that picks a more specific icon to display based on an item's resource type.

For cases where an item had multiple resource types, but one of them was one that mapped to an icon (e.g. "Raster data" and "Nautical charts"), we were sometimes falling back to the resource class ("Datasets"). This change has us use "Raster data" since we know we have a more specific icon for it in that situation.

For more info, see https://github.com/sul-dlss/earthworks/issues/1398.