### PR TITLE
Make template builds for v5 actually point at v5

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -18,7 +18,7 @@ end
 if ENV["BRANCH"]
   gem "geoblacklight", github: "geoblacklight/geoblacklight", branch: ENV["BRANCH"]
 else
-  gem "geoblacklight", "~> 4.0"
+  gem "geoblacklight", "~> 5.0"
 end
 
 run "bundle install"


### PR DESCRIPTION
This won't work right now because there isn't a v5 released to
rubygems that satisfies the version lock (only prereleases),
but it will as soon as one is released.

Fixes #1610
