### PR TITLE
Pin blacklight < 8.12

### DIFF
--- a/geoblacklight.gemspec
+++ b/geoblacklight.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.required_rubygems_version = ">= 2.5.2"
 
   spec.add_dependency "rails", ">= 6.1", "< 9"
-  spec.add_dependency "blacklight", "~> 8.0"
+  spec.add_dependency "blacklight", "~> 8.0", "< 8.12"
   spec.add_dependency "config"
   spec.add_dependency "faraday", "~> 2.0"
   spec.add_dependency "coderay"


### PR DESCRIPTION
Blacklight 8.12 and above use view_component v4, which brings a
lot of breaking changes that need to be addressed. This pins
Blacklight to v8.11 or before until we can handle that.

See https://github.com/geoblacklight/geoblacklight/issues/1680.
