### PR TITLE
Drop support for Rails 6 in GBLv4; update GitHub CI

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       matrix:
         ruby_version: ['3.2', '3.3']
-        rails_version: [6.1.7.6, 7.1.3, 7.2.0]
+        rails_version: [7.1.3, 7.2.0]
 
     name: test ruby ${{ matrix.ruby_version }} / rails ${{ matrix.rails_version }}
     steps:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -68,7 +68,7 @@ jobs:
         ENGINE_CART_RAILS_OPTIONS: '--skip-git --skip-listen --skip-spring --skip-keeps --skip-action-cable --skip-coffee --skip-test --skip-webpack-install --skip-javascript'
         SOLR_URL: http://solr:SolrRocks@localhost:8983/solr/blacklight-core
     - name: Upload coverage artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: coverage

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -10,7 +10,7 @@ jobs:
   linter:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
@@ -23,7 +23,7 @@ jobs:
   aardvark-fixture-linter:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
@@ -42,7 +42,7 @@ jobs:
 
     name: test ruby ${{ matrix.ruby_version }} / rails ${{ matrix.rails_version }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/geoblacklight.gemspec
+++ b/geoblacklight.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.required_rubygems_version = ">= 2.5.2"
 
-  spec.add_dependency "rails", ">= 6.1", "< 7.3"
+  spec.add_dependency "rails", ">= 7", "< 7.3"
   spec.add_dependency "blacklight", "~> 7.0"
   spec.add_dependency "config"
   spec.add_dependency "faraday", "~> 2.0"

--- a/spec/test_app_templates/lib/generators/test_app_generator.rb
+++ b/spec/test_app_templates/lib/generators/test_app_generator.rb
@@ -8,14 +8,6 @@ class TestAppGenerator < Rails::Generators::Base
   def add_gems
     gem "blacklight"
 
-    # In CI, Javascript and Webpacker are removed when generating Rails 6.x
-    # applications to enable Vite. Disabling javascript during test app
-    # generation removes Turbolinks. This gem is required and needs to be
-    # re-added.
-    if ENV["RAILS_VERSION"] && Gem::Version.new(ENV["RAILS_VERSION"]) < Gem::Version.new("7.0")
-      gem "turbolinks"
-    end
-
     Bundler.with_clean_env do
       run "bundle install"
     end


### PR DESCRIPTION
This backports e8b71065ad0358d2c1b01e521cdb7328a1c99990.
