### PR TITLE
Prevent remote reads in test suite

### DIFF
--- a/spec/fixtures/solr_documents/b1g_wabash_parent.json
+++ b/spec/fixtures/solr_documents/b1g_wabash_parent.json
@@ -3,54 +3,27 @@
   "dct_description_sm": [
     "See Related Records below to download individual GeoTIFFs. The images represented here are the raster orthophoto set collected by remote sensing of 25 aerial images  owned by EAS library. Each aerial image was up to 450MB, 400dpi, grayscale. These images can be viewed and performed in the using either ArcGIS Desktop or QGIS (user choice), referencing against a number of known mapsets like the 2005 Indiana Orthophoto setand USGS DRGs. The geographic coordinate system reference of the maps included are applied in GCS_WGS_1984."
   ],
-  "dct_language_sm": [
-    "eng"
-  ],
-  "dct_creator_sm": [
-    "Brock & Weymouth Inc.",
-    "United States Engineer Office"
-  ],
+  "dct_language_sm": ["eng"],
+  "dct_creator_sm": ["Brock & Weymouth Inc.", "United States Engineer Office"],
   "schema_provider_s": "Purdue University",
-  "gbl_resourceClass_sm": [
-    "Imagery"
-  ],
-  "dcat_theme_sm": [
-    "Imagery"
-  ],
-  "dcat_keyword_sm": [
-    "Universities",
-    "Campuses"
-  ],
-  "dct_temporal_sm": [
-    "1929"
-  ],
+  "gbl_resourceClass_sm": ["Imagery"],
+  "dcat_theme_sm": ["Imagery"],
+  "dcat_keyword_sm": ["Universities", "Campuses"],
+  "dct_temporal_sm": ["1929"],
   "dct_issued_s": "2015-11-03",
-  "gbl_indexYear_im": [
-    1929
-  ],
-  "gbl_dateRange_drsim": [
-    "[1929 TO 1929]"
-  ],
-  "dct_spatial_sm": [
-    "Indiana",
-    "West Lafayette, Indiana"
-  ],
+  "gbl_indexYear_im": [1929],
+  "gbl_dateRange_drsim": ["[1929 TO 1929]"],
+  "dct_spatial_sm": ["Indiana", "West Lafayette, Indiana"],
   "locn_geometry": "ENVELOPE(-87.5291,-86.2066,40.8009,39.3999)",
   "dcat_bbox": "ENVELOPE(-87.5291,-86.2066,40.8009,39.3999)",
   "dcat_centroid": "40.1004,-86.86785",
-  "pcdm_memberOf_sm": [
-    "dc8c18df-7d64-4ff4-a754-d18d0891187d"
-  ],
-  "dct_isPartOf_sm": [
-    "09d-01"
-  ],
+  "pcdm_memberOf_sm": ["dc8c18df-7d64-4ff4-a754-d18d0891187d"],
+  "dct_isPartOf_sm": ["09d-01"],
   "dct_accessRights_s": "Public",
   "dct_format_s": "Image Service",
-  "dct_references_s": "{\"urn:x-esri:serviceType:ArcGIS#ImageMapLayer\":\"https://mapsweb.lib.purdue.edu/arcgis/rest/services/Purdue/wabashaerial/ImageServer\",\"http://schema.org/url\":\"https://mapsweb.lib.purdue.edu/wabashriver/\"}",
+  "dct_references_s": "{\"http://schema.org/url\":\"https://mapsweb.lib.purdue.edu/wabashriver/\"}",
   "id": "eee6150b-ce2f-4837-9d17-ce72a0c1c26f",
-  "dct_identifier_sm": [
-    "eee6150b-ce2f-4837-9d17-ce72a0c1c26f"
-  ],
+  "dct_identifier_sm": ["eee6150b-ce2f-4837-9d17-ce72a0c1c26f"],
   "gbl_mdModified_dt": "2022-05-31T13:44:08Z",
   "gbl_mdVersion_s": "Aardvark"
 }

