### PR TITLE
refactor sidebar_component

### DIFF
--- a/app/components/geoblacklight/document/sidebar_component.html.erb
+++ b/app/components/geoblacklight/document/sidebar_component.html.erb
@@ -1,12 +1,12 @@
-<%= render Geoblacklight::StaticMapComponent.new(document:) %>
+<%= render_static_map_component %>
 <%= render_show_tools %>
 
 <div class="sidebar-buttons">
-  <%= render Geoblacklight::WebServicesLinkComponent.new(document:) %>
-  <%= render Geoblacklight::DownloadLinksComponent.new(document:) %>
-  <%= render Geoblacklight::LoginLinkComponent.new(document:) %>
+  <% sidebar_buttons.each do | sidebar_button |  %>
+    <%= render sidebar_button %>
+  <% end %>
 </div>
 
-<%= render Blacklight::Document::MoreLikeThisComponent.new(document: document) %>
+<%= render_more_like_this %>
 
 <%= render "relations_container", document: document %>

--- a/app/components/geoblacklight/document/sidebar_component.rb
+++ b/app/components/geoblacklight/document/sidebar_component.rb
@@ -3,6 +3,21 @@
 module Geoblacklight
   module Document
     class SidebarComponent < Blacklight::Document::SidebarComponent
+      def render_static_map_component
+        render Geoblacklight::StaticMapComponent.new(document:)
+      end
+
+      def sidebar_buttons
+        [
+          Geoblacklight::WebServicesLinkComponent.new(document:),
+          Geoblacklight::DownloadLinksComponent.new(document:),
+          Geoblacklight::LoginLinkComponent.new(document:)
+        ]
+      end
+
+      def render_more_like_this
+        render Blacklight::Document::MoreLikeThisComponent.new(document:)
+      end
     end
   end
 end


### PR DESCRIPTION
If a user wants to update any of the components in the sidebar they need to override the entire sidebar component (for example if they only want two of the sidebar buttons, they have to override the whole component html). This updates it so they can override the rb file and only update the components they want to. It also brings this more in line with blacklight's way of doing things. 