### PR TITLE
Use FacetItemPresenter to generate proper paths

### DIFF
--- a/app/components/geoblacklight/homepage_feature_facet_component.rb
+++ b/app/components/geoblacklight/homepage_feature_facet_component.rb
@@ -2,20 +2,20 @@
 
 module Geoblacklight
   class HomepageFeatureFacetComponent < ViewComponent::Base
-    def initialize(icon:, label:, facet_field:, response:)
+    def initialize(icon:, label:, facet_field_presenter:, items:)
       @icon = icon
       @label = label
-      @facet_field = facet_field
-      @items = response.aggregations[@facet_field].items
-
+      @facet_field_presenter = facet_field_presenter
+      @items = items
       super()
     end
 
     def facets
       links = @items.map do |item|
-        link_to(item.value, search_catalog_path("f[#{@facet_field}][]": item.value), class: "home-facet-link")
+        item_presenter = @facet_field_presenter.item_presenter(item)
+        link_to(item_presenter.value, item_presenter.href, class: "home-facet-link")
       end
-      links << link_to("more »", facet_catalog_path(@facet_field), class: "more_facets_link")
+      links << link_to("more »", facet_catalog_path(@facet_field_presenter.key), class: "more_facets_link")
       safe_join(links, ", ")
     end
   end

--- a/app/views/catalog/_home_text.html.erb
+++ b/app/views/catalog/_home_text.html.erb
@@ -3,14 +3,22 @@
     <div class="col-sm">
       <%= content_tag :h3, t('geoblacklight.home.category_heading') %>
       <div class="row">
-        <%= render(Geoblacklight::HomepageFeatureFacetComponent.new(icon: 'home', label: 'geoblacklight.home.institution', facet_field: Geoblacklight.configuration.fields.provider, response: @response)) %>
+        <%= render(Geoblacklight::HomepageFeatureFacetComponent.new(icon: 'home', label: 'geoblacklight.home.institution',
+          facet_field_presenter: facet_field_presenter(blacklight_config.facet_fields[Geoblacklight.configuration.fields.provider], {}),
+          items: @response.aggregations[Geoblacklight.configuration.fields.provider].items)) %>
 
-        <%= render(Geoblacklight::HomepageFeatureFacetComponent.new(icon: 'arrow-circle-down', label: 'geoblacklight.home.data_type', facet_field: Geoblacklight.configuration.fields.resource_type, response: @response)) %>
+        <%= render(Geoblacklight::HomepageFeatureFacetComponent.new(icon: 'arrow-circle-down', label: 'geoblacklight.home.data_type',
+          facet_field_presenter: facet_field_presenter(blacklight_config.facet_fields[Geoblacklight.configuration.fields.resource_type], {}),
+          items: @response.aggregations[Geoblacklight.configuration.fields.resource_type].items)) %>
       </div>
       <div class="row">
-        <%= render(Geoblacklight::HomepageFeatureFacetComponent.new(icon: 'globe', label: 'geoblacklight.home.placename', facet_field: Geoblacklight.configuration.fields.spatial_coverage, response: @response)) %>
+        <%= render(Geoblacklight::HomepageFeatureFacetComponent.new(icon: 'globe', label: 'geoblacklight.home.placename',
+          facet_field_presenter: facet_field_presenter(blacklight_config.facet_fields[Geoblacklight.configuration.fields.spatial_coverage], {}),
+          items: @response.aggregations[Geoblacklight.configuration.fields.spatial_coverage].items)) %>
 
-        <%= render(Geoblacklight::HomepageFeatureFacetComponent.new(icon: 'tags', label: 'geoblacklight.home.subject', facet_field: Geoblacklight.configuration.fields.subject, response: @response)) %>
+        <%= render(Geoblacklight::HomepageFeatureFacetComponent.new(icon: 'tags', label: 'geoblacklight.home.subject',
+          facet_field_presenter: facet_field_presenter(blacklight_config.facet_fields[Geoblacklight.configuration.fields.subject], {}),
+          items: @response.aggregations[Geoblacklight.configuration.fields.subject].items)) %>
       </div>
     </div>
     <div class="col-sm">

--- a/spec/components/geoblacklight/homepage_feature_facet_component_spec.rb
+++ b/spec/components/geoblacklight/homepage_feature_facet_component_spec.rb
@@ -4,34 +4,29 @@ require "spec_helper"
 
 RSpec.describe Geoblacklight::HomepageFeatureFacetComponent, type: :component do
   # Build a search
-  let(:context) { {whatever: :value} }
-  let(:service) { Blacklight::SearchService.new(config: blacklight_config, search_state:, **context) }
-  let(:repository) { Blacklight::Solr::Repository.new(blacklight_config) }
+  let(:service) { Blacklight::SearchService.new(config: blacklight_config, search_state:) }
   let(:search_state) { Blacklight::SearchState.new({}, blacklight_config) }
-  let(:blacklight_config) { Blacklight::Configuration.new }
-  let(:copy_of_catalog_config) { ::CatalogController.blacklight_config.deep_copy }
-  let(:blacklight_solr) { RSolr.connect(Blacklight.connection_config.except(:adapter)) }
+  let(:blacklight_config) { ::CatalogController.blacklight_config.deep_copy }
+  let(:facet_field) { Geoblacklight.configuration.fields.provider }
+  let(:facet_config) { blacklight_config.facet_fields[facet_field] }
+  let(:facet_field_presenter) { Blacklight::FacetFieldPresenter.new(facet_config, nil, vc_test_controller.view_context, nil) }
+  let(:response) { service.search_results }
+  let(:items) { response.aggregations[facet_field].items }
 
-  describe "homepage" do
-    before do
-      (@response, @document_list) = service.search_results
-    end
+  subject(:instance) do
+    described_class.new(
+      icon: "home",
+      label: "geoblacklight.home.institution",
+      facet_field_presenter: facet_field_presenter,
+      items: items
+    )
+  end
 
-    let(:kargs) do
-      {
-        icon: "home",
-        label: "geoblacklight.home.institution",
-        facet_field: Geoblacklight.configuration.fields.provider,
-        response: @response
-      }
-    end
-
-    it "includes facet links" do
-      render_inline(described_class.new(**kargs))
-      expect(page).to have_selector("div.category-block")
-      expect(page).to have_selector("div.category-icon")
-      expect(page).to have_selector("a.home-facet-link")
-      expect(page).to have_selector("a.more_facets_link")
-    end
+  it "includes facet links" do
+    render_inline(instance)
+    expect(page).to have_selector("div.category-block")
+    expect(page).to have_selector("div.category-icon")
+    expect(page).to have_selector("a.home-facet-link")
+    expect(page).to have_selector("a.more_facets_link")
   end
 end


### PR DESCRIPTION
Prior to this change, the links on the front page were using search_catalog_path, but the intended way in Blacklight to link to these searches is via the presenter. This removes the undesirable /catalog url path.

Ref #1258