### PR TITLE
Create a geoblacklight configuration with a well defined API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,9 @@ gemspec path: File.expand_path(".")
 # engine_cart: 2.6.0
 # engine_cart stanza: 2.5.0
 # the below comes from engine_cart, a gem used to test this Rails engine gem in the context of a Rails app.
-file = File.expand_path("Gemfile", ENV["ENGINE_CART_DESTINATION"] || ENV["RAILS_ROOT"] || File.expand_path(".internal_test_app", File.dirname(__FILE__)))
+file = File.expand_path("Gemfile",
+  ENV["ENGINE_CART_DESTINATION"] || ENV["RAILS_ROOT"] || File.expand_path(".internal_test_app",
+    File.dirname(__FILE__)))
 if File.exist?(file)
   begin
     eval_gemfile file

--- a/app/components/geoblacklight/arcgis_component.rb
+++ b/app/components/geoblacklight/arcgis_component.rb
@@ -15,7 +15,7 @@ module Geoblacklight
       params = URI.encode_www_form(
         urls: document.arcgis_urls
       )
-      Settings.ARCGIS_BASE_URL + "?" + params
+      Geoblacklight.configuration.arcgis_base_url + "?" + params
     end
 
     def key

--- a/app/components/geoblacklight/display_note_component.rb
+++ b/app/components/geoblacklight/display_note_component.rb
@@ -41,7 +41,8 @@ module Geoblacklight
     end
 
     def prefixes
-      Settings.DISPLAY_NOTES_SHOWN.map { |key, value| [value.note_prefix, [value.bootstrap_alert_class, value.icon]] }.to_h
+      Geoblacklight.configuration.display_notes_shown
+        .map { |key, value| [value.note_prefix, [value.bootstrap_alert_class, value.icon]] }.to_h
     end
   end
 end

--- a/app/components/geoblacklight/header_icons_component.rb
+++ b/app/components/geoblacklight/header_icons_component.rb
@@ -4,14 +4,16 @@ module Geoblacklight
   class HeaderIconsComponent < ViewComponent::Base
     attr_reader :document, :fields
 
-    def initialize(document:, fields: [Settings.FIELDS.RESOURCE_CLASS, Settings.FIELDS.ACCESS_RIGHTS])
+    def initialize(document:,
+      fields: [Geoblacklight.configuration.fields.resource_class,
+        Geoblacklight.configuration.fields.access_rights])
       @document = document
       @fields = fields
       super()
     end
 
     def icon(field)
-      return resource_icon if field == Settings.FIELDS.RESOURCE_CLASS
+      return resource_icon if field == Geoblacklight.configuration.fields.resource_class
 
       helpers.geoblacklight_icon(@document[field], classes: "svg_tooltip")
     end

--- a/app/components/geoblacklight/iiif_drag_drop_component.rb
+++ b/app/components/geoblacklight/iiif_drag_drop_component.rb
@@ -6,11 +6,11 @@ module Geoblacklight
       super()
       manifest_ref = document.item_viewer&.iiif_manifest
       @manifest = manifest_ref&.endpoint || ""
-      @href_link = Settings.IIIF_DRAG_DROP_LINK&.gsub("@manifest", @manifest)
+      @href_link = Geoblacklight.configuration.iiif_drag_drop_link.gsub("@manifest", @manifest)
     end
 
     def render?
-      Settings.IIIF_DRAG_DROP_LINK.present? && @manifest.present?
+      @manifest.present? && @href_link.present?
     end
   end
 end

