### PR TITLE
Backport ARCGIS_BASE_URL update to 5.x

### DIFF
--- a/lib/generators/geoblacklight/templates/settings.yml
+++ b/lib/generators/geoblacklight/templates/settings.yml
@@ -1,5 +1,5 @@
 # ArcGIS Online Base URL
-ARCGIS_BASE_URL: 'https://www.arcgis.com/home/webmap/viewer.html'
+ARCGIS_BASE_URL: 'https://www.arcgis.com/apps/mapviewer/index.html'
 
 # Download path can be configured using this setting
 #DOWNLOAD_PATH: "./tmp/cache/downloads"


### PR DESCRIPTION
Backport https://github.com/geoblacklight/geoblacklight/pull/1735 to release-5.x.

Addresses: https://github.com/geoblacklight/geoblacklight/issues/1671