--- a/spec/fixtures/solr_documents/esri-image-map-layer.json
+++ b/spec/fixtures/solr_documents/esri-image-map-layer.json
@@ -1,56 +1,29 @@
 {
-  "dct_title_s": "Wabash River Aerial Imagery: Indiana, 1929",
+  "dct_title_s": "Wabash Topo (27): Indiana, 1929",
   "dct_description_sm": [
-    "See Related Records below to download individual GeoTIFFs. The images represented here are the raster orthophoto set collected by remote sensing of 25 aerial images  owned by EAS library. Each aerial image was up to 450MB, 400dpi, grayscale. These images can be viewed and performed in the using either ArcGIS Desktop or QGIS (user choice), referencing against a number of known mapsets like the 2005 Indiana Orthophoto setand USGS DRGs. The geographic coordinate system reference of the maps included are applied in GCS_WGS_1984."
+    "The images represented here are the raster orthophoto set collected by remote sensing of 25 aerial images owned by EAS library. Each aerial image was up to 450MB, 400dpi, grayscale."
   ],
-  "dct_language_sm": [
-    "eng"
-  ],
-  "dct_creator_sm": [
-    "Brock & Weymouth Inc.",
-    "United States Engineer Office"
-  ],
+  "dct_language_sm": ["eng"],
+  "dct_creator_sm": ["Brock & Weymouth Inc.", "United States Engineer Office"],
   "schema_provider_s": "Purdue University",
-  "gbl_resourceClass_sm": [
-    "Imagery"
-  ],
-  "dcat_theme_sm": [
-    "Imagery"
-  ],
-  "dcat_keyword_sm": [
-    "Universities",
-    "Campuses"
-  ],
-  "dct_temporal_sm": [
-    "1929"
-  ],
+  "gbl_resourceClass_sm": ["Imagery"],
+  "dcat_theme_sm": ["Imagery"],
+  "dcat_keyword_sm": ["Universities", "Campuses"],
+  "dct_temporal_sm": ["1929"],
   "dct_issued_s": "2015-11-03",
-  "gbl_indexYear_im": [
-    1929
-  ],
-  "gbl_dateRange_drsim": [
-    "[1929 TO 1929]"
-  ],
-  "dct_spatial_sm": [
-    "Indiana",
-    "West Lafayette, Indiana"
-  ],
+  "gbl_indexYear_im": [1929],
+  "gbl_dateRange_drsim": ["[1929 TO 1929]"],
+  "dct_spatial_sm": ["Indiana", "West Lafayette, Indiana"],
   "locn_geometry": "ENVELOPE(-87.5291,-86.2066,40.8009,39.3999)",
   "dcat_bbox": "ENVELOPE(-87.5291,-86.2066,40.8009,39.3999)",
   "dcat_centroid": "40.1004,-86.86785",
-  "pcdm_memberOf_sm": [
-    "dc8c18df-7d64-4ff4-a754-d18d0891187d"
-  ],
-  "dct_isPartOf_sm": [
-    "09d-01"
-  ],
+  "pcdm_memberOf_sm": ["dc8c18df-7d64-4ff4-a754-d18d0891187d"],
+  "dct_isPartOf_sm": ["09d-01"],
   "dct_accessRights_s": "Public",
-  "dct_format_s": "Image Service",
-  "dct_references_s": "{\"urn:x-esri:serviceType:ArcGIS#ImageMapLayer\":\"https://mapsweb.lib.purdue.edu/arcgis/rest/services/Purdue/wabashaerial/ImageServer\",\"http://schema.org/url\":\"https://mapsweb.lib.purdue.edu/wabashriver/\"}",
-  "id": "eee6150b-ce2f-4837-9d17-ce72a0c1c26f",
-  "dct_identifier_sm": [
-    "eee6150b-ce2f-4837-9d17-ce72a0c1c26f"
-  ],
+  "dct_format_s": "GeoTIFF",
+  "dct_references_s": "{\"http://schema.org/downloadUrl\":\"https://mapsweb.lib.purdue.edu/datasets/Wabash1929/wabashAerial_27.tif.zip\",\"urn:x-esri:serviceType:ArcGIS#ImageMapLayer\":\"https://mapsweb.lib.purdue.edu/arcgis/rest/services/Purdue/wabashaerial/ImageServer\",\"http://schema.org/url\":\"https://mapsweb.lib.purdue.edu/wabashriver/\"}",
+  "id": "32653ed6-8d83-4692-8a06-bf13ffe2c018",
+  "dct_identifier_sm": ["32653ed6-8d83-4692-8a06-bf13ffe2c018"],
   "gbl_mdModified_dt": "2022-05-31T13:44:08Z",
   "gbl_mdVersion_s": "Aardvark"
 }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -45,12 +45,7 @@ Capybara.register_driver :chrome_headless do |app|
   options.add_argument("--no-sandbox")
   options.add_argument("--window-size=1280,1024")
 
-  # Allow longer TCP reads to prevent timeout in the case of loading fixture
-  # eee6150b-ce2f-4837-9d17-ce72a0c1c26f, as part of relations_spec.rb
-  client = Selenium::WebDriver::Remote::Http::Default.new
-  client.read_timeout = 120 # seconds
-
-  Capybara::Selenium::Driver.new(app, browser: :chrome, options: options, http_client: client)
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
 end
 
 Capybara.javascript_driver = :chrome_headless


### PR DESCRIPTION
What's happening:
* visit solr_document_path("eee6150b-ce2f-4837-9d17-ce72a0c1c26f")` loads the Wabash parent record in headless Chrome.
* b1g_wabash_parent.json` had `"urn:x-esri:serviceType:ArcGIS#ImageMapLayer"` in its `dct_references_s`, pointing at `https://mapsweb.lib.purdue.edu/arcgis/rest/services/Purdue/wabashaerial/ImageServer`.
* leaflet_viewer_controller.js` called `imageMapLayer({ url })` from `esri-leaflet`, which immediately fires an HTTP `GET` to the Purdue ArcGIS server for service metadata.