### PR TITLE
remove unnecessary styles

### DIFF
--- a/app/assets/stylesheets/geoblacklight/modules/geosearch.scss
+++ b/app/assets/stylesheets/geoblacklight/modules/geosearch.scss
@@ -1,9 +1,3 @@
-.search-control {
-  background-color: #FFF;
-  border-radius: 4px;
-  box-shadow: 0 1px 5px rgba(0,0,0,0.65);
-}
-
 .search-control a {
   color: #FFF
 }


### PR DESCRIPTION
This code actually adds a white border to the button https://private-user-images.githubusercontent.com/13892693/370072140-4ece882a-7337-42c8-b002-525bfc4aedf1.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NDMwMDUxMzIsIm5iZiI6MTc0MzAwNDgzMiwicGF0aCI6Ii8xMzg5MjY5My8zNzAwNzIxNDAtNGVjZTg4MmEtNzMzNy00MmM4LWIwMDItNTI1YmZjNGFlZGYxLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNTAzMjYlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjUwMzI2VDE2MDAzMlomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPWVkMzhiOWVkMjk5NTdlNmJhYWU4NWNmYzkzMDJlODQ0NTNmMzUzMWU5ZTEyNTAzZGQzYzNjNDgyZjUxNWU2M2ImWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.93J71urtvfdNyRAf9mv9maut4G64fdHTMTZTjBHFXW4

This CSS is unnecessary because .search-control has a child element with the class .btn that now does all of this.