### PR TITLE
Change bootstrap imports in initializers

### DIFF
--- a/app/javascript/geoblacklight/initializers/popovers.js
+++ b/app/javascript/geoblacklight/initializers/popovers.js
@@ -1,10 +1,10 @@
-import { Popover } from 'bootstrap';
+import * as bootstrap from 'bootstrap';
 
 // Initialize popovers
 export default function initializePopovers() {
   const popoverElements = document.querySelectorAll('[data-bs-toggle="popover"]'); // Bootstrap 5 uses 'data-bs-toggle'
   popoverElements.forEach((element) => {
-    const popover = new Popover(element, {
+    new bootstrap.Popover(element, {
       trigger: "hover",
     });
   });

--- a/app/javascript/geoblacklight/initializers/tooltips.js
+++ b/app/javascript/geoblacklight/initializers/tooltips.js
@@ -1,4 +1,4 @@
-import { Tooltip } from "bootstrap";
+import * as bootstrap from "bootstrap";
 
 export default function initializeTooltips() {
   document.body.addEventListener(
@@ -13,7 +13,7 @@ export default function initializeTooltips() {
 
         if (titleText !== undefined && titleText !== "") {
           // Initialize Bootstrap tooltip with native JavaScript
-          const tooltip = new Tooltip(svgElement, {
+          const tooltip = new bootstrap.Tooltip(svgElement, {
             placement: "bottom",
             title: titleText,
           });


### PR DESCRIPTION
This fixes an error in the importmap build because the Tooltip
and Popover classes weren't export from the bootstrap module
at the top level.
