### PR TITLE
Prevent conflicting artifact names for GH CI coverage upload

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -71,5 +71,5 @@ jobs:
       uses: actions/upload-artifact@v4
       if: always()
       with:
-        name: coverage
+        name: "coverage-${{ matrix.ruby_version }}-${{ matrix.rails_version }}"
         path: coverage/


### PR DESCRIPTION
This was fixed in `main` long ago, but is now apparent for `release-4.x` because of #1657 (where you can see tests passed but the CI job failed).