### PR TITLE
Fix bug in Aardvark JSON validation file

### DIFF
--- a/schema/geoblacklight-schema-aardvark.json
+++ b/schema/geoblacklight-schema-aardvark.json
@@ -190,8 +190,8 @@
       "type": "string",
       "const": "Aardvark"
     },
-    "gbl_suppressed_b": { "type": "boolean" },
-    "gbl_georeferenced_b": { "type": "boolean" }
+    "gbl_suppressed_b": { "type": ["string", "boolean"] },
+    "gbl_georeferenced_b": { "type": ["string", "boolean"] }
   },
   "required": ["id", "dct_title_s", "gbl_resourceClass_sm", "dct_accessRights_s", "gbl_mdVersion_s"]
 }


### PR DESCRIPTION
Addresses https://github.com/geoblacklight/geoblacklight/issues/1627

The Aardvark schema validation file only permits boolean values for `gbl_suppressed_b` and `gbl_georeferenced_b`, but the metadata schema allows both string and boolean values. This PR adds "string" as an option for validation.