### PR TITLE
Remove transparency of Leaflet's attribution display

### DIFF
--- a/app/assets/stylesheets/geoblacklight/modules/_base.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/_base.scss
@@ -16,6 +16,7 @@
 @import 'index_maps';
 @import 'item';
 @import 'layer_opacity';
+@import 'leaflet';
 @import 'metadata';
 @import 'metadata_content';
 @import 'metadata_missing';

--- a/app/assets/stylesheets/geoblacklight/modules/leaflet.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/leaflet.scss
@@ -1,0 +1,4 @@
+/* Prevent transparency of Leaflet's affiliations display to improve contrast */
+.leaflet-container .leaflet-control-attribution {
+  background: white;
+}


### PR DESCRIPTION
This fixes an accessibility issue identified by some automated
checkers. See: https://github.com/sul-dlss/earthworks/issues/1432