### PR TITLE
Update ARCGIS_BASE_URL to new map viewer

### DIFF
--- a/lib/generators/geoblacklight/templates/settings.yml
+++ b/lib/generators/geoblacklight/templates/settings.yml
@@ -1,5 +1,5 @@
 # ArcGIS Online Base URL
-ARCGIS_BASE_URL: 'https://www.arcgis.com/home/webmap/viewer.html'
+ARCGIS_BASE_URL: 'https://www.arcgis.com/apps/mapviewer/index.html'
 
 # Download path can be configured using this setting
 #DOWNLOAD_PATH: "./tmp/cache/downloads"


### PR DESCRIPTION
Addresses: https://github.com/geoblacklight/geoblacklight/issues/1671

Points ARCGIS_BASE_URL to the new ArcGIS Map Viewer in the settings template due to upcoming deprecation of ArcGIS Map Viewer Classic: https://doc.arcgis.com/en/arcgis-online/reference/view-maps.htm