### PR TITLE
Remove console.log statements

### DIFF
--- a/app/javascript/geoblacklight/leaflet/controls/layer_opacity.js
+++ b/app/javascript/geoblacklight/leaflet/controls/layer_opacity.js
@@ -50,7 +50,7 @@ export default class LayerOpacityControl extends Control {
       try {
         layer.setOpacity(opacity);
       } catch {
-        console.log(layer)
+        console.error("Couldn't set opacity for layer", layer)
       }
     }
   }

--- a/app/javascript/geoblacklight/leaflet/controls/sleep.js
+++ b/app/javascript/geoblacklight/leaflet/controls/sleep.js
@@ -60,7 +60,6 @@ export default class Sleep extends Handler {
 
     if (_this._map.options.MARGIN_DISTANCE){
       window.addEventListener("resize", (event) => {
-        console.log(event)
         _this.updateBasedOnSize();
       })
     }
@@ -97,4 +96,3 @@ export default class Sleep extends Handler {
     });
   }
 }
-


### PR DESCRIPTION
This removes one and changes the other to an error, since it
looked like that's what it was intended to do.
