### PR TITLE
Make importmaps the default asset pipeline for new v5 apps

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -39,13 +39,13 @@ jobs:
       matrix:
         ruby_version: ["3.2", "3.3", "3.4"]
         rails_version: ["7.2.3", "8.1.1"]
-        asset_pipeline: ["vite"]
-        additional_engine_cart_rails_options: ["--js rollup"]
+        asset_pipeline: ["importmap"]
+        additional_engine_cart_rails_options: ["--js importmap"]
         include:
           - ruby_version: "3.4"
             rails_version: "8.1.1"
-            asset_pipeline: "importmap"
-            additional_engine_cart_rails_options: "--js importmap"
+            asset_pipeline: "vite"
+            additional_engine_cart_rails_options: "--js rollup"
 
     name: test ruby ${{ matrix.ruby_version }} / rails ${{ matrix.rails_version }} / ${{ matrix.asset_pipeline }}
     steps:

--- a/lib/generators/geoblacklight/assets_generator.rb
+++ b/lib/generators/geoblacklight/assets_generator.rb
@@ -4,7 +4,7 @@ module Geoblacklight
   # Run general asset setup and then delegate to the appropriate generator
   # Based on Blacklight::AssetsGenerator
   class AssetsGenerator < Rails::Generators::Base
-    class_option :"asset-pipeline", type: :string, default: ENV.fetch("ASSET_PIPELINE", "vite"), desc: "Choose the asset pipeline to use (vite or importmap)"
+    class_option :"asset-pipeline", type: :string, default: ENV.fetch("ASSET_PIPELINE", "importmap"), desc: "Choose the asset pipeline to use (vite or importmap)"
     class_option :test, type: :boolean, default: ENV.fetch("CI", false), aliases: "-t", desc: "Indicates that app will be installed in a test environment"
 
     # Pick a version of the frontend asset package and install it.
@@ -27,7 +27,7 @@ module Geoblacklight
       generator = if options[:"asset-pipeline"]
         "geoblacklight:assets:#{options[:"asset-pipeline"]}"
       else
-        "geoblacklight:assets:vite"
+        "geoblacklight:assets:importmap"
       end
 
       generate generator, generated_options


### PR DESCRIPTION
This aligns with the recommendation we make in the v5 docs to
use importmaps instead of vite.
