### PR TITLE
Use Capybara's method and remove fixed sleep

### DIFF
--- a/spec/features/search_results_map_spec.rb
+++ b/spec/features/search_results_map_spec.rb
@@ -6,7 +6,7 @@ feature "search results map", js: true do
   scenario "view is scoped to Twin Cities metro area" do
     visit search_catalog_path(q: "Minneapolis")
     expect(page).to have_css "#leaflet-viewer"
-    sleep 1
+    expect(page).to have_css "#leaflet-viewer[data-bounds]"
 
     bbox = page.find("#leaflet-viewer")["data-bounds"]
 


### PR DESCRIPTION
Capybara waits until the target element to appear automatically (Default `2sec`). 
ref: https://github.com/teamcapybara/capybara#asynchronous-javascript-ajax-and-friends

So, I fixed to use Capybara's method. By this change, sometimes the test finishes earlier, and sometimes it waits until it appears, which should improve the reliability of the tests