--- a/app/components/geoblacklight/location_leaflet_map_component.rb
+++ b/app/components/geoblacklight/location_leaflet_map_component.rb
@@ -4,7 +4,7 @@ module Geoblacklight
   class LocationLeafletMapComponent < ViewComponent::Base
     def initialize(
       id: "leaflet-viewer",
-      map_geometry: Settings.HOMEPAGE_MAP_GEOM,
+      map_geometry: Geoblacklight.configuration.homepage_map_geom,
       classes: "",
       page: nil,
       geosearch: nil

--- a/app/components/geoblacklight/relations_component.html.erb
+++ b/app/components/geoblacklight/relations_component.html.erb
@@ -14,7 +14,7 @@
     <% end %>
     <% unless (relationship_type_results['numFound'].to_i <= 3) %>
       <li class="list-group-item border-bottom-0">
-        <%= link_to search_catalog_path({f: {"#{Settings.RELATIONSHIPS_SHOWN.public_send(relationship_type).field}" => [relations.link_id]}}) do %>
+        <%= link_to search_catalog_path({f: {"#{Geoblacklight.configuration.relationships_shown.public_send(relationship_type).field}" => [relations.link_id]}}) do %>
           <%= t('geoblacklight.relations.browse_all', count: relationship_type_results['numFound']) %>
         <% end %>
       </li>

--- a/app/components/geoblacklight/static_map_component.rb
+++ b/app/components/geoblacklight/static_map_component.rb
@@ -10,7 +10,7 @@ module Geoblacklight
     end
 
     def render?
-      Settings.SIDEBAR_STATIC_MAP&.any? { |vp| @document.viewer_protocol == vp }
+      Geoblacklight.configuration.sidebar_static_map&.any? { |vp| @document.viewer_protocol == vp }
     end
 
     def before_render

--- a/app/components/geoblacklight/viewer_help_text_component.rb
+++ b/app/components/geoblacklight/viewer_help_text_component.rb
@@ -40,7 +40,7 @@ module Geoblacklight
     end
 
     def render?
-      Settings&.HELP_TEXT&.public_send(@feature)&.include?(@key)
+      Geoblacklight.configuration.help_text.fetch(@feature.to_sym, []).include?(@key)
     end
   end
 end

--- a/app/components/geoblacklight/web_services_component.rb
+++ b/app/components/geoblacklight/web_services_component.rb
@@ -12,7 +12,7 @@ module Geoblacklight
     end
 
     def render?
-      Settings.WEBSERVICES_SHOWN.include? @type
+      Geoblacklight.configuration.webservices_shown.include? @type
     end
 
     def render_web_services

--- a/app/controllers/wms_controller.rb
+++ b/app/controllers/wms_controller.rb
@@ -12,6 +12,6 @@ class WmsController < ApplicationController
   private
 
   def wms_params
-    params.permit(Settings.GBL_PARAMS)
+    params.permit(Geoblacklight.configuration.gbl_params)
   end
 end

--- a/app/models/concerns/geoblacklight/solr_document.rb
+++ b/app/models/concerns/geoblacklight/solr_document.rb
@@ -15,20 +15,21 @@ module Geoblacklight
     delegate :viewer_endpoint, to: :item_viewer
 
     included do
-      attribute :display_note, :array, Settings.FIELDS.DISPLAY_NOTE
-      attribute :geom_field, :string, Settings.FIELDS.GEOMETRY
-      attribute :wxs_identifier, :string, Settings.FIELDS.WXS_IDENTIFIER
-      attribute :file_format, :string, Settings.FIELDS.FORMAT
-      attribute :rights_field_data, :string, Settings.FIELDS.ACCESS_RIGHTS
-      attribute :provider, :string, Settings.FIELDS.PROVIDER
-      attribute :resource_type, :array, Settings.FIELDS.RESOURCE_TYPE
-      attribute :resource_class, :array, Settings.FIELDS.RESOURCE_CLASS
-      attribute :title, :string, Settings.FIELDS.TITLE
-      attribute :creator, :array, Settings.FIELDS.CREATOR
-      attribute :publisher, :string, Settings.FIELDS.PUBLISHER
-      attribute :identifiers, :array, Settings.FIELDS.IDENTIFIER
-      attribute :issued, :string, Settings.FIELDS.DATE_ISSUED
-      attribute :format, :string, Settings.FIELDS.FORMAT
+      field_config = Geoblacklight.configuration.fields
+      attribute :display_note, :array, field_config.display_note
+      attribute :geom_field, :string, field_config.geometry
+      attribute :wxs_identifier, :string, field_config.wxs_identifier
+      attribute :file_format, :string, field_config.format
+      attribute :rights_field_data, :string, field_config.access_rights
+      attribute :provider, :string, field_config.provider
+      attribute :resource_type, :array, field_config.resource_type
+      attribute :resource_class, :array, field_config.resource_class
+      attribute :title, :string, field_config.title
+      attribute :creator, :array, field_config.creator
+      attribute :publisher, :string, field_config.publisher
+      attribute :identifiers, :array, field_config.identifier
+      attribute :issued, :string, field_config.date_issued
+      attribute :format, :string, field_config.format
     end
 
     def available?
@@ -60,7 +61,7 @@ module Geoblacklight
     end
 
     def same_institution?
-      provider&.casecmp?(Settings.INSTITUTION.downcase)
+      provider&.casecmp?(Geoblacklight.configuration.institution.downcase)
     end
 
     def iiif_download

--- a/app/models/concerns/geoblacklight/suppressed_records_search_behavior.rb
+++ b/app/models/concerns/geoblacklight/suppressed_records_search_behavior.rb
@@ -16,17 +16,17 @@ module Geoblacklight
       # Show suppressed records when searching relationships
       return if blacklight_params.fetch(:f,
         {}).keys.any? do |field|
-                  Settings.RELATIONSHIPS_SHOWN.map do |_key, value|
+                  Geoblacklight.configuration.relationships_shown.map do |_key, value|
                     value.field
                   end.include?(field)
                 end
 
       # Do not suppress action_documents method calls for individual documents
       # ex. CatalogController#web_services (exportable views)
-      return if solr_params[:q]&.include?("{!lucene}#{Settings.FIELDS.ID}:")
+      return if solr_params[:q]&.include?("{!lucene}#{Geoblacklight.configuration.fields.id}:")
 
       solr_params[:fq] ||= []
-      solr_params[:fq] << "-#{Settings.FIELDS.SUPPRESSED}: true"
+      solr_params[:fq] << "-#{Geoblacklight.configuration.fields.suppressed}: true"
     end
   end
 end

--- a/app/views/catalog/_home_text.html.erb
+++ b/app/views/catalog/_home_text.html.erb
@@ -1,19 +1,19 @@
-<div class='container'>
-  <div class='row text-center'>
-    <div class='col-sm'>
+<div class="container">
+  <div class="row text-center">
+    <div class="col-sm">
       <%= content_tag :h3, t('geoblacklight.home.category_heading') %>
-      <div class='row'>
-        <%= render(Geoblacklight::HomepageFeatureFacetComponent.new(icon: 'home', label: 'geoblacklight.home.institution', facet_field: Settings.FIELDS.PROVIDER, response: @response)) %>
+      <div class="row">
+        <%= render(Geoblacklight::HomepageFeatureFacetComponent.new(icon: 'home', label: 'geoblacklight.home.institution', facet_field: Geoblacklight.configuration.fields.provider, response: @response)) %>
 
-        <%= render(Geoblacklight::HomepageFeatureFacetComponent.new(icon: 'arrow-circle-down', label: 'geoblacklight.home.data_type', facet_field: Settings.FIELDS.RESOURCE_TYPE, response: @response)) %>
+        <%= render(Geoblacklight::HomepageFeatureFacetComponent.new(icon: 'arrow-circle-down', label: 'geoblacklight.home.data_type', facet_field: Geoblacklight.configuration.fields.resource_type, response: @response)) %>
       </div>
-      <div class='row'>
-        <%= render(Geoblacklight::HomepageFeatureFacetComponent.new(icon: 'globe', label: 'geoblacklight.home.placename', facet_field: Settings.FIELDS.SPATIAL_COVERAGE, response: @response)) %>
+      <div class="row">
+        <%= render(Geoblacklight::HomepageFeatureFacetComponent.new(icon: 'globe', label: 'geoblacklight.home.placename', facet_field: Geoblacklight.configuration.fields.spatial_coverage, response: @response)) %>
 
-        <%= render(Geoblacklight::HomepageFeatureFacetComponent.new(icon: 'tags', label: 'geoblacklight.home.subject', facet_field: Settings.FIELDS.SUBJECT, response: @response)) %>
+        <%= render(Geoblacklight::HomepageFeatureFacetComponent.new(icon: 'tags', label: 'geoblacklight.home.subject', facet_field: Geoblacklight.configuration.fields.subject, response: @response)) %>
       </div>
     </div>
-    <div class='col-sm'>
+    <div class="col-sm">
       <%= content_tag :h3, t('geoblacklight.home.map_heading') %>
       <%= render(Geoblacklight::LocationLeafletMapComponent.new(page: 'home', geosearch: { dynamic: false }, classes: 'border')) %>
     </div>

--- a/app/views/relation/index.html.erb
+++ b/app/views/relation/index.html.erb
@@ -1,3 +1,3 @@
-<%- Settings.RELATIONSHIPS_SHOWN.each do |relationship_type, rel_type_info| %>
+<%- Geoblacklight.configuration.relationships_shown.each do |relationship_type, rel_type_info| %>
   <%= render Geoblacklight::RelationsComponent.new(relations: @relations, relationship_type:, rel_type_info:) %>
 <% end %>

--- a/app/views/relation/index.json.jbuilder
+++ b/app/views/relation/index.json.jbuilder
@@ -2,7 +2,7 @@
 
 json.current_doc @relations.search_id
 json.relations do
-  Settings.RELATIONSHIPS_SHOWN.each do |key, _value|
+  Geoblacklight.configuration.relationships_shown.each do |key, _value|
     json.set! key.downcase.to_s, @relations.public_send(key) unless @relations.public_send(key)["numFound"].to_i.zero?
   end
 end

--- a/lib/generators/geoblacklight/install_generator.rb
+++ b/lib/generators/geoblacklight/install_generator.rb
@@ -4,7 +4,7 @@ require "rails/generators"
 
 module Geoblacklight
   class Install < Rails::Generators::Base
-    source_root File.expand_path("../templates", __FILE__)
+    source_root File.expand_path("templates", __dir__)
     desc "Install Geoblacklight"
 
     def allow_geoblacklight_params
@@ -13,7 +13,7 @@ module Geoblacklight
 
         def allow_geoblacklight_params
           # Blacklight::Parameters will pass these to params.permit
-          blacklight_config.search_state_fields.append(Settings.GBL_PARAMS)
+          blacklight_config.search_state_fields.append(Geoblacklight.configuration.gbl_params)
         end
       PARAMS
 
@@ -21,7 +21,8 @@ module Geoblacklight
     end
 
     def raise_unpermitted_params
-      inject_into_file "config/environments/test.rb", "config.action_controller.action_on_unpermitted_parameters = :raise\n", before: /^end/
+      inject_into_file "config/environments/test.rb",
+        "config.action_controller.action_on_unpermitted_parameters = :raise\n", before: /^end/
     end
 
     def mount_geoblacklight_engine
@@ -77,7 +78,7 @@ module Geoblacklight
 
     def add_unique_key
       inject_into_file "app/models/solr_document.rb", after: "# self.unique_key = 'id'" do
-        "\n  self.unique_key = Settings.FIELDS.ID"
+        "\n  self.unique_key = Geoblacklight.configuration.fields.id"
       end
     end
 

--- a/lib/generators/geoblacklight/templates/catalog_controller.rb
+++ b/lib/generators/geoblacklight/templates/catalog_controller.rb
@@ -7,6 +7,9 @@ class CatalogController < ApplicationController
     # Please see https://github.com/projectblacklight/blacklight/pull/2006/
     config.raw_endpoint.enabled = true
 
+    gbl_config = Geoblacklight.configuration
+    field_config = gbl_config.fields
+
     ## Default parameters to send to solr for all search-like requests. See also SolrHelper#solr_search_params
     ## @see https://lucene.apache.org/solr/guide/6_6/common-query-parameters.html
     ## @see https://lucene.apache.org/solr/guide/6_6/the-dismax-query-parser.html#TheDisMaxQueryParser-Theq.altParameter
@@ -24,7 +27,7 @@ class CatalogController < ApplicationController
     #
     config.default_document_solr_params = {
       qt: "document",
-      q: "{!raw f=#{Settings.FIELDS.ID} v=$id}"
+      q: "{!raw f=#{field_config.id} v=$id}"
     }
 
     # GeoBlacklight Defaults
@@ -36,7 +39,7 @@ class CatalogController < ApplicationController
     # config.index.show_link = 'title_display'
     # config.index.record_display_type = 'format'
     config.index.document_component = Geoblacklight::SearchResultComponent
-    config.index.title_field = Settings.FIELDS.TITLE
+    config.index.title_field = field_config.title
 
     # solr field configuration for document/show views
     # This sets the metadata to display below the map viewer.
@@ -84,19 +87,18 @@ class CatalogController < ApplicationController
     # FACETS
 
     # DEFAULT FACETS
-    # to add additional facets, use the keys defined in the settings.yml file
-    config.add_facet_field Settings.FIELDS.INDEX_YEAR, label: "Year", limit: 10
-    config.add_facet_field Settings.FIELDS.SPATIAL_COVERAGE, label: "Place", limit: 8
-    config.add_facet_field Settings.FIELDS.ACCESS_RIGHTS, label: "Access", limit: 8
-    config.add_facet_field Settings.FIELDS.RESOURCE_CLASS, label: "Resource Class", limit: 8
-    config.add_facet_field Settings.FIELDS.RESOURCE_TYPE, label: "Resource Type", limit: 8
-    config.add_facet_field Settings.FIELDS.FORMAT, label: "Format", limit: 8
-    config.add_facet_field Settings.FIELDS.SUBJECT, label: "Subject", limit: 8
-    config.add_facet_field Settings.FIELDS.THEME, label: "Theme", limit: 8
-    config.add_facet_field Settings.FIELDS.CREATOR, label: "Creator", limit: 8
-    config.add_facet_field Settings.FIELDS.PUBLISHER, label: "Publisher", limit: 8
-    config.add_facet_field Settings.FIELDS.PROVIDER, label: "Provider", limit: 8
-    config.add_facet_field Settings.FIELDS.GEOREFERENCED, label: "Georeferenced", limit: 3
+    config.add_facet_field field_config.index_year, label: "Year", limit: 10
+    config.add_facet_field field_config.spatial_coverage, label: "Place", limit: 8
+    config.add_facet_field field_config.access_rights, label: "Access", limit: 8
+    config.add_facet_field field_config.resource_class, label: "Resource Class", limit: 8
+    config.add_facet_field field_config.resource_type, label: "Resource Type", limit: 8
+    config.add_facet_field field_config.format, label: "Format", limit: 8
+    config.add_facet_field field_config.subject, label: "Subject", limit: 8
+    config.add_facet_field field_config.theme, label: "Theme", limit: 8
+    config.add_facet_field field_config.creator, label: "Creator", limit: 8
+    config.add_facet_field field_config.publisher, label: "Publisher", limit: 8
+    config.add_facet_field field_config.provider, label: "Provider", limit: 8
+    config.add_facet_field field_config.georeferenced, label: "Georeferenced", limit: 3
 
     # GEOBLACKLIGHT APPLICATION FACETS
 
@@ -105,19 +107,25 @@ class CatalogController < ApplicationController
     # filter_query_builder - Defines the query generated for Solr
     # filter_class         - Defines how to add/remove facet from query
     # label                - Defines the label used in contstraints container
-    config.add_facet_field Settings.FIELDS.GEOMETRY, item_presenter: Geoblacklight::BboxItemPresenter, filter_class: Geoblacklight::BboxFilterField, filter_query_builder: Geoblacklight::BboxFilterQuery, within_boost: Settings.BBOX_WITHIN_BOOST, overlap_boost: Settings.OVERLAP_RATIO_BOOST, overlap_field: Settings.FIELDS.OVERLAP_FIELD, label: "Bounding Box"
+    config.add_facet_field field_config.geometry, item_presenter: Geoblacklight::BboxItemPresenter,
+      filter_class: Geoblacklight::BboxFilterField,
+      filter_query_builder: Geoblacklight::BboxFilterQuery,
+      within_boost: gbl_config.bbox_within_boost,
+      overlap_boost: gbl_config.overlap_ratio_boost,
+      overlap_field: field_config.overlap_field,
+      label: "Bounding Box"
 
     # Item Relationship Facets
     # * Not displayed to end user (show: false)
     # * Must be present for relationship "Browse all 4 records" links to work
     # * Label value becomes the search contraint filter name
-    config.add_facet_field Settings.FIELDS.MEMBER_OF, label: "Member Of", show: false
-    config.add_facet_field Settings.FIELDS.IS_PART_OF, label: "Is Part Of", show: false
-    config.add_facet_field Settings.FIELDS.RELATION, label: "Related", show: false
-    config.add_facet_field Settings.FIELDS.REPLACES, label: "Replaces", show: false
-    config.add_facet_field Settings.FIELDS.IS_REPLACED_BY, label: "Is Replaced By", show: false
-    config.add_facet_field Settings.FIELDS.SOURCE, label: "Source", show: false
-    config.add_facet_field Settings.FIELDS.VERSION, label: "Is Version Of", show: false
+    config.add_facet_field field_config.member_of, label: "Member Of", show: false
+    config.add_facet_field field_config.is_part_of, label: "Is Part Of", show: false
+    config.add_facet_field field_config.relation, label: "Related", show: false
+    config.add_facet_field field_config.replaces, label: "Replaces", show: false
+    config.add_facet_field field_config.is_replaced_by, label: "Is Replaced By", show: false
+    config.add_facet_field field_config.source, label: "Source", show: false
+    config.add_facet_field field_config.version, label: "Is Version Of", show: false
 
     # Have BL send all facet field names to Solr, which has been the default
     # previously. Simply remove these lines if you'd rather use Solr request
@@ -128,14 +136,14 @@ class CatalogController < ApplicationController
 
     # solr fields to be displayed in the index (search results) view
     #   The ordering of the field names is the order of the display
-    # config.add_index_field Settings.FIELDS.PROVIDER, :label => 'Institution:'
-    # config.add_index_field Settings.FIELDS.RIGHTS, :label => 'Access:'
+    # config.add_index_field field_config.provider, :label => 'Institution:'
+    # config.add_index_field field_config.rights, :label => 'Access:'
     # # config.add_index_field 'Area', :label => 'Area:'
-    # config.add_index_field Settings.FIELDS.SUBJECT, :label => 'Keywords:'
-    config.add_index_field Settings.FIELDS.INDEX_YEAR
-    config.add_index_field Settings.FIELDS.CREATOR
-    config.add_index_field Settings.FIELDS.DESCRIPTION, helper_method: :snippit
-    config.add_index_field Settings.FIELDS.PUBLISHER
+    # config.add_index_field field_config.subject, :label => 'Keywords:'
+    config.add_index_field field_config.index_year
+    config.add_index_field field_config.creator
+    config.add_index_field field_config.description, helper_method: :snippit
+    config.add_index_field field_config.publisher
 
     # ITEM VIEW FIELDS
 
@@ -149,27 +157,35 @@ class CatalogController < ApplicationController
     # The following fields all feature string values. If there is a value present in the metadata, they fields will show up on the item show page.
     # The labels and order can be customed. Comment out fields to hide them.
 
-    config.add_show_field Settings.FIELDS.ALTERNATIVE_TITLE, label: "Alternative Title", itemprop: "alt_title"
-    config.add_show_field Settings.FIELDS.DESCRIPTION, label: "Description", itemprop: "description", helper_method: :render_value_as_truncate_abstract
-    config.add_show_field Settings.FIELDS.CREATOR, label: "Creator", itemprop: "creator"
-    config.add_show_field Settings.FIELDS.PUBLISHER, label: "Publisher", itemprop: "publisher"
-    config.add_show_field Settings.FIELDS.PROVIDER, label: "Provider", link_to_facet: true
-    config.add_show_field Settings.FIELDS.RESOURCE_CLASS, label: "Resource Class", itemprop: "class"
-    config.add_show_field Settings.FIELDS.RESOURCE_TYPE, label: "Resource Type", itemprop: "type"
-    config.add_show_field Settings.FIELDS.SUBJECT, label: "Subject", itemprop: "keywords", link_to_facet: true
-    config.add_show_field Settings.FIELDS.THEME, label: "Theme", itemprop: "theme"
-    config.add_show_field Settings.FIELDS.TEMPORAL_COVERAGE, label: "Temporal Coverage", itemprop: "temporal"
-    config.add_show_field Settings.FIELDS.DATE_ISSUED, label: "Date Issued", itemprop: "issued"
-    config.add_show_field Settings.FIELDS.SPATIAL_COVERAGE, label: "Spatial Coverage", itemprop: "spatial", link_to_facet: true
-    config.add_show_field Settings.FIELDS.RIGHTS, label: "Rights", itemprop: "rights"
-    config.add_show_field Settings.FIELDS.RIGHTS_HOLDER, label: "Rights Holder", itemprop: "rights_holder"
-    config.add_show_field Settings.FIELDS.LICENSE, label: "License", itemprop: "license"
-    config.add_show_field Settings.FIELDS.ACCESS_RIGHTS, label: "Access Rights", itemprop: "access_rights"
-    config.add_show_field Settings.FIELDS.FORMAT, label: "Format", itemprop: "format"
-    config.add_show_field Settings.FIELDS.FILE_SIZE, label: "File Size", itemprop: "file_size"
-    config.add_show_field Settings.FIELDS.GEOREFERENCED, label: "Georeferenced", itemprop: "georeferenced"
+    config.add_show_field field_config.alternative_title, label: "Alternative Title",
+      itemprop: "alt_title"
+    config.add_show_field field_config.description, label: "Description", itemprop: "description",
+      helper_method: :render_value_as_truncate_abstract
+    config.add_show_field field_config.creator, label: "Creator", itemprop: "creator"
+    config.add_show_field field_config.publisher, label: "Publisher", itemprop: "publisher"
+    config.add_show_field field_config.provider, label: "Provider", link_to_facet: true
+    config.add_show_field field_config.resource_class, label: "Resource Class", itemprop: "class"
+    config.add_show_field field_config.resource_type, label: "Resource Type", itemprop: "type"
+    config.add_show_field field_config.subject, label: "Subject", itemprop: "keywords",
+      link_to_facet: true
+    config.add_show_field field_config.theme, label: "Theme", itemprop: "theme"
+    config.add_show_field field_config.temporal_coverage, label: "Temporal Coverage",
+      itemprop: "temporal"
+    config.add_show_field field_config.date_issued, label: "Date Issued", itemprop: "issued"
+    config.add_show_field field_config.spatial_coverage, label: "Spatial Coverage", itemprop: "spatial",
+      link_to_facet: true
+    config.add_show_field field_config.rights, label: "Rights", itemprop: "rights"
+    config.add_show_field field_config.rights_holder, label: "Rights Holder",
+      itemprop: "rights_holder"
+    config.add_show_field field_config.license, label: "License", itemprop: "license"
+    config.add_show_field field_config.access_rights, label: "Access Rights",
+      itemprop: "access_rights"
+    config.add_show_field field_config.format, label: "Format", itemprop: "format"
+    config.add_show_field field_config.file_size, label: "File Size", itemprop: "file_size"
+    config.add_show_field field_config.georeferenced, label: "Georeferenced",
+      itemprop: "georeferenced"
     config.add_show_field(
-      Settings.FIELDS.REFERENCES,
+      field_config.references,
       label: "More details at",
       accessor: [:external_url],
       if: proc { |_, _, doc| doc.external_url },
@@ -180,29 +196,29 @@ class CatalogController < ApplicationController
     # The following fields are not user friendly and are not set to appear on the item show page. They contain non-literal values, codes, URIs, or are otherwise designed to power features in the interface.
     # These values might need a translations to be readable by users.
 
-    # config.add_show_field Settings.FIELDS.LANGUAGE, label: 'Language', itemprop: 'language'
-    # config.add_show_field Settings.FIELDS.KEYWORD, label: 'Keyword(s)', itemprop: 'keyword'
+    # config.add_show_field field_config.language, label: 'Language', itemprop: 'language'
+    # config.add_show_field field_config.keyword, label: 'Keyword(s)', itemprop: 'keyword'
 
-    # config.add_show_field Settings.FIELDS.INDEX_YEAR, label: 'Year', itemprop: 'year'
-    # config.add_show_field Settings.FIELDS.DATE_RANGE, label: 'Date Range', itemprop: 'date_range'
+    # config.add_show_field field_config.index_year, label: 'Year', itemprop: 'year'
+    # config.add_show_field field_config.date_range, label: 'Date Range', itemprop: 'date_range'
 
-    # config.add_show_field Settings.FIELDS.CENTROID, label: 'Centroid', itemprop: 'centroid'
-    # config.add_show_field Settings.FIELDS.OVERLAP_FIELD, label: 'Overlap BBox', itemprop: 'overlap_field'
+    # config.add_show_field field_config.centroid, label: 'Centroid', itemprop: 'centroid'
+    # config.add_show_field field_config.overlap_field, label: 'Overlap BBox', itemprop: 'overlap_field'
 
-    # config.add_show_field Settings.FIELDS.RELATION, label: 'Relation', itemprop: 'relation'
-    # config.add_show_field Settings.FIELDS.MEMBER_OF, label: 'Member Of', itemprop: 'member_of'
-    # config.add_show_field Settings.FIELDS.IS_PART_OF, label: 'Is Part Of', itemprop: 'is_part_of'
-    # config.add_show_field Settings.FIELDS.VERSION, label: 'Version', itemprop: 'version'
-    # config.add_show_field Settings.FIELDS.REPLACES, label: 'Replaces', itemprop: 'replaces'
-    # config.add_show_field Settings.FIELDS.IS_REPLACED_BY, label: 'Is Replaced By', itemprop: 'is_replaced_by'
+    # config.add_show_field field_config.relation, label: 'Relation', itemprop: 'relation'
+    # config.add_show_field field_config.member_of, label: 'Member Of', itemprop: 'member_of'
+    # config.add_show_field field_config.is_part_of, label: 'Is Part Of', itemprop: 'is_part_of'
+    # config.add_show_field field_config.version, label: 'Version', itemprop: 'version'
+    # config.add_show_field field_config.replaces, label: 'Replaces', itemprop: 'replaces'
+    # config.add_show_field field_config.is_replaced_by, label: 'Is Replaced By', itemprop: 'is_replaced_by'
 
-    # config.add_show_field Settings.FIELDS.WXS_IDENTIFIER, label: 'Web Service Layer', itemprop: 'wxs_identifier'
-    # config.add_show_field Settings.FIELDS.ID, label: 'ID', itemprop: 'id'
-    # config.add_show_field Settings.FIELDS.IDENTIFIER, label: 'Identifier', itemprop: 'identifier'
+    # config.add_show_field field_config.wxs_identifier, label: 'Web Service Layer', itemprop: 'wxs_identifier'
+    # config.add_show_field field_config.id, label: 'ID', itemprop: 'id'
+    # config.add_show_field field_config.identifier, label: 'Identifier', itemprop: 'identifier'
 
-    # config.add_show_field Settings.FIELDS.MODIFIED, label: 'Date Modified', itemprop: 'modified'
-    # config.add_show_field Settings.FIELDS.METADATA_VERSION, label: 'Metadata Version', itemprop: 'metadata_version'
-    # config.add_show_field Settings.FIELDS.SUPPRESSED, label: 'Suppressed', itemprop: 'suppresed'
+    # config.add_show_field field_config.modified, label: 'Date Modified', itemprop: 'modified'
+    # config.add_show_field field_config.metadata_version, label: 'Metadata Version', itemprop: 'metadata_version'
+    # config.add_show_field field_config.suppressed, label: 'Suppressed', itemprop: 'suppresed'
 
     # "fielded" search configuration. Used by pulldown among other places.
     # For supported keys in hash, see rdoc for Blacklight::SearchFields
@@ -277,8 +293,10 @@ class CatalogController < ApplicationController
     # whether the sort is ascending or descending (it must be asc or desc
     # except in the relevancy case).
     config.add_sort_field "score desc, dct_title_sort asc", label: "Relevance"
-    config.add_sort_field "#{Settings.FIELDS.INDEX_YEAR} desc, dct_title_sort asc", label: "Year (Newest first)"
-    config.add_sort_field "#{Settings.FIELDS.INDEX_YEAR} asc, dct_title_sort asc", label: "Year (Oldest first)"
+    config.add_sort_field "#{field_config.index_year} desc, dct_title_sort asc",
+      label: "Year (Newest first)"
+    config.add_sort_field "#{field_config.index_year} asc, dct_title_sort asc",
+      label: "Year (Oldest first)"
     config.add_sort_field "dct_title_sort asc", label: "Title (A-Z)"
     config.add_sort_field "dct_title_sort desc", label: "Title (Z-A)"
 
@@ -299,10 +317,15 @@ class CatalogController < ApplicationController
     config.add_show_tools_partial(:sms, if: :render_sms_action?, callback: :sms_action, validator: :validate_sms_params)
 
     # Custom tools for GeoBlacklight
-    config.add_show_tools_partial :metadata, if: proc { |_context, _config, options| options[:document] && (Settings.METADATA_SHOWN & options[:document].references.refs.map(&:type).map(&:to_s)).any? }
-    config.add_show_tools_partial :arcgis, component: Geoblacklight::ArcgisComponent, if: proc { |_context, _config, options| options[:document] && options[:document].arcgis_urls.present? }
-    config.add_show_tools_partial :data_dictionary, component: Geoblacklight::DataDictionaryDownloadComponent, if: proc { |_context, _config, options| options[:document] && options[:document].data_dictionary_download.present? }
-    config.add_show_tools_partial :web_services, component: Geoblacklight::WebServicesLinkComponent, if: proc { |_context, _config, options| options[:document] && (Settings.WEBSERVICES_SHOWN & options[:document].references.refs.map(&:type).map(&:to_s)).any? }
+    config.add_show_tools_partial :metadata, if: proc { |_context, _config, options|
+      options[:document] && (gbl_config.metadata_shown & options[:document].references.refs.map(&:type).map(&:to_s)).any?
+    }
+    config.add_show_tools_partial :arcgis, component: Geoblacklight::ArcgisComponent,
+      if: proc { |_context, _config, options| options[:document]&.arcgis_urls.present? }
+    config.add_show_tools_partial :data_dictionary, component: Geoblacklight::DataDictionaryDownloadComponent,
+      if: proc { |_context, _config, options| options[:document]&.data_dictionary_download.present? }
+    config.add_show_tools_partial :web_services, component: Geoblacklight::WebServicesLinkComponent,
+      if: proc { |_context, _config, options| options[:document] && (gbl_config.webservices_shown & options[:document].references.refs.map(&:type).map(&:to_s)).any? }
 
     # Configure basemap provider for GeoBlacklight maps (uses https only basemap
     # providers with open licenses)

--- a/lib/geoblacklight.rb
+++ b/lib/geoblacklight.rb
@@ -13,4 +13,8 @@ module Geoblacklight
   def self.logger
     ::Rails.logger
   end
+
+  def self.configuration
+    @configuration ||= Configuration::LegacySettingsBuilder.build
+  end
 end

--- a/lib/geoblacklight/configuration.rb
+++ b/lib/geoblacklight/configuration.rb
@@ -1,0 +1,82 @@
+module Geoblacklight
+  # Configuration for Geoblacklight
+  class Configuration
+    include ActiveModel::Attributes
+
+    # ArcGIS Online Base URL
+    attribute :arcgis_base_url, :string, default: "https://www.arcgis.com/apps/mapviewer/index.html"
+
+    # The bq boost value for spatial search matches within a bounding box
+    attribute :bbox_within_boost, :string, default: "10"
+
+    # The bf boost value for overlap ratio
+    attribute :overlap_ratio_boost, :string, default: "2"
+
+    # Institution deployed at
+    attribute :institution, :string, default: "Stanford"
+
+    # (For external Download) timeout and open_timeout parameters for Faraday
+    attribute :timeout_download, :integer, default: 180
+
+    # (For WMS inspection) timeout and open_timeout parameters for Faraday
+    attribute :timeout_wms, :integer, default: 4
+
+    # Display Notes to display / Non-prefixed default bootstrap class is alert-secondary
+    attr_accessor :display_notes_shown # typed as Hash
+
+    # Toggle the help text feature that offers users context
+    attr_accessor :help_text # typed as Hash
+
+    # Non-search-field GeoBlacklight application permitted params
+    attr_accessor :gbl_params # typed as Array
+
+    # WMS Parameters
+    attr_accessor :wms_params # typed as Hash
+
+    # Enable catalog#show sidebar static map for items with the following viewer protocols
+    attr_accessor :sidebar_static_map # typed as Array
+
+    attribute :iiif_drag_drop_link, :string, default: "@manifest?manifest=@manifest"
+
+    # Homepage Map Geometry
+    # Leave null to default to entire world
+    # Add a stringified GeoJSON object to scope initial render (example from UMass)
+    #   config.homepage_map_geom = '{"type":"Polygon","coordinates":[[[-73.58,42.93],[-73.58,41.20],[-69.90,41.20],[-69.90,42.93]]]}'
+    attribute :homepage_map_geom, :string
+
+    # Vector data download formats to be displayed
+    attr_accessor :vector_download_formats  # typed as Array
+
+    # Metadata shown in tool panel
+    attr_accessor :metadata_shown # typed as Array
+
+    # Web services shown in tool panel
+    attr_accessor :webservices_shown # typed as Array
+
+    # Relationships to display
+    attr_accessor :relationships_shown # typed as Hash
+
+    attribute :download_path, :string, default: Rails.root.join("tmp", "cache", "downloads")
+
+    def fields
+      @fields ||= FieldsConfig.new
+    end
+
+    def initialize
+      super
+      @gbl_params = [
+        :bbox, :email, :file, :format, :id, :logo, :provider, :type,
+        :BBOX, :HEIGHT, :LAYERS, :QUERY_LAYERS, :URL, :WIDTH, :X, :Y
+      ]
+      @wms_params = {
+        SERVICE: "WMS",
+        VERSION: "1.1.1",
+        REQUEST: "GetFeatureInfo",
+        STYLES: "",
+        SRS: "EPSG:4326",
+        EXCEPTIONS: "application/json",
+        INFO_FORMAT: "application/json"
+      }
+    end
+  end
+end

--- a/lib/geoblacklight/configuration/fields_config.rb
+++ b/lib/geoblacklight/configuration/fields_config.rb
@@ -1,0 +1,52 @@
+module Geoblacklight
+  class Configuration
+    # Configuration for fields used in GeoBlacklight search results and metadata display.
+    class FieldsConfig
+      include ActiveModel::Attributes
+
+      attribute :access_rights, :string, default: "dct_accessRights_s"
+      attribute :alternative_title, :string, default: "dct_alternative_sm"
+      attribute :centroid, :string, default: "dcat_centroid"
+      attribute :creator, :string, default: "dct_creator_sm"
+      attribute :date_issued, :string, default: "dct_issued_s"
+      attribute :date_range, :string, default: "gbl_dateRange_drsim"
+      attribute :description, :string, default: "dct_description_sm"
+      attribute :display_note, :string, default: "gbl_displayNote_s"
+      attribute :format, :string, default: "dct_format_s"
+      attribute :file_size, :string, default: "gbl_fileSize_drsim"
+      attribute :georeferenced, :string, default: "gbl_georeferenced_drsim"
+      attribute :id, :string, default: "id"
+      attribute :identifier, :string, default: "dct_identifier_s"
+      attribute :index_year, :string, default: "gbl_indexYear_drsim"
+      attribute :is_part_of, :string, default: "gbl_isPartOf_drsim"
+      attribute :is_replaced_by, :string, default: "gbl_isReplacedBy_drsim"
+      attribute :theme, :string, default: "gbl_theme_drsim"
+      attribute :keyword, :string, default: "dct_keyword_sm"
+      attribute :language, :string, default: "dct_language_s"
+      attribute :layer_modified, :string, default: "gbl_layerModified_drsim"
+      attribute :license, :string, default: "dct_license_s"
+      attribute :member_of, :string, default: "gbl_memberOf_drsim"
+      attribute :metadata_version, :string, default: "gbl_metadataVersion_drsim"
+      attribute :modified, :string, default: "gbl_modified_drsim"
+      attribute :overlap_field, :string, default: "gbl_overlapField_drsim"
+      attribute :publisher, :string, default: "gbl_publisher_drsim"
+      attribute :provider, :string, default: "gbl_provider_drsim"
+      attribute :references, :string, default: "gbl_references_drsim"
+      attribute :relation, :string, default: "gbl_relation_drsim"
+      attribute :replaces, :string, default: "gbl_replaces_drsim"
+      attribute :resource_class, :string, default: "gbl_resourceClass_drsim"
+      attribute :resource_type, :string, default: "gbl_resourceType_drsim"
+      attribute :rights, :string, default: "gbl_rights_drsim"
+      attribute :rights_holder, :string, default: "gbl_rightsHolder_drsim"
+      attribute :source, :string, default: "gbl_source_drsim"
+      attribute :spatial_coverage, :string, default: "gbl_spatialCoverage_drsim"
+      attribute :geometry, :string, default: "gbl_geometry_drsim"
+      attribute :subject, :string, default: "gbl_subject_drsim"
+      attribute :suppressed, :string, default: "gbl_suppressed_drsim"
+      attribute :temporal_coverage, :string, default: "gbl_temporalCoverage_drsim"
+      attribute :title, :string, default: "gbl_title_drsim"
+      attribute :version, :string, default: "gbl_version_drsim"
+      attribute :wxs_identifier, :string, default: "gbl_wxsIdentifier_drsim"
+    end
+  end
+end

--- a/lib/geoblacklight/configuration/legacy_settings_builder.rb
+++ b/lib/geoblacklight/configuration/legacy_settings_builder.rb
@@ -1,0 +1,86 @@
+module Geoblacklight
+  class Configuration
+    # Builds a configuration from legacy (uppercase) settings
+    class LegacySettingsBuilder
+      def self.build
+        new.build
+      end
+
+      def initialize
+        @configuration = Configuration.new
+      end
+
+      def build
+        @configuration.tap do |config|
+          config.arcgis_base_url = Settings.ARCGIS_BASE_URL
+          config.bbox_within_boost = Settings.BBOX_WITHIN_BOOST
+          config.overlap_ratio_boost = Settings.OVERLAP_RATIO_BOOST
+          config.display_notes_shown = Settings.DISPLAY_NOTES_SHOWN
+          config.institution = Settings.INSTITUTION
+          config.help_text = Settings.HELP_TEXT.to_h
+          config.sidebar_static_map = Settings.SIDEBAR_STATIC_MAP
+          config.iiif_drag_drop_link = Settings.IIIF_DRAG_DROP_LINK
+          config.homepage_map_geom = Settings.HOMEPAGE_MAP_GEOM
+          config.vector_download_formats = Settings.DOWNLOAD_FORMATS&.VECTOR
+          config.metadata_shown = Settings.METADATA_SHOWN
+          config.webservices_shown = Settings.WEBSERVICES_SHOWN
+          config.relationships_shown = Settings.RELATIONSHIPS_SHOWN
+          config.download_path = Settings.DOWNLOAD_PATH if Settings.DOWNLOAD_PATH
+          config.gbl_params = Settings.GBL_PARAMS
+          config.wms_params = Settings.WMS_PARAMS.to_h
+          config.timeout_wms = Settings.TIMEOUT_WMS
+
+          build_fields(config)
+        end
+      end
+
+      private
+
+      def build_fields(config)
+        config.fields.access_rights = Settings.FIELDS.ACCESS_RIGHTS
+        config.fields.alternative_title = Settings.FIELDS.ALTERNATIVE_TITLE
+        config.fields.centroid = Settings.FIELDS.CENTROID
+        config.fields.creator = Settings.FIELDS.CREATOR
+        config.fields.date_issued = Settings.FIELDS.DATE_ISSUED
+        config.fields.date_range = Settings.FIELDS.DATE_RANGE
+        config.fields.description = Settings.FIELDS.DESCRIPTION
+        config.fields.display_note = Settings.FIELDS.DISPLAY_NOTE
+        config.fields.format = Settings.FIELDS.FORMAT
+        config.fields.file_size = Settings.FIELDS.FILE_SIZE
+        config.fields.georeferenced = Settings.FIELDS.GEOREFERENCED
+        config.fields.id = Settings.FIELDS.ID
+        config.fields.identifier = Settings.FIELDS.IDENTIFIER
+        config.fields.index_year = Settings.FIELDS.INDEX_YEAR
+        config.fields.is_part_of = Settings.FIELDS.IS_PART_OF
+        config.fields.is_replaced_by = Settings.FIELDS.IS_REPLACED_BY
+        config.fields.theme = Settings.FIELDS.THEME
+        config.fields.keyword = Settings.FIELDS.KEYWORD
+        config.fields.language = Settings.FIELDS.LANGUAGE
+        config.fields.layer_modified = Settings.FIELDS.LAYER_MODIFIED
+        config.fields.license = Settings.FIELDS.LICENSE
+        config.fields.member_of = Settings.FIELDS.MEMBER_OF
+        config.fields.metadata_version = Settings.FIELDS.METADATA_VERSION
+        config.fields.modified = Settings.FIELDS.MODIFIED
+        config.fields.overlap_field = Settings.FIELDS.OVERLAP_FIELD
+        config.fields.publisher = Settings.FIELDS.PUBLISHER
+        config.fields.provider = Settings.FIELDS.PROVIDER
+        config.fields.references = Settings.FIELDS.REFERENCES
+        config.fields.relation = Settings.FIELDS.RELATION
+        config.fields.replaces = Settings.FIELDS.REPLACES
+        config.fields.resource_class = Settings.FIELDS.RESOURCE_CLASS
+        config.fields.resource_type = Settings.FIELDS.RESOURCE_TYPE
+        config.fields.rights = Settings.FIELDS.RIGHTS
+        config.fields.rights_holder = Settings.FIELDS.RIGHTS_HOLDER
+        config.fields.source = Settings.FIELDS.SOURCE
+        config.fields.spatial_coverage = Settings.FIELDS.SPATIAL_COVERAGE
+        config.fields.geometry = Settings.FIELDS.GEOMETRY
+        config.fields.subject = Settings.FIELDS.SUBJECT
+        config.fields.suppressed = Settings.FIELDS.SUPPRESSED
+        config.fields.temporal_coverage = Settings.FIELDS.TEMPORAL_COVERAGE
+        config.fields.title = Settings.FIELDS.TITLE
+        config.fields.version = Settings.FIELDS.VERSION
+        config.fields.wxs_identifier = Settings.FIELDS.WXS_IDENTIFIER
+      end
+    end
+  end
+end

--- a/lib/geoblacklight/download.rb
+++ b/lib/geoblacklight/download.rb
@@ -16,7 +16,7 @@ module Geoblacklight
     end
 
     def self.file_path
-      Settings.DOWNLOAD_PATH || Rails.root.join("tmp", "cache", "downloads")
+      Geoblacklight.configuration.download_path
     end
 
     def file_path_and_name
@@ -95,7 +95,7 @@ module Geoblacklight
     # the Geoblacklight::Download class
     # @return [Fixnum] download timeout in seconds
     def timeout
-      @options[:timeout] || Settings.TIMEOUT_DOWNLOAD || 20
+      @options[:timeout] || Geoblacklight.configuration.timeout_download
     end
 
     ##

--- a/lib/geoblacklight/references.rb
+++ b/lib/geoblacklight/references.rb
@@ -5,7 +5,7 @@ module Geoblacklight
   class References
     attr_reader :refs, :reference_field
 
-    def initialize(document, reference_field = Settings.FIELDS.REFERENCES)
+    def initialize(document, reference_field = Geoblacklight.configuration.fields.references)
       @document = document
       @reference_field = reference_field
       @refs = parse_references.map { |ref| Reference.new(ref) }
@@ -15,9 +15,10 @@ module Geoblacklight
     # Return only those metadata references which are exposed within the configuration
     # @return [Geoblacklight::Reference]
     def shown_metadata_refs
-      metadata = @refs.select { |ref| Settings.METADATA_SHOWN.include?(ref.type.to_s) }
+      metadata_shown = Geoblacklight.configuration.metadata_shown
+      metadata = @refs.select { |ref| metadata_shown.include?(ref.type.to_s) }
       metadata.sort do |u, v|
-        Settings.METADATA_SHOWN.index(u.type.to_s) <=> Settings.METADATA_SHOWN.index(v.type.to_s)
+        metadata_shown.index(u.type.to_s) <=> metadata_shown.index(v.type.to_s)
       end
     end
 
@@ -111,7 +112,7 @@ module Geoblacklight
     end
 
     def format_list
-      Settings.DOWNLOAD_FORMATS&.VECTOR
+      Geoblacklight.configuration.vector_download_formats || []
     end
 
     def web_service_hash(format)

--- a/lib/geoblacklight/relation/ancestors.rb
+++ b/lib/geoblacklight/relation/ancestors.rb
@@ -10,8 +10,9 @@ module Geoblacklight
       end
 
       def create_search_params
-        {fq: ["{!join from=#{@field} to=#{Settings.FIELDS.ID}}#{Settings.FIELDS.ID}:#{@search_id}"],
-         fl: [Settings.FIELDS.TITLE, Settings.FIELDS.ID, Settings.FIELDS.RESOURCE_TYPE]}
+        {fq: ["{!join from=#{@field} to=#{Geoblacklight.configuration.fields.id}}#{Geoblacklight.configuration.fields.id}:#{@search_id}"],
+         fl: [Geoblacklight.configuration.fields.title, Geoblacklight.configuration.fields.id,
+           Geoblacklight.configuration.fields.resource_type]}
       end
 
       def execute_query

--- a/lib/geoblacklight/relation/descendants.rb
+++ b/lib/geoblacklight/relation/descendants.rb
@@ -11,7 +11,8 @@ module Geoblacklight
 
       def create_search_params
         {fq: "#{@field}:#{@search_id}",
-         fl: [Settings.FIELDS.TITLE, Settings.FIELDS.ID, Settings.FIELDS.RESOURCE_TYPE]}
+         fl: [Geoblacklight.configuration.fields.title, Geoblacklight.configuration.fields.id,
+           Geoblacklight.configuration.fields.resource_type]}
       end
 
       def execute_query

--- a/lib/geoblacklight/relation/relation_response.rb
+++ b/lib/geoblacklight/relation/relation_response.rb
@@ -11,9 +11,9 @@ module Geoblacklight
       end
 
       def method_missing(method, *args, &block)
-        if Settings.RELATIONSHIPS_SHOWN.key?(method)
-          field = Settings.RELATIONSHIPS_SHOWN[method].field
-          query_type = query_type(Settings.RELATIONSHIPS_SHOWN[method])
+        if Geoblacklight.configuration.relationships_shown.key?(method)
+          field = Geoblacklight.configuration.relationships_shown[method].field
+          query_type = query_type(Geoblacklight.configuration.relationships_shown[method])
           @results = query_type.new(@search_id, field, @repository).results
         else
           super
@@ -21,7 +21,7 @@ module Geoblacklight
       end
 
       def respond_to_missing?(method_name, *args)
-        Settings.RELATIONSHIPS_SHOWN.key?(method_name) or super
+        Geoblacklight.configuration.relationships_shown.key?(method_name) or super
       end
 
       private

--- a/lib/geoblacklight/wms_layer.rb
+++ b/lib/geoblacklight/wms_layer.rb
@@ -3,7 +3,7 @@
 module Geoblacklight
   class WmsLayer
     def initialize(params)
-      @params = params.to_h.merge(Settings.WMS_PARAMS)
+      @params = params.to_h.merge(Geoblacklight.configuration.wms_params)
       @response = Geoblacklight::FeatureInfoResponse.new(request_response)
     end
 
@@ -23,8 +23,8 @@ module Geoblacklight
       conn = Faraday.new(url: url)
       conn.get do |request|
         request.params = search_params
-        request.options.timeout = Settings.TIMEOUT_WMS
-        request.options.open_timeout = Settings.TIMEOUT_WMS
+        request.options.timeout = Geoblacklight.configuration.timeout_wms
+        request.options.open_timeout = Geoblacklight.configuration.timeout_wms
       end
     rescue Faraday::ConnectionFailed, Faraday::TimeoutError => error
       Geoblacklight.logger.error error.inspect

--- a/spec/components/geoblacklight/arcgis_component_spec.rb
+++ b/spec/components/geoblacklight/arcgis_component_spec.rb
@@ -10,13 +10,15 @@ RSpec.describe Geoblacklight::ArcgisComponent, type: :component do
   let(:document) { instance_double(SolrDocument, id: 123, arcgis_urls: ["https://www.stanford.edu"]) }
 
   it "shows link" do
-    expect(rendered).to have_css("a[href='#{Settings.ARCGIS_BASE_URL}?urls=https%3A%2F%2Fwww.stanford.edu']", text: "Open in ArcGIS Online")
+    expect(rendered).to have_css(
+      "a[href='#{Geoblacklight.configuration.arcgis_base_url}?urls=https%3A%2F%2Fwww.stanford.edu']", text: "Open in ArcGIS Online"
+    )
   end
 
   describe "#arcgis_link" do
     context "single url" do
       it "creates a single url param" do
-        expect(component.arcgis_link).to eq "#{Settings.ARCGIS_BASE_URL}?urls=https%3A%2F%2Fwww.stanford.edu"
+        expect(component.arcgis_link).to eq "#{Geoblacklight.configuration.arcgis_base_url}?urls=https%3A%2F%2Fwww.stanford.edu"
       end
     end
 
@@ -24,7 +26,7 @@ RSpec.describe Geoblacklight::ArcgisComponent, type: :component do
       let(:document) { instance_double(SolrDocument, id: 123, arcgis_urls: ["http://example.com/foo/MapServer", "http://example.com/foo/FeatureServer"]) }
 
       it "appends the url params" do
-        expect(component.arcgis_link).to eq "#{Settings.ARCGIS_BASE_URL}?urls=http%3A%2F%2Fexample.com%2Ffoo%2FMapServer&urls=http%3A%2F%2Fexample.com%2Ffoo%2FFeatureServer"
+        expect(component.arcgis_link).to eq "#{Geoblacklight.configuration.arcgis_base_url}?urls=http%3A%2F%2Fexample.com%2Ffoo%2FMapServer&urls=http%3A%2F%2Fexample.com%2Ffoo%2FFeatureServer"
       end
     end
   end

--- a/spec/components/geoblacklight/download_links_component_spec.rb
+++ b/spec/components/geoblacklight/download_links_component_spec.rb
@@ -57,12 +57,13 @@ RSpec.describe Geoblacklight::DownloadLinksComponent, type: :component do
     let(:url) { "http://example.com/urn:hul.harvard.edu:HARVARD.SDE2.TG10USAIANNH/data.zip" }
 
     it "generates a link to download the original file" do
-      expect(component.download_link_file(label, id, url)).to eq '<a contentUrl="http://example.com/urn:hul.harvard.edu:HARVARD.SDE2.TG10USAIANNH/data.zip" data-download="trigger" data-download-type="direct" data-download-id="test-id" href="http://example.com/urn:hul.harvard.edu:HARVARD.SDE2.TG10USAIANNH/data.zip">Test Link Text</a>'
+      expect(component.download_link_file(label, id,
+        url)).to eq '<a contentUrl="http://example.com/urn:hul.harvard.edu:HARVARD.SDE2.TG10USAIANNH/data.zip" data-download="trigger" data-download-type="direct" data-download-id="test-id" href="http://example.com/urn:hul.harvard.edu:HARVARD.SDE2.TG10USAIANNH/data.zip">Test Link Text</a>'
     end
   end
 
   describe "#download_link_iiif" do
-    let(:references_field) { Settings.FIELDS.REFERENCES }
+    let(:references_field) { Geoblacklight.configuration.fields.references }
     let(:document_attributes) do
       {
         references_field => {
@@ -83,7 +84,7 @@ RSpec.describe Geoblacklight::DownloadLinksComponent, type: :component do
   end
 
   describe "#iiif_jpg_url" do
-    let(:references_field) { Settings.FIELDS.REFERENCES }
+    let(:references_field) { Geoblacklight.configuration.fields.references }
     let(:document_attributes) do
       {
         references_field => {
@@ -111,8 +112,10 @@ RSpec.describe Geoblacklight::DownloadLinksComponent, type: :component do
     it "generates a link to download the JPG file from the IIIF server" do
       # Stub I18n to ensure the link can be customized via `export_` labels.
       allow(component).to receive(:t).with("geoblacklight.download.export_shapefile_link").and_return("Shapefile Export Customization")
-      allow(component).to receive(:t).with("geoblacklight.download.export_link", {download_format: "Shapefile Export Customization"}).and_return("Export Shapefile Export Customization")
-      expect(component.download_link_generated(download_type, document)).to eq '<a data-download-path="/download/test-id?type=SHAPEFILE" data-download="trigger" data-action="downloads#download:once" data-download-type="SHAPEFILE" data-download-id="test-id" href="">Export Shapefile Export Customization</a>'
+      allow(component).to receive(:t).with("geoblacklight.download.export_link",
+        {download_format: "Shapefile Export Customization"}).and_return("Export Shapefile Export Customization")
+      expect(component.download_link_generated(download_type,
+        document)).to eq '<a data-download-path="/download/test-id?type=SHAPEFILE" data-download="trigger" data-action="downloads#download:once" data-download-type="SHAPEFILE" data-download-id="test-id" href="">Export Shapefile Export Customization</a>'
     end
   end
 end

--- a/spec/components/geoblacklight/homepage_feature_facet_component_spec.rb
+++ b/spec/components/geoblacklight/homepage_feature_facet_component_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Geoblacklight::HomepageFeatureFacetComponent, type: :component do
       {
         icon: "home",
         label: "geoblacklight.home.institution",
-        facet_field: Settings.FIELDS.PROVIDER,
+        facet_field: Geoblacklight.configuration.fields.provider,
         response: @response
       }
     end

--- a/spec/components/geoblacklight/search_result_component_spec.rb
+++ b/spec/components/geoblacklight/search_result_component_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe Geoblacklight::SearchResultComponent, type: :component do
       config.add_index_field "multi_display"
     end
   end
-  let(:solr_fields) { Settings.FIELDS }
   let(:presenter) do
     Blacklight::DocumentPresenter.new(document, request_context, blacklight_config)
   end

--- a/spec/components/geoblacklight/static_map_component_spec.rb
+++ b/spec/components/geoblacklight/static_map_component_spec.rb
@@ -11,10 +11,10 @@ RSpec.describe Geoblacklight::StaticMapComponent, type: :component do
 
   before do
     allow(document).to receive(:viewer_protocol).and_return("map")
-    allow(Settings).to receive(:SIDEBAR_STATIC_MAP).and_return(["map"])
+    allow(Geoblacklight.configuration).to receive(:sidebar_static_map).and_return(["map"])
   end
 
-  context "when the protocol matches the SIDEBAR_STATIC_MAP setting" do
+  context "when the protocol matches the sidebar_static_map setting" do
     it "renders the static map" do
       expect(rendered.css("#static-map")).to be_present
     end

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -73,12 +73,12 @@ describe CatalogController, type: :controller do
       expect(response.body).not_to be_empty
       response_values = JSON.parse(response.body)
       expect(response_values).to include "gbl_mdVersion_s" => "Aardvark"
-      expect(response_values).to include Settings.FIELDS.TITLE => "100 Foot Grid Cambridge MA 2004"
-      expect(response_values).to include Settings.FIELDS.IDENTIFIER => ["urn:geodata.tufts.edu:Tufts.CambridgeGrid100_04"]
-      expect(response_values).to include Settings.FIELDS.ACCESS_RIGHTS => "Public"
-      expect(response_values).to include Settings.FIELDS.PROVIDER => "Tufts"
-      expect(response_values).to include Settings.FIELDS.ID => "tufts-cambridgegrid100-04"
-      expect(response_values).to include Settings.FIELDS.GEOMETRY => "ENVELOPE(-71.163984,-71.052581,42.408316,42.34757)"
+      expect(response_values).to include Geoblacklight.configuration.fields.title => "100 Foot Grid Cambridge MA 2004"
+      expect(response_values).to include Geoblacklight.configuration.fields.identifier => ["urn:geodata.tufts.edu:Tufts.CambridgeGrid100_04"]
+      expect(response_values).to include Geoblacklight.configuration.fields.access_rights => "Public"
+      expect(response_values).to include Geoblacklight.configuration.fields.provider => "Tufts"
+      expect(response_values).to include Geoblacklight.configuration.fields.id => "tufts-cambridgegrid100-04"
+      expect(response_values).to include Geoblacklight.configuration.fields.geometry => "ENVELOPE(-71.163984,-71.052581,42.408316,42.34757)"
     end
   end
 end

--- a/spec/features/index_view_spec.rb
+++ b/spec/features/index_view_spec.rb
@@ -3,20 +3,20 @@
 require "spec_helper"
 
 feature "Index view", js: true do
-  let(:subject_field) { Settings.FIELDS.SUBJECT }
+  let(:subject_field) { Geoblacklight.configuration.fields.subject }
   before do
     visit search_catalog_path(q: "*")
   end
 
   scenario "should have documents and map on page" do
-    visit search_catalog_path(f: {Settings.FIELDS.PROVIDER => ["Stanford"]})
+    visit search_catalog_path(f: {Geoblacklight.configuration.fields.provider => ["Stanford"]})
     expect(page).to have_css("#documents")
     expect(page).to have_css(".document", count: 5)
     expect(page).to have_css("#leaflet-viewer")
   end
 
   scenario "should have sort and per_page on page" do
-    visit search_catalog_path(f: {Settings.FIELDS.PROVIDER => ["Stanford"]})
+    visit search_catalog_path(f: {Geoblacklight.configuration.fields.provider => ["Stanford"]})
     expect(page).to have_css("#sort-dropdown")
     expect(page).to have_css("#per_page-dropdown")
   end
@@ -49,7 +49,7 @@ feature "Index view", js: true do
 
   scenario "hover on record should produce bounding box on map" do
     # Needed to find an svg element on the page
-    visit search_catalog_path(f: {Settings.FIELDS.PROVIDER => ["Stanford"]})
+    visit search_catalog_path(f: {Geoblacklight.configuration.fields.provider => ["Stanford"]})
     # BL7 has svg icons, so sniffing for SVG path won't return false
     # expect(Nokogiri::HTML.parse(page.body).css('path').length).to eq 0
     find(".documentHeader", match: :first).hover
@@ -82,7 +82,7 @@ feature "Index view", js: true do
   end
 
   scenario "should have schema.org props listed" do
-    visit search_catalog_path(f: {Settings.FIELDS.PROVIDER => ["Stanford"]})
+    visit search_catalog_path(f: {Geoblacklight.configuration.fields.provider => ["Stanford"]})
     within(".documentHeader", match: :first) do
       expect(page).to have_css("a[itemprop='name']")
       find(".dropdown-toggle").click

--- a/spec/features/relations_spec.rb
+++ b/spec/features/relations_spec.rb
@@ -17,7 +17,7 @@ feature "Display related documents" do
     visit relations_solr_document_path("nyu_2451_34635", format: "json")
     response = JSON.parse(page.body)
     expect(response["relations"]).not_to respond_to("source_ancestors")
-    expect(response["relations"]["source_descendants"]["docs"].first[Settings.FIELDS.ID]).to eq "nyu_2451_34502"
+    expect(response["relations"]["source_descendants"]["docs"].first[Geoblacklight.configuration.fields.id]).to eq "nyu_2451_34502"
     expect(response["current_doc"]).to eq "nyu_2451_34635"
   end
 

--- a/spec/features/search_results_overlap_ratio_spec.rb
+++ b/spec/features/search_results_overlap_ratio_spec.rb
@@ -9,7 +9,7 @@ feature "spatial search results overlap ratio" do
     # BBox param is the US upper midwest and Canada, roughly centered on the state of Minnesota
     visit search_catalog_path(
       bbox: "-103.196521 39.21962 -84.431873 53.63497",
-      "f[#{Settings.FIELDS.PROVIDER}][]": "University of Minnesota"
+      "f[#{Geoblacklight.configuration.fields.provider}][]": "University of Minnesota"
     )
 
     # MN State result
@@ -31,7 +31,7 @@ feature "spatial search results overlap ratio" do
     # BBox param is the center to western edge of New York state and Canada, roughly centered on Lake Ontario
     visit search_catalog_path(
       bbox: "-83.750499 40.41709 -74.368175 47.963663",
-      "f[#{Settings.FIELDS.PROVIDER}][]": "Cornell"
+      "f[#{Geoblacklight.configuration.fields.provider}][]": "Cornell"
     )
 
     # NY State result

--- a/spec/helpers/geoblacklight_helper_spec.rb
+++ b/spec/helpers/geoblacklight_helper_spec.rb
@@ -37,7 +37,7 @@ describe GeoblacklightHelper, type: :helper do
 
   describe "#snippit" do
     let(:document) { SolrDocument.new(document_attributes) }
-    let(:references_field) { Settings.FIELDS.REFERENCES }
+    let(:references_field) { Geoblacklight.configuration.fields.references }
     context "as a String" do
       let(:document_attributes) do
         {
@@ -85,7 +85,7 @@ describe GeoblacklightHelper, type: :helper do
 
   describe "#leaflet_options" do
     it "returns a hash of options for leaflet" do
-      expect(leaflet_options[:LAYERS][:INDEX].keys).to eq([:DEFAULT, :UNAVAILABLE, :SELECTED])
+      expect(leaflet_options[:LAYERS][:INDEX].keys).to eq(%i[DEFAULT UNAVAILABLE SELECTED])
     end
   end
 
@@ -119,7 +119,8 @@ describe GeoblacklightHelper, type: :helper do
       end
 
       it "renders the partial with metadata content" do
-        expect(helper).to receive(:render).with(partial: "catalog/metadata/markup", locals: {content: "<data></data>"})
+        expect(helper).to receive(:render).with(partial: "catalog/metadata/markup",
+          locals: {content: "<data></data>"})
         helper.render_transformed_metadata(metadata)
       end
     end

--- a/spec/lib/geoblacklight/download/csv_download_spec.rb
+++ b/spec/lib/geoblacklight/download/csv_download_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 describe Geoblacklight::CsvDownload do
-  let(:document) { SolrDocument.new(Settings.FIELDS.ID => "test", :solr_wfs_url => "http://www.example.com/wfs", Settings.FIELDS.WXS_IDENTIFIER => "stanford-test", Settings.FIELDS.GEOMETRY => "ENVELOPE(-180, 180, 90, -90)") }
+  let(:document) { SolrDocument.new(Geoblacklight.configuration.fields.id => "test", :solr_wfs_url => "http://www.example.com/wfs", Geoblacklight.configuration.fields.wxs_identifier => "stanford-test", Geoblacklight.configuration.fields.geometry => "ENVELOPE(-180, 180, 90, -90)") }
   let(:download) { described_class.new(document) }
   describe "#initialize" do
     it "initializes as a CsvDownload object with specific options" do

--- a/spec/lib/geoblacklight/download/geojson_download_spec.rb
+++ b/spec/lib/geoblacklight/download/geojson_download_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 describe Geoblacklight::GeojsonDownload do
-  let(:document) { SolrDocument.new(Settings.FIELDS.ID => "test", :solr_wfs_url => "http://www.example.com/wfs", Settings.FIELDS.WXS_IDENTIFIER => "stanford-test", Settings.FIELDS.GEOMETRY => "ENVELOPE(-180, 180, 90, -90)") }
+  let(:document) { SolrDocument.new(Geoblacklight.configuration.fields.id => "test", :solr_wfs_url => "http://www.example.com/wfs", Geoblacklight.configuration.fields.wxs_identifier => "stanford-test", Geoblacklight.configuration.fields.geometry => "ENVELOPE(-180, 180, 90, -90)") }
   let(:download) { described_class.new(document) }
   describe "#initialize" do
     it "initializes as a GeojsonDownload object with specific options" do

--- a/spec/lib/geoblacklight/download/geotiff_download_spec.rb
+++ b/spec/lib/geoblacklight/download/geotiff_download_spec.rb
@@ -3,7 +3,10 @@
 require "spec_helper"
 
 describe Geoblacklight::GeotiffDownload do
-  let(:document) { SolrDocument.new(Settings.FIELDS.ID => "test", Settings.FIELDS.WXS_IDENTIFIER => "stanford-test", Settings.FIELDS.GEOMETRY => "ENVELOPE(-180, 180, 90, -90)") }
+  let(:document) do
+    SolrDocument.new(Geoblacklight.configuration.fields.id => "test", Geoblacklight.configuration.fields.wxs_identifier => "stanford-test",
+      Geoblacklight.configuration.fields.geometry => "ENVELOPE(-180, 180, 90, -90)")
+  end
   let(:download) { described_class.new(document) }
   describe "#initialize" do
     it "initializes as a GeotiffDownload object with specific options" do

--- a/spec/lib/geoblacklight/download/kmz_download_spec.rb
+++ b/spec/lib/geoblacklight/download/kmz_download_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 describe Geoblacklight::KmzDownload do
-  let(:document) { SolrDocument.new(Settings.FIELDS.ID => "test", :solr_wfs_url => "http://www.example.com/wfs", Settings.FIELDS.WXS_IDENTIFIER => "stanford-test", Settings.FIELDS.GEOMETRY => "ENVELOPE(-180, 180, 90, -90)") }
+  let(:document) { SolrDocument.new(Geoblacklight.configuration.fields.id => "test", :solr_wfs_url => "http://www.example.com/wfs", Geoblacklight.configuration.fields.wxs_identifier => "stanford-test", Geoblacklight.configuration.fields.geometry => "ENVELOPE(-180, 180, 90, -90)") }
   let(:download) { described_class.new(document) }
   describe "#initialize" do
     it "initializes as a KmzDownload object with specific options" do

--- a/spec/lib/geoblacklight/download/shapefile_download_spec.rb
+++ b/spec/lib/geoblacklight/download/shapefile_download_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 describe Geoblacklight::ShapefileDownload do
-  let(:document) { SolrDocument.new(Settings.FIELDS.ID => "test", :solr_wfs_url => "http://www.example.com/wfs", Settings.FIELDS.WXS_IDENTIFIER => "stanford-test", Settings.FIELDS.GEOMETRY => "ENVELOPE(-180, 180, 90, -90)") }
+  let(:document) { SolrDocument.new(Geoblacklight.configuration.fields.id => "test", :solr_wfs_url => "http://www.example.com/wfs", Geoblacklight.configuration.fields.wxs_identifier => "stanford-test", Geoblacklight.configuration.fields.geometry => "ENVELOPE(-180, 180, 90, -90)") }
   let(:download) { described_class.new(document) }
   describe "#initialize" do
     it "initializes as a ShapefileDownload object with specific options" do

--- a/spec/lib/geoblacklight/download_spec.rb
+++ b/spec/lib/geoblacklight/download_spec.rb
@@ -7,8 +7,11 @@ describe Geoblacklight::Download do
 
   let(:faraday_connection) { instance_double(Faraday::Connection) }
   let(:faraday_response) { instance_double(Faraday::Response) }
-  let(:references_field) { Settings.FIELDS.REFERENCES }
-  let(:document) { SolrDocument.new(:"#{Settings.FIELDS.ID}" => "test", references_field => {"http://www.opengis.net/def/serviceType/ogc/wms" => "http://www.example.com/wms"}.to_json) }
+  let(:references_field) { Geoblacklight.configuration.fields.references }
+  let(:document) do
+    SolrDocument.new(:"#{Geoblacklight.configuration.fields.id}" => "test",
+      references_field => {"http://www.opengis.net/def/serviceType/ogc/wms" => "http://www.example.com/wms"}.to_json)
+  end
   let(:options) { {type: "shapefile", extension: "zip", service_type: "wms", content_type: "application/zip"} }
 
   describe "#initialize" do
@@ -31,15 +34,18 @@ describe Geoblacklight::Download do
       expect(download.file_name).to eq "test-shapefile.zip"
     end
   end
+
   describe "#file_path" do
     it "returns the path with name and extension" do
-      expect(download.class.file_path).to eq Rails.root.join("tmp", "cache", "downloads")
+      expect(download.class.file_path).to eq Rails.root.join("tmp", "cache", "downloads").to_s
     end
+
     it "is configurable" do
-      expect(Settings).to receive(:DOWNLOAD_PATH).and_return("configured/path")
+      expect(Geoblacklight.configuration).to receive(:download_path).and_return("configured/path")
       expect(download.class.file_path).to eq "configured/path"
     end
   end
+
   describe "#download_exists?" do
     it "returns false if file does not exist" do
       expect(File).to receive(:file?).and_return(false)
@@ -106,7 +112,10 @@ describe Geoblacklight::Download do
       it "creates the file in fs and delete it if the content headers are not correct" do
         allow(File).to receive(:delete).with("#{download.file_path_and_name}.tmp").and_return(nil)
 
-        expect { download.create_download_file }.to raise_error(Geoblacklight::Exceptions::ExternalDownloadFailed, "Wrong download type")
+        expect do
+          download.create_download_file
+        end.to raise_error(Geoblacklight::Exceptions::ExternalDownloadFailed,
+          "Wrong download type")
       end
     end
 

--- a/spec/lib/geoblacklight/item_viewer_spec.rb
+++ b/spec/lib/geoblacklight/item_viewer_spec.rb
@@ -6,7 +6,7 @@ describe Geoblacklight::ItemViewer do
   let(:document) { SolrDocument.new(document_attributes) }
   let(:document_attributes) { {} }
   let(:references) { document.references }
-  let(:references_field) { Settings.FIELDS.REFERENCES }
+  let(:references_field) { Geoblacklight.configuration.fields.references }
   let(:item_viewer) { described_class.new(references) }
   describe "viewer_preference" do
     describe "for no references" do

--- a/spec/lib/geoblacklight/references_spec.rb
+++ b/spec/lib/geoblacklight/references_spec.rb
@@ -3,8 +3,8 @@
 require "spec_helper"
 
 describe Geoblacklight::References do
-  let(:references_field) { Settings.FIELDS.REFERENCES }
-  let(:file_format_field) { Settings.FIELDS.FORMAT }
+  let(:references_field) { Geoblacklight.configuration.fields.references }
+  let(:file_format_field) { Geoblacklight.configuration.fields.format }
   let(:typical_ogp_shapefile) do
     described_class.new(
       SolrDocument.new(
@@ -134,9 +134,11 @@ describe Geoblacklight::References do
     end
     context "with an overridden order for the formats" do
       before do
+        allow(Geoblacklight.configuration).to receive_messages(
+          metadata_shown: %w[iso19139 mods]
+        )
         stub_const("Settings", Module.new)
         allow(Settings).to receive_messages(
-          METADATA_SHOWN: %w[iso19139 mods],
           FIELDS: OpenStruct.new(FORMAT: "dct_format_s")
         )
       end

--- a/spec/lib/geoblacklight/relation/ancestors_spec.rb
+++ b/spec/lib/geoblacklight/relation/ancestors_spec.rb
@@ -4,12 +4,18 @@ require "spec_helper"
 
 describe Geoblacklight::Relation::Ancestors do
   let(:repository) { Blacklight::Solr::Repository.new(CatalogController.blacklight_config) }
-  let(:ancestors) { described_class.new("nyu_2451_34502", Settings.FIELDS.SOURCE, repository) }
-  let(:empty_ancestors) { described_class.new("harvard-g7064-s2-1834-k3", Settings.FIELDS.SOURCE, repository) }
+  let(:ancestors) { described_class.new("nyu_2451_34502", Geoblacklight.configuration.fields.source, repository) }
+  let(:empty_ancestors) do
+    described_class.new("harvard-g7064-s2-1834-k3", Geoblacklight.configuration.fields.source, repository)
+  end
 
   describe "#create_search_params" do
     it "assembles the correct search params for finding ancestor documents" do
-      expect(ancestors.create_search_params).to eq(fq: ["{!join from=#{Settings.FIELDS.SOURCE} to=#{Settings.FIELDS.ID}}#{Settings.FIELDS.ID}:nyu_2451_34502"], fl: [Settings.FIELDS.TITLE.to_s, Settings.FIELDS.ID, Settings.FIELDS.RESOURCE_TYPE])
+      expect(ancestors.create_search_params).to eq(
+        fq: ["{!join from=#{Geoblacklight.configuration.fields.source} to=#{Geoblacklight.configuration.fields.id}}#{Geoblacklight.configuration.fields.id}:nyu_2451_34502"], fl: [
+          Geoblacklight.configuration.fields.title, Geoblacklight.configuration.fields.id, Geoblacklight.configuration.fields.resource_type
+        ]
+      )
     end
   end
 

--- a/spec/lib/geoblacklight/relation/descendants_spec.rb
+++ b/spec/lib/geoblacklight/relation/descendants_spec.rb
@@ -4,12 +4,17 @@ require "spec_helper"
 
 describe Geoblacklight::Relation::Descendants do
   let(:repository) { Blacklight::Solr::Repository.new(CatalogController.blacklight_config) }
-  let(:descendants) { described_class.new("nyu_2451_34636", Settings.FIELDS.SOURCE, repository) }
-  let(:empty_descendants) { described_class.new("harvard-g7064-s2-1834-k3", Settings.FIELDS.SOURCE, repository) }
+  let(:descendants) { described_class.new("nyu_2451_34636", Geoblacklight.configuration.fields.source, repository) }
+  let(:empty_descendants) do
+    described_class.new("harvard-g7064-s2-1834-k3", Geoblacklight.configuration.fields.source, repository)
+  end
 
   describe "#create_search_params" do
     it "assembles the correct search params for finding descendant documents" do
-      expect(descendants.create_search_params).to eq(fq: "#{Settings.FIELDS.SOURCE}:nyu_2451_34636", fl: [Settings.FIELDS.TITLE.to_s, Settings.FIELDS.ID, Settings.FIELDS.RESOURCE_TYPE])
+      expect(descendants.create_search_params).to eq(fq: "#{Geoblacklight.configuration.fields.source}:nyu_2451_34636",
+        fl: [
+          Geoblacklight.configuration.fields.title, Geoblacklight.configuration.fields.id, Geoblacklight.configuration.fields.resource_type
+        ])
     end
   end
 

--- a/spec/lib/geoblacklight/relation/relation_response_spec.rb
+++ b/spec/lib/geoblacklight/relation/relation_response_spec.rb
@@ -30,7 +30,7 @@ describe Geoblacklight::Relation::RelationResponse do
 
   describe "#respond_to_missing?" do
     it "returns true for configured relationships" do
-      Settings.RELATIONSHIPS_SHOWN.each_key do |key|
+      Geoblacklight.configuration.relationships_shown.each_key do |key|
         expect(relation_resp).to respond_to(key)
       end
     end
@@ -43,23 +43,20 @@ describe Geoblacklight::Relation::RelationResponse do
   describe "#query_type" do
     it "fails for a bad query type request" do
       # Cache the existing relationship values and add a test value
-      relationships = Settings.RELATIONSHIPS_SHOWN
-      Settings.add_source!({
-        RELATIONSHIPS_SHOWN: {
-          BAD: {
-            field: "dct_source_sm",
-            query_type: "bad_query_type",
-            icon: "pagelines-brands",
-            label: "geoblacklight.relations.source_ancestor"
-          }
-        }
-      })
-      Settings.reload!
+      relationships = Geoblacklight.configuration.relationships_shown
+      Geoblacklight.configuration.relationships_shown = {
+        BAD: Config::Options.new({
+          field: "dct_source_sm",
+          query_type: "bad_query_type",
+          icon: "pagelines-brands",
+          label: "geoblacklight.relations.source_ancestor"
+        })
+      }
 
       expect { relation_resp.BAD }.to raise_error(ArgumentError)
 
       # Restore relationship values
-      Settings.RELATIONSHIPS_SHOWN = relationships
+      Geoblacklight.configuration.relationships_shown = relationships
     end
   end
 end

--- a/spec/models/concerns/geoblacklight/bbox_filter_query_spec.rb
+++ b/spec/models/concerns/geoblacklight/bbox_filter_query_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Geoblacklight::BboxFilterQuery do
         result
       end
 
-      it "applies boost based on configured Settings.BBOX_WITHIN_BOOST" do
+      it "applies boost based on configuration" do
         expect(bbox_filter_query.boost).to eq("^99")
       end
     end
@@ -76,7 +76,7 @@ RSpec.describe Geoblacklight::BboxFilterQuery do
         facet_config.overlap_boost = 2
       end
 
-      it "applies overlapRatio when Settings.OVERLAP_RATIO_BOOST is configured" do
+      it "applies overlapRatio" do
         expect(relevancy_boost[:bf].to_s).to include("$overlap^2")
       end
     end
@@ -86,7 +86,7 @@ RSpec.describe Geoblacklight::BboxFilterQuery do
         facet_config.overlap_boost = nil
       end
 
-      it "does not apply overlapRatio when Settings.OVERLAP_RATIO_BOOST not configured" do
+      it "does not apply overlapRatio" do
         expect(relevancy_boost).not_to have_key(:overlap)
       end
     end

--- a/spec/models/concerns/geoblacklight/solr_document_spec.rb
+++ b/spec/models/concerns/geoblacklight/solr_document_spec.rb
@@ -4,9 +4,9 @@ require "spec_helper"
 
 describe Geoblacklight::SolrDocument do
   let(:document) { SolrDocument.new(document_attributes) }
-  let(:rights_field) { Settings.FIELDS.ACCESS_RIGHTS }
-  let(:provider_field) { Settings.FIELDS.PROVIDER }
-  let(:references_field) { Settings.FIELDS.REFERENCES }
+  let(:rights_field) { Geoblacklight.configuration.fields.access_rights }
+  let(:provider_field) { Geoblacklight.configuration.fields.provider }
+  let(:references_field) { Geoblacklight.configuration.fields.references }
   describe "#available?" do
     let(:document_attributes) { {} }
     describe "a public document" do

--- a/spec/models/concerns/geoblacklight/suppressed_records_search_behavior_spec.rb
+++ b/spec/models/concerns/geoblacklight/suppressed_records_search_behavior_spec.rb
@@ -25,7 +25,7 @@ describe Geoblacklight::SuppressedRecordsSearchBehavior do
 
   context "when document action call like CatalogController#web_services" do
     it "does not hide/filter suppressed records" do
-      solr_params[:q] = "{!lucene}#{Settings.FIELDS.ID}:"
+      solr_params[:q] = "{!lucene}#{Geoblacklight.configuration.fields.id}:"
       expect(searcher.hide_suppressed_records(solr_params)).to be_nil
     end
   end


### PR DESCRIPTION
Stop relying on a generated configuration in the application.  This just adds the first step of the configuration. If this is merged we can follow on with other parts of the config.  When complete, GBL should be able to run without requiring a whole copy of the default config in the generated app.