### PR TITLE
Use the publicly available seed rake task for generated apps

### DIFF
--- a/lib/tasks/geoblacklight.rake
+++ b/lib/tasks/geoblacklight.rake
@@ -23,7 +23,7 @@ namespace :geoblacklight do
   desc "Run Solr and GeoBlacklight for interactive development"
   task :server, [:rails_server_args] do |_t, args|
     with_solr do
-      Rake::Task["geoblacklight:internal:seed"].invoke
+      Rake::Task["geoblacklight:index:seed"].invoke
 
       puts "Starting GeoBlacklight (Rails server)"
       puts " "


### PR DESCRIPTION
This fixes an issue where apps newly generated using the
template.rb can't start because they can't access the internal
version of the seed task, which is defined in the Rakefile
instead of in lib/.

We want the bundled version of the seed task, not the top-level
one.
