### PR TITLE
Fix importmap cache sweeper path

### DIFF
--- a/lib/geoblacklight/engine.rb
+++ b/lib/geoblacklight/engine.rb
@@ -32,7 +32,7 @@ module Geoblacklight
       next unless app.config.respond_to?(:importmap) # skip for Vite
 
       app.config.importmap.paths << Engine.root.join("config/importmap.rb")
-      app.config.importmap.cache_sweepers << Engine.root.join("app/assets/javascripts")
+      app.config.importmap.cache_sweepers << Engine.root.join("app/javascript")
     end
   end
 end


### PR DESCRIPTION
Without this fix, propshaft would generate new digest filenames
every time you change a JS file in development, which would
cause the browser to 404 when requesting the new file when
you reloaded. This would only be resolved by restarting the
rails server.

Now, if you change a JS file in local dev and reload, the browser
importmap will pick up the new path to the file.
