### PR TITLE
Add visibility helpers to fullscreen tests

### DIFF
--- a/spec/features/full_screen_control_spec.rb
+++ b/spec/features/full_screen_control_spec.rb
@@ -5,18 +5,18 @@ require "spec_helper"
 feature "Leaflet fullscreen control", js: true do
   scenario "WMS layer should have full screen control" do
     visit solr_document_path("stanford-cz128vq0535")
-    expect(page).to have_css(".leaflet-control-zoom-fullscreen")
+    expect(page).to have_css(".leaflet-control-zoom-fullscreen", visible: :all)
   end
 end
 
 feature "IIIF fullscreen control", js: true do
   scenario "IIIF layer should have full screen control" do
     visit solr_document_path("princeton-sx61dn82p")
-    expect(page).to have_button("Full screen")
+    expect(page).to have_button("Full screen", visible: :all)
   end
 
   scenario "IIIF image should have full screen control" do
     visit solr_document_path("princeton-02870w62c")
-    expect(page).to have_css("img[alt='Toggle full page']")
+    expect(page).to have_css("img[alt='Toggle full page']", visible: :all)
   end
 end


### PR DESCRIPTION
These were sometimes failing in CI but passing locally, so they
get the "visibility: :all" treatement.

See https://github.com/geoblacklight/geoblacklight/actions/runs/26588258789/job/78344637646?pr=1766
