### PR TITLE
Backport leaflet-fullscreen fixes to v5

### DIFF
--- a/app/javascript/geoblacklight/controllers/leaflet_viewer_controller.js
+++ b/app/javascript/geoblacklight/controllers/leaflet_viewer_controller.js
@@ -1,5 +1,5 @@
 import { Icon, Control } from "leaflet";
-import "leaflet-fullscreen";
+import { FullScreen } from "leaflet.fullscreen";
 import { layerGroup, polygon, map, tileLayer } from "leaflet";
 import { imageMapLayer } from "esri-leaflet";
 import { Controller } from "@hotwired/stimulus";
@@ -146,7 +146,7 @@ export default class LeafletViewerController extends Controller {
     if (controlName == "Opacity")
       return new LayerOpacityControl(this.previewOverlay);
     if (controlName == "Fullscreen")
-      return new Control.Fullscreen({ position: "topright", ...controlOptions });
+      return new FullScreen({ position: "topright", ...controlOptions });
     if (controlName == "Geosearch")
       return new GeoSearchControl({ baseUrl: this.catalogBaseUrlValue, ...controlOptions });
     console.error(`Unsupported control name: "${controlName}"`);

--- a/lib/generators/geoblacklight/assets/importmap_generator.rb
+++ b/lib/generators/geoblacklight/assets/importmap_generator.rb
@@ -21,16 +21,19 @@ module Geoblacklight
         delivered via CDN.
       DESCRIPTION
 
-      # Switch bootstrap import to ESM version so we can import individual parts
+      # Switch Blacklight's bootstrap and popper imports to ESM versions so we
+      # can import individual modules
       def use_bootstrap_esm
-        gsub_file "config/importmap.rb", /dist\/js\/bootstrap\.js/, "dist/js/bootstrap.esm.js"
+        gsub_file "config/importmap.rb", %r{dist/js/bootstrap.js}, "dist/js/bootstrap.esm.js"
+        gsub_file "config/importmap.rb", %r{dist/umd/popper.min.js}, "dist/esm/popper.js"
       end
 
-      # Add the customization overrides and insert before bootstrap import
+      # Add the SCSS customization overrides and insert before bootstrap import
       def add_customizations
         copy_file "assets/_customizations.scss", "app/assets/stylesheets/_customizations.scss"
         gsub_file "app/assets/stylesheets/_customizations.scss", "@geoblacklight/frontend/app/assets/", ""
-        insert_into_file "app/assets/stylesheets/application.bootstrap.scss", "@import 'customizations';\n", before: "@import 'bootstrap/scss/bootstrap';"
+        insert_into_file "app/assets/stylesheets/application.bootstrap.scss", "@import 'customizations';\n",
+          before: "@import 'bootstrap/scss/bootstrap';"
       end
 
       # Add CDN imports for CSS files used by Geoblacklight (leaflet, openlayers)
@@ -38,9 +41,9 @@ module Geoblacklight
         insert_into_file "app/assets/stylesheets/application.bootstrap.scss", before: "@import 'customizations';\n" do
           <<~SCSS
             /* GeoBlacklight dependencies CSS */
-            @import url("https://cdn.skypack.dev/leaflet@1.9.4/dist/leaflet.css");
-            @import url("https://cdn.jsdelivr.net/npm/leaflet-fullscreen@1.0.2/dist/leaflet.fullscreen.css");
-            @import url("https://cdn.skypack.dev/ol@8.1.0/ol.css");
+            @import url("https://cdn.jsdelivr.net/npm/leaflet@1.9.4/dist/leaflet.css");
+            @import url("https://cdn.jsdelivr.net/npm/leaflet.fullscreen@5.3.0/dist/Control.FullScreen.css");
+            @import url("https://cdn.jsdelivr.net/npm/ol@8.1.0/ol.css");
 
           SCSS
         end

--- a/lib/generators/geoblacklight/assets/vite_generator.rb
+++ b/lib/generators/geoblacklight/assets/vite_generator.rb
@@ -16,14 +16,21 @@ module Geoblacklight
       SCSS entrypoint file, which will be bundled by Vite.
 
       Geoblacklight's frontend assets are installed from the npm package. In
-      local development they automatically reference the versions from the
-      outer directory (the Geoblacklight repository) via a yarn symlink.
+      CI they automatically reference the versions from the outer directory
+      (the Geoblacklight repository) via a yarn symlink.
       DESCRIPTION
 
       # Install Vite
       def install_vite_rails
         gem "vite_rails", "~> 3.0"
         run "bundle install"
+      end
+
+      # Symlink geoblacklight's frontend assets in CI
+      def link_geoblacklight_package
+        if options[:test]
+          run "yarn link @geoblacklight/frontend"
+        end
       end
 
       # Add our version of the Blacklight base layout with Vite helper tags

--- a/lib/generators/geoblacklight/templates/assets/application.scss
+++ b/lib/generators/geoblacklight/templates/assets/application.scss
@@ -2,7 +2,7 @@
 
 // Leaflet, OpenLayers, GeoBlacklight (includes Blacklight and Bootstrap)
 @import "leaflet/dist/leaflet.css";
-@import "leaflet-fullscreen/dist/leaflet.fullscreen.css";
+@import "leaflet.fullscreen/dist/Control.FullScreen.css";
 @import "ol/ol.css";
 @import "~/stylesheets/geoblacklight.scss";
 

--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
     "bootstrap": "^5.3.3",
     "esri-leaflet": "^3.0.12",
     "leaflet": "^1.9.4",
-    "leaflet-iiif": "^3.0.0",
-    "leaflet-fullscreen": "^1.0.2",
+    "leaflet.fullscreen": "^5.3.0",
     "ol": "10.7.0",
     "ol-pmtiles": "^2.0.2"
   },

--- a/spec/features/full_screen_control_spec.rb
+++ b/spec/features/full_screen_control_spec.rb
@@ -5,20 +5,18 @@ require "spec_helper"
 feature "Leaflet fullscreen control", js: true do
   scenario "WMS layer should have full screen control" do
     visit solr_document_path("stanford-cz128vq0535")
-    expect(page).to have_css(".leaflet-control-fullscreen-button", visible: :all)
+    expect(page).to have_css(".leaflet-control-zoom-fullscreen")
   end
 end
 
-feature "Clover IIIF fullscreen control", js: true do
+feature "IIIF fullscreen control", js: true do
   scenario "IIIF layer should have full screen control" do
-    skip "Clover is disabled" # see https://github.com/geoblacklight/geoblacklight/issues/1675
     visit solr_document_path("princeton-sx61dn82p")
-    expect(page).to have_button("Toggle full page")
+    expect(page).to have_button("Full screen")
   end
 
   scenario "IIIF image should have full screen control" do
-    skip "Clover is disabled" # see https://github.com/geoblacklight/geoblacklight/issues/1675
     visit solr_document_path("princeton-02870w62c")
-    expect(page).to have_css("[data-button='full-page']")
+    expect(page).to have_css("img[alt='Toggle full page']")
   end
 end


### PR DESCRIPTION
This backports some fixes to our fullscreen control needed for importmap compatibility.

Also re-adds the `yarn link` process for vite builds in CI, because otherwise you don't get the version of the Geoblacklight package from `main` – only the most recently released version.