### PR TITLE
Provide gemspec path to prevent bundler clash

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
 # Specify your gem's dependencies in geoblacklight.gemspec
-gemspec
+gemspec path: File.expand_path(".")
 
 # BEGIN ENGINE_CART BLOCK
 # engine_cart: 2.6.0


### PR DESCRIPTION
This prevents the following error:
```
[!] There was an error parsing `Gemfile`: You cannot specify the same gem twice coming from different sources.
You specified that geoblacklight (>= 0) should come from gemspec at `.` and gemspec at `/Users/jcoyne85/workspace/geoblacklight/geoblacklight`
. Bundler cannot continue.
```