### PR TITLE
Index test fixtures using the gem path

### DIFF
--- a/lib/tasks/geoblacklight.rake
+++ b/lib/tasks/geoblacklight.rake
@@ -13,6 +13,7 @@ end
 def with_solr(&block)
   puts "Starting Solr"
   system_with_error_handling "docker compose up -d solr"
+  sleep 5 # give solr a few seconds to load the core config and be ready
   yield
 ensure
   puts "Stopping Solr"


### PR DESCRIPTION
This lets us pull in the fixture data from Geoblacklight's repo
without needing to fetch it remotely from GitHub, by referencing
the files that are bundled with the gem. These always get
installed in your local Geoblacklight, so they're already there
for you to use.

Works both when working on the Geoblacklight gem and working on
your local install.

Might fix https://github.com/geoblacklight/geoblacklight/issues/1668.

Makes #1676 unnecessary because we don't need to do remote
indexing of fixtures anymore.

Also adds a slight delay after solr is loaded in docker to fix issues
where indexing was rejected because the core wasn't ready.
