### PR TITLE
Remove web services copy to clipboard functionality

### DIFF
--- a/app/components/geoblacklight/web_services_default_component.html.erb
+++ b/app/components/geoblacklight/web_services_default_component.html.erb
@@ -4,8 +4,5 @@
   </label>
   <div class='input-group'>  
     <input type='text' id='<%= reference.type%>_webservice' value='<%= reference.endpoint %>' class='form-control'>
-    <div class="input-group-append">
-      <button button type="button" class="btn btn-primary" data-action="clipboard#copyToClipboard" data-clipboard-value='<%= reference.endpoint %>'><%= t('blacklight.modal.copy') %></button>
-    </div>
   </div>
 </div>

--- a/app/components/geoblacklight/web_services_wfs_component.html.erb
+++ b/app/components/geoblacklight/web_services_wfs_component.html.erb
@@ -3,8 +3,5 @@
   <label for="wfs_abv_webservice" class="me-2"><%= t('geoblacklight.references.wfs_abv')%> <code><%= t('geoblacklight.references.wfs_label')%></code></label>
   <div class='input-group'>
     <input id="wfs_abv_webservice" type='text' value='<%= document.wxs_identifier %>' readonly='readonly' class="form-control">
-    <div class="input-group-append">
-      <button button type="button" class="btn btn-primary"  data-action="clipboard#copyToClipboard" data-clipboard-value='<%= document.wxs_identifier %>'><%= t('blacklight.modal.copy') %></button>
-    </div>
   </div>
 </div>

--- a/app/components/geoblacklight/web_services_wms_component.html.erb
+++ b/app/components/geoblacklight/web_services_wms_component.html.erb
@@ -3,8 +3,5 @@
   <label for="wms_abv_webservice" class="me-2"><%= t('geoblacklight.references.wms_abv')%> <code><%= t('geoblacklight.references.wms_label')%></code></label>
   <div class='input-group'>
     <input id="wms_abv_webservice" type='text' value='<%= document.wxs_identifier %>' class="form-control">
-    <div class="input-group-append">
-      <button button type="button" class="btn btn-primary"  data-action="clipboard#copyToClipboard" data-clipboard-value='<%= document.wxs_identifier %>'><%= t('blacklight.modal.copy') %></button>
-    </div>
   </div>
 </div>

--- a/app/views/catalog/web_services.html.erb
+++ b/app/views/catalog/web_services.html.erb
@@ -3,11 +3,7 @@
     <%= t('geoblacklight.references.services') %>
   <% end %>
   <% component.with_body do %>
-    <div class="modal-body web-services-modal-body" data-controller="clipboard">
-      <div class="alert alert-info d-none" role="alert" data-clipboard-target="alert">
-        <%= t('geoblacklight.clipboard.web_service') %>
-        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-      </div>
+    <div class="modal-body web-services-modal-body">
       <div class="web-services-modal-entry">
         <%= render Geoblacklight::WebServicesComponent.with_collection(@documents.first.references.refs, document: @documents.first) %>
       </div>

--- a/spec/features/citations_spec.rb
+++ b/spec/features/citations_spec.rb
@@ -7,10 +7,10 @@ feature "Blacklight Citation", js: true do
     sign_in
     visit "/catalog/princeton-1r66j405w"
     click_link "Cite"
-    page.driver.browser.add_permission('clipboard-read', 'granted')
-    page.driver.browser.add_permission('clipboard-write', 'granted')
+    page.driver.browser.add_permission("clipboard-read", "granted")
+    page.driver.browser.add_permission("clipboard-write", "granted")
     click_button "Copy Citation"
-    clip_text = page.evaluate_async_script('navigator.clipboard.readText().then(arguments[0])')
+    clip_text = page.evaluate_async_script("navigator.clipboard.readText().then(arguments[0])")
     expect(clip_text).to include("Sanborn Map Company")
   end
 end

--- a/spec/features/citations_spec.rb
+++ b/spec/features/citations_spec.rb
@@ -2,11 +2,15 @@
 
 require "spec_helper"
 
-feature "Blacklight Citation" do
+feature "Blacklight Citation", js: true do
   scenario "index has created citations" do
     sign_in
     visit "/catalog/princeton-1r66j405w"
     click_link "Cite"
-    expect(page).to have_text "Copy Citation"
+    page.driver.browser.add_permission('clipboard-read', 'granted')
+    page.driver.browser.add_permission('clipboard-write', 'granted')
+    click_button "Copy Citation"
+    clip_text = page.evaluate_async_script('navigator.clipboard.readText().then(arguments[0])')
+    expect(clip_text).to include("Sanborn Map Company")
   end
 end

--- a/spec/features/web_services_modal_spec.rb
+++ b/spec/features/web_services_modal_spec.rb
@@ -17,14 +17,6 @@ describe "web services tools", type: :feature do
     end
   end
 
-  context "when any reference is linked" do
-    it "shows copy to clipboard button" do
-      visit solr_document_path "princeton-dc7h14b252v"
-      open_web_services_modal
-      expect(page).to have_text "Copy"
-    end
-  end
-
   context "when wms/wfs are provided" do
     it "shows up in tools" do
       visit solr_document_path "stanford-cg357zz0321"


### PR DESCRIPTION
Removes web services clipboard functionality. This needs more engineering work and is currently very obviously broken.
Added a test to check for the (working) citation clipboard contents. Something like this should be used in specs if this feature is re-introduced.

Closes #1550 