### PR TITLE
Remove `enableRemoteStreaming` from configuration

### DIFF
--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -94,7 +94,7 @@
   </query>
 
   <requestDispatcher handleSelect="false">
-    <requestParsers enableRemoteStreaming="true" multipartUploadLimitInKB="2048000" formdataUploadLimitInKB="2048"/>
+    <requestParsers multipartUploadLimitInKB="2048000" formdataUploadLimitInKB="2048"/>
     <httpCaching never304="true"/>
    </requestDispatcher>
 


### PR DESCRIPTION
This is no longer the default (as of Solr 7.x), and Solr maintainers [recommend removing it](https://solr.apache.org/guide/solr/latest/indexing-guide/content-streams.html#remote-streaming).