### PR TITLE
Backport: add "string" as option to 'gbl_suppressed_b' and 'gbl_georeferenced_b'

### DIFF
--- a/schema/geoblacklight-schema-aardvark.json
+++ b/schema/geoblacklight-schema-aardvark.json
@@ -190,8 +190,8 @@
       "type": "string",
       "const": "Aardvark"
     },
-    "gbl_suppressed_b": { "type": "boolean" },
-    "gbl_georeferenced_b": { "type": "boolean" }
+    "gbl_suppressed_b": { "type": ["string", "boolean"] },
+    "gbl_georeferenced_b": { "type": ["string", "boolean"] }
   },
   "required": ["id", "dct_title_s", "gbl_resourceClass_sm", "dct_accessRights_s", "gbl_mdVersion_s"]
 }


### PR DESCRIPTION
this backports #1745 to v5.