### PR TITLE
Prefer search_action_path over search_catalog_url

### DIFF
--- a/app/components/geoblacklight/location_leaflet_map_component.rb
+++ b/app/components/geoblacklight/location_leaflet_map_component.rb
@@ -46,7 +46,7 @@ module Geoblacklight
           "leaflet-viewer-data-map-value" => @data_map,
           "leaflet-viewer-page-value" => params[:action]&.upcase,
           "leaflet-viewer-options-value" => leaflet_options.to_h,
-          "leaflet-viewer-catalog-base-url-value" => (helpers.search_catalog_url if @geosearch)
+          "leaflet-viewer-catalog-base-url-value" => (helpers.search_action_path if @geosearch)
         }.compact)
     end
   end


### PR DESCRIPTION
The former is a blacklight method that can have custom logic for routing in the app.  The latter is just a plain rails routing helper

Ref #1258 