### PR TITLE
Backport: rewrite a flappy test for saved searches

### DIFF
--- a/spec/features/saved_searches_spec.rb
+++ b/spec/features/saved_searches_spec.rb
@@ -4,14 +4,7 @@ require "spec_helper"
 
 feature "saved searches" do
   scenario "list spatial search", js: true do
-    visit root_path
-    within "#leaflet-viewer" do
-      find(".search-control a").click
-      expect(page.current_url).to match(/bbox=/)
-    end
-    if Rails.version == "6.1.7.6"
-      visit root_path({bbox: "-180 -89.338214 180 88.918831"})
-    end
+    visit root_path({bbox: "-180 -89.338214 180 88.918831"})
     visit blacklight.search_history_path
     expect(page).to have_css "td.query a", text: /#{I18n.t("geoblacklight.bbox_label")}/
   end


### PR DESCRIPTION
This has been intermittently failing. Simplifies the test by just
visiting the desired URL instead of using the Leaflet map to set
it.
