### PR TITLE
Don't truncate abstracts equal to minHeight

### DIFF
--- a/app/javascript/geoblacklight/initializers/truncation.js
+++ b/app/javascript/geoblacklight/initializers/truncation.js
@@ -6,7 +6,7 @@ class Truncator {
   constructor(element, { lines, id }) {
     // if the element is already small enough, don't truncate it
     const minHeight = lines * parseFloat(window.getComputedStyle(element).fontSize);
-    if (element.getBoundingClientRect().height < minHeight) return;
+    if (element.getBoundingClientRect().height <= minHeight) return;
 
     // set a unique ID for the element if it doesn't have one
     this.element = element;


### PR DESCRIPTION
Fixes: https://github.com/geoblacklight/geoblacklight/issues/1661

Updates truncation logic to not add a Read More link when abstract length is <= computed min height.

Before:
<img width="861" height="257" alt="Screenshot 2026-01-27 at 9 18 40 AM" src="https://github.com/user-attachments/assets/9325d6e0-4715-4542-a8b2-773c19f30164" />

After:
<img width="859" height="231" alt="Screenshot 2026-01-27 at 9 18 13 AM" src="https://github.com/user-attachments/assets/4a2e0a64-8044-4d74-8597-231366a8bdf5" />