### PR TITLE
Fix clipboard copy functionality for web services modal

### DIFF
--- a/app/components/geoblacklight/web_services_default_component.html.erb
+++ b/app/components/geoblacklight/web_services_default_component.html.erb
@@ -5,7 +5,7 @@
   <div class='input-group'>  
     <input type='text' id='<%= reference.type%>_webservice' value='<%= reference.endpoint %>' class='form-control'>
     <div class="input-group-append">
-      <button button type="button" class="btn btn-primary" data-action="clipboard#copyToClipboard" data-clipboard-value='<%= reference.endpoint %>'><%= t('blacklight.modal.copy') %></button>
+      <button button type="button" class="btn btn-primary" data-action="clipboard#copyToClipboard" data-clipboard-value-param='<%= reference.endpoint %>'><%= t('blacklight.modal.copy') %></button>
     </div>
   </div>
 </div>

--- a/app/components/geoblacklight/web_services_wfs_component.html.erb
+++ b/app/components/geoblacklight/web_services_wfs_component.html.erb
@@ -4,7 +4,7 @@
   <div class='input-group'>
     <input id="wfs_abv_webservice" type='text' value='<%= document.wxs_identifier %>' readonly='readonly' class="form-control">
     <div class="input-group-append">
-      <button button type="button" class="btn btn-primary"  data-action="clipboard#copyToClipboard" data-clipboard-value='<%= document.wxs_identifier %>'><%= t('blacklight.modal.copy') %></button>
+      <button button type="button" class="btn btn-primary"  data-action="clipboard#copyToClipboard" data-clipboard-value-param='<%= document.wxs_identifier %>'><%= t('blacklight.modal.copy') %></button>
     </div>
   </div>
 </div>

--- a/app/components/geoblacklight/web_services_wms_component.html.erb
+++ b/app/components/geoblacklight/web_services_wms_component.html.erb
@@ -4,7 +4,7 @@
   <div class='input-group'>
     <input id="wms_abv_webservice" type='text' value='<%= document.wxs_identifier %>' class="form-control">
     <div class="input-group-append">
-      <button button type="button" class="btn btn-primary"  data-action="clipboard#copyToClipboard" data-clipboard-value='<%= document.wxs_identifier %>'><%= t('blacklight.modal.copy') %></button>
+      <button button type="button" class="btn btn-primary"  data-action="clipboard#copyToClipboard" data-clipboard-value-param='<%= document.wxs_identifier %>'><%= t('blacklight.modal.copy') %></button>
     </div>
   </div>
 </div>

--- a/app/javascript/geoblacklight/controllers/clipboard_controller.js
+++ b/app/javascript/geoblacklight/controllers/clipboard_controller.js
@@ -4,7 +4,7 @@ export default class extends Controller {
     static targets = ["alert"];
 
     async copyToClipboard(event) {  
-        let text = event.target.dataset.clipboardValue;
+        let text = event.params.value;
         await navigator.clipboard.writeText(text)
         this.alertTarget.classList.remove('d-none');
     }

--- a/app/views/catalog/_citation.html.erb
+++ b/app/views/catalog/_citation.html.erb
@@ -12,7 +12,7 @@
       <%= citation %>
     </div>
     <div class="modal-footer">
-      <button type="button" class="btn btn-primary" data-action="clipboard#copyToClipboard" data-clipboard-value="<%= citation %>"><%= t('geoblacklight.modal.copy-citation') %></button>
+      <button type="button" class="btn btn-primary" data-action="clipboard#copyToClipboard" data-clipboard-value-param="<%= citation %>"><%= t('geoblacklight.modal.copy-citation') %></button>
       <button type="button" class="btn btn-secondary" data-bl-dismiss="modal"><%= t('blacklight.modal.close') %></button>
     </div>
   </div>

--- a/spec/features/citations_spec.rb
+++ b/spec/features/citations_spec.rb
@@ -3,10 +3,14 @@
 require "spec_helper"
 
 feature "Blacklight Citation" do
-  scenario "index has created citations" do
-    sign_in
+  scenario "citations can be copied", js: true do
+    sign_in # NOTE: this seems to be required for clipboard permissions to be granted succesfully
+    page.driver.browser.add_permission("clipboard-read", "granted")
+    page.driver.browser.add_permission("clipboard-write", "granted")
     visit "/catalog/princeton-1r66j405w"
     click_link "Cite"
-    expect(page).to have_text "Copy Citation"
+    click_button "Copy Citation"
+    clip_text = page.evaluate_async_script("navigator.clipboard.readText().then(arguments[0])")
+    expect(clip_text).to include("Sanborn Map Company. Princeton, Mercer County, New Jersey.")
   end
 end

--- a/spec/features/web_services_modal_spec.rb
+++ b/spec/features/web_services_modal_spec.rb
@@ -23,6 +23,17 @@ describe "web services tools", type: :feature do
       open_web_services_modal
       expect(page).to have_text "Copy"
     end
+
+    it "copies the link to clipboard", js: true do
+      sign_in # NOTE: this seems to be required for clipboard permissions to be granted succesfully
+      page.driver.browser.add_permission("clipboard-read", "granted")
+      page.driver.browser.add_permission("clipboard-write", "granted")
+      visit solr_document_path "princeton-1r66j405w"
+      open_web_services_modal
+      click_button "Copy"
+      clip_text = page.evaluate_async_script("navigator.clipboard.readText().then(arguments[0])")
+      expect(clip_text).to include("https://libimages1.princeton.edu/loris/figgy_prod/5a%2F20%2F58%2F5a20585db50d44959fe5ae44821fd174%2Fintermediate_file.jp2/info.json")
+    end
   end
 
   context "when wms/wfs are provided" do


### PR DESCRIPTION
This fixes the clipboard copying logic for the web services modal
and adds tests, inspired by #1613.

Closes #1550
