### PR TITLE
Add the dynamic fields that blacklight has

### DIFF
--- a/solr/conf/schema.xml
+++ b/solr/conf/schema.xml
@@ -27,35 +27,258 @@
     <!-- Spatial Field Type: Internal field used for overlap ratio boosting. -->
     <field name="solr_bboxtype" type="bbox" stored="true" indexed="true"/>
 
-    <!-- dynamic field with simple types by suffix -->
-    <dynamicField name="*_b"    type="boolean" stored="true"  indexed="true"/>
-    <dynamicField name="*_d"    type="double"  stored="true"  indexed="true"/>
-    <dynamicField name="*_dt"   type="date"    stored="true"  indexed="true"/>
-    <dynamicField name="*_f"    type="float"   stored="true"  indexed="true"/>
-    <dynamicField name="*_i"    type="int"     stored="true"  indexed="true"/>
-    <dynamicField name="*_im"   type="int"     stored="true"  indexed="true" multiValued="true" sortMissingLast="true" />
-    <dynamicField name="*_l"    type="long"    stored="true"  indexed="true"/>
-    <dynamicField name="*_s"    type="string"  stored="true"  indexed="true"/>
-    <dynamicField name="*_ss"   type="string"  stored="true"  indexed="false"/>
-    <dynamicField name="*_si"   type="string"  stored="false" indexed="true"/>
-    <dynamicField name="*_sim"  type="string"  stored="false" indexed="true" multiValued="true" />
-    <dynamicField name="*_sm"   type="string"  stored="true"  indexed="true" multiValued="true" />
-    <dynamicField name="*_url"  type="string"  stored="true"  indexed="false"/>
-    <dynamicField name="*_blob" type="binary"  stored="true"  indexed="false"/>
 
-    <!-- dynamic Text fields by suffix without storage -->
-    <dynamicField name="*_t"    type="text_en" stored="false"  indexed="true"
-                                termVectors="true" termPositions="true" termOffsets="true"/>
-    <dynamicField name="*_tm"   type="text_en" stored="false"  indexed="true" multiValued="true"
-                                termVectors="true" termPositions="true" termOffsets="true"/>
-    <dynamicField name="*_ti"   type="text_en" stored="false" indexed="true"
-                                termVectors="true" termPositions="true" termOffsets="true"/>
-    <dynamicField name="*_tmi"  type="text_en" stored="false" indexed="true" multiValued="true"
-                                termVectors="true" termPositions="true" termOffsets="true"/>
-    <dynamicField name="*_sort" type="text_sort" stored="false" indexed="true" multiValued="false"/>
+    <!-- text (_t...) -->
 
+    <dynamicField name="*_ti" type="text" stored="false" indexed="true" multiValued="false" />
+    <dynamicField name="*_tim" type="text" stored="false" indexed="true" multiValued="true" />
+
+    <dynamicField name="*_ts" type="text" stored="true" indexed="false" multiValued="false" />
+    <dynamicField name="*_tsm" type="text" stored="true" indexed="false" multiValued="true" />
+    <dynamicField name="*_tsi" type="text" stored="true" indexed="true" multiValued="false" />
+    <dynamicField name="*_tsim" type="text" stored="true" indexed="true" multiValued="true" />
+
+    <dynamicField
+      name="*_tiv"
+      type="text"
+      stored="false"
+      indexed="true"
+      multiValued="false"
+      termVectors="true"
+      termPositions="true"
+      termOffsets="true"
+    />
+    <dynamicField
+      name="*_timv"
+      type="text"
+      stored="false"
+      indexed="true"
+      multiValued="true"
+      termVectors="true"
+      termPositions="true"
+      termOffsets="true"
+    />
+
+    <dynamicField
+      name="*_tsiv"
+      type="text"
+      stored="true"
+      indexed="true"
+      multiValued="false"
+      termVectors="true"
+      termPositions="true"
+      termOffsets="true"
+    />
+    <dynamicField
+      name="*_tsimv"
+      type="text"
+      stored="true"
+      indexed="true"
+      multiValued="true"
+      termVectors="true"
+      termPositions="true"
+      termOffsets="true"
+    />
+
+    <!-- English text (_te...) -->
+
+    <dynamicField name="*_tei" type="text_en" stored="false" indexed="true" multiValued="false" />
+    <dynamicField name="*_teim" type="text_en" stored="false" indexed="true" multiValued="true" />
+
+    <dynamicField name="*_tes" type="text_en" stored="true" indexed="false" multiValued="false" />
+    <dynamicField name="*_tesm" type="text_en" stored="true" indexed="false" multiValued="true" />
+    <dynamicField name="*_tesi" type="text_en" stored="true" indexed="true" multiValued="false" />
+    <dynamicField name="*_tesim" type="text_en" stored="true" indexed="true" multiValued="true" />
+
+    <dynamicField
+      name="*_teiv"
+      type="text_en"
+      stored="false"
+      indexed="true"
+      multiValued="false"
+      termVectors="true"
+      termPositions="true"
+      termOffsets="true"
+    />
+    <dynamicField
+      name="*_teimv"
+      type="text_en"
+      stored="false"
+      indexed="true"
+      multiValued="true"
+      termVectors="true"
+      termPositions="true"
+      termOffsets="true"
+    />
+
+    <dynamicField
+      name="*_tesiv"
+      type="text_en"
+      stored="true"
+      indexed="true"
+      multiValued="false"
+      termVectors="true"
+      termPositions="true"
+      termOffsets="true"
+    />
+    <dynamicField
+      name="*_tesimv"
+      type="text_en"
+      stored="true"
+      indexed="true"
+      multiValued="true"
+      termVectors="true"
+      termPositions="true"
+      termOffsets="true"
+    />
+
+    <!-- string (_s...) -->
+
+      <dynamicField name="*_si" type="string" stored="false" indexed="true" multiValued="false" />
+    <dynamicField name="*_sim" type="string" stored="false" indexed="true" multiValued="true" />
+
+    <dynamicField name="*_ss" type="string" stored="true" indexed="false" multiValued="false" />
+    <dynamicField name="*_ssm" type="string" stored="true" indexed="false" multiValued="true" />
+    <dynamicField name="*_ssi" type="string" stored="true" indexed="true" multiValued="false" />
+    <dynamicField name="*_s"   type="string" stored="true" indexed="true"/> <!-- same as _ssi, but for Aardvark compat -->
+    <dynamicField name="*_ssim" type="string" stored="true" indexed="true" multiValued="true" />
+    <dynamicField name="*_sm" type="string" stored="true" indexed="true" multiValued="true" /><!-- same as _ssim, but for Aardvark compat -->
+
+    <dynamicField name="*_ssort" type="alphaSort" stored="false" indexed="true" multiValued="false" />
+    <dynamicField name="*_sort" type="text_sort" stored="false" indexed="true" multiValued="false" /><!-- almost same as _ssort, but punctuation is stripped -->
+
+    <!-- integer (_i...) -->
+
+    <dynamicField name="*_ii" type="int" stored="false" indexed="true" multiValued="false" />
+    <dynamicField name="*_iim" type="int" stored="false" indexed="true" multiValued="true" />
+
+    <dynamicField name="*_is" type="int" stored="true" indexed="false" multiValued="false" />
+    <dynamicField name="*_ism" type="int" stored="true" indexed="false" multiValued="true" />
+    <dynamicField name="*_isi" type="int" stored="true" indexed="true" multiValued="false" />
+    <dynamicField name="*_isim" type="int" stored="true" indexed="true" multiValued="true" />
+    <dynamicField name="*_im" type="int" stored="true" indexed="true" multiValued="true" sortMissingLast="true" /><!-- same as _isim, but for backward compatibility -->
+
+    <!-- IntegerPointField (_it...) (for faster range queries) -->
+
+    <dynamicField name="*_iti" type="tint" stored="false" indexed="true" multiValued="false" />
+    <dynamicField name="*_itim" type="tint" stored="false" indexed="true" multiValued="true" />
+
+    <dynamicField name="*_its" type="tint" stored="true" indexed="false" multiValued="false" />
+    <dynamicField name="*_itsm" type="tint" stored="true" indexed="false" multiValued="true" />
+    <dynamicField name="*_itsi" type="tint" stored="true" indexed="true" multiValued="false" />
+    <dynamicField name="*_itsim" type="tint" stored="true" indexed="true" multiValued="true" />
+
+    <!-- date (_dt...) -->
+    <!-- The format for this date field is of the form 1995-12-31T23:59:59Z
+         Optional fractional seconds are allowed: 1995-12-31T23:59:59.999Z -->
+
+    <dynamicField name="*_dti" type="date" stored="false" indexed="true" multiValued="false" />
+    <dynamicField name="*_dtim" type="date" stored="false" indexed="true" multiValued="true" />
+
+    <dynamicField name="*_dts" type="date" stored="true" indexed="false" multiValued="false" />
+    <dynamicField name="*_dtsm" type="date" stored="true" indexed="false" multiValued="true" />
+    <dynamicField name="*_dtsi" type="date" stored="true" indexed="true" multiValued="false" />
+    <dynamicField name="*_dtsim" type="date" stored="true" indexed="true" multiValued="true" />
+    <dynamicField name="*_dt"   type="date" stored="true" indexed="true" /> <!-- same as _dtsi, but for backward compatibility -->
+
+    <!-- DatePointField (_dtt...) (for faster range queries) -->
+
+    <dynamicField name="*_dtti" type="tdate" stored="false" indexed="true" multiValued="false" />
+    <dynamicField name="*_dttim" type="tdate" stored="false" indexed="true" multiValued="true" />
+
+    <dynamicField name="*_dtts" type="tdate" stored="true" indexed="false" multiValued="false" />
+    <dynamicField name="*_dttsm" type="tdate" stored="true" indexed="false" multiValued="true" />
+    <dynamicField name="*_dttsi" type="tdate" stored="true" indexed="true" multiValued="false" />
+    <dynamicField name="*_dttsim" type="tdate" stored="true" indexed="true" multiValued="true" />
+
+    <!-- long (_l...) -->
+
+    <dynamicField name="*_li" type="long" stored="false" indexed="true" multiValued="false" />
+    <dynamicField name="*_lim" type="long" stored="false" indexed="true" multiValued="true" />
+
+    <dynamicField name="*_ls" type="long" stored="true" indexed="false" multiValued="false" />
+    <dynamicField name="*_lsm" type="long" stored="true" indexed="false" multiValued="true" />
+    <dynamicField name="*_lsi" type="long" stored="true" indexed="true" multiValued="false" />
+    <dynamicField name="*_lsim" type="long" stored="true" indexed="true" multiValued="true" />
+
+    <!-- LongPointField (_lt...) (for faster range queries) -->
+
+    <dynamicField name="*_lti" type="tlong" stored="false" indexed="true" multiValued="false" />
+    <dynamicField name="*_ltim" type="tlong" stored="false" indexed="true" multiValued="true" />
+
+    <dynamicField name="*_lts" type="tlong" stored="true" indexed="false" multiValued="false" />
+    <dynamicField name="*_ltsm" type="tlong" stored="true" indexed="false" multiValued="true" />
+    <dynamicField name="*_ltsi" type="tlong" stored="true" indexed="true" multiValued="false" />
+    <dynamicField name="*_ltsim" type="tlong" stored="true" indexed="true" multiValued="true" />
+
+    <!-- double (_db...) -->
+
+    <dynamicField name="*_dbi" type="double" stored="false" indexed="true" multiValued="false" />
+    <dynamicField name="*_dbim" type="double" stored="false" indexed="true" multiValued="true" />
+
+    <dynamicField name="*_dbs" type="double" stored="true" indexed="false" multiValued="false" />
+    <dynamicField name="*_dbsm" type="double" stored="true" indexed="false" multiValued="true" />
+    <dynamicField name="*_dbsi" type="double" stored="true" indexed="true" multiValued="false" />
+    <dynamicField name="*_dbsim" type="double" stored="true" indexed="true" multiValued="true" />
+
+    <!-- DoublePointField (_dbt...) (for faster range queries) -->
+
+    <dynamicField name="*_dbti" type="tdouble" stored="false" indexed="true" multiValued="false" />
+    <dynamicField name="*_dbtim" type="tdouble" stored="false" indexed="true" multiValued="true" />
+
+    <dynamicField name="*_dbts" type="tdouble" stored="true" indexed="false" multiValued="false" />
+    <dynamicField name="*_dbtsm" type="tdouble" stored="true" indexed="false" multiValued="true" />
+    <dynamicField name="*_dbtsi" type="tdouble" stored="true" indexed="true" multiValued="false" />
+    <dynamicField name="*_dbtsim" type="tdouble" stored="true" indexed="true" multiValued="true" />
+
+    <!-- float (_f...) -->
+
+    <dynamicField name="*_fi" type="float" stored="false" indexed="true" multiValued="false" />
+    <dynamicField name="*_fim" type="float" stored="false" indexed="true" multiValued="true" />
+
+    <dynamicField name="*_fs" type="float" stored="true" indexed="false" multiValued="false" />
+    <dynamicField name="*_fsm" type="float" stored="true" indexed="false" multiValued="true" />
+    <dynamicField name="*_fsi" type="float" stored="true" indexed="true" multiValued="false" />
+    <dynamicField name="*_fsim" type="float" stored="true" indexed="true" multiValued="true" />
+
+    <!-- FloatPointField (_ft...) (for faster range queries) -->
+
+    <dynamicField name="*_fti" type="tfloat" stored="false" indexed="true" multiValued="false" />
+    <dynamicField name="*_ftim" type="tfloat" stored="false" indexed="true" multiValued="true" />
+
+    <dynamicField name="*_fts" type="tfloat" stored="true" indexed="false" multiValued="false" />
+    <dynamicField name="*_ftsm" type="tfloat" stored="true" indexed="false" multiValued="true" />
+    <dynamicField name="*_ftsi" type="tfloat" stored="true" indexed="true" multiValued="false" />
+    <dynamicField name="*_ftsim" type="tfloat" stored="true" indexed="true" multiValued="true" />
+
+    <!-- boolean (_b...) -->
+
+    <dynamicField name="*_bi" type="boolean" stored="false" indexed="true" multiValued="false" />
+    <dynamicField name="*_bs" type="boolean" stored="true" indexed="false" multiValued="false" />
+    <dynamicField name="*_bsi" type="boolean" stored="true" indexed="true" multiValued="false" />
+    <dynamicField name="*_b" type="boolean" stored="true" indexed="true"/><!-- same as _bsi, but for backward compatibility -->
+
+    <!-- Type used to index the lat and lon components for the "location" FieldType -->
+
+    <dynamicField name="*_coordinate" type="tdouble" indexed="true" stored="false" />
+
+
+    <!-- location (_ll...) -->
+
+    <dynamicField name="*_lli" type="location" stored="false" indexed="true" multiValued="false" />
+    <dynamicField name="*_llim" type="location" stored="false" indexed="true" multiValued="true" />
+
+    <dynamicField name="*_lls" type="location" stored="true" indexed="false" multiValued="false" />
+    <dynamicField name="*_llsm" type="location" stored="true" indexed="false" multiValued="true" />
+    <dynamicField name="*_llsi" type="location" stored="true" indexed="true" multiValued="false" />
+    <dynamicField name="*_llsim" type="location" stored="true" indexed="true" multiValued="true" />
+
+    <dynamicField name="*_srpt" type="location_rpt" stored="true" indexed="true" multiValued="true" />
+    <dynamicField name="*_bbox" type="bbox" stored="true" indexed="true" />
+
+
+    <!-- suggest and spelling -->
     <dynamicField name="*spell" type="textSpell" indexed="true" stored="false" multiValued="true" />
-
     <dynamicField name="*suggest" type="textSuggest" indexed="true" stored="false" multiValued="true" />
 
     <!-- date range (_drsim) -->
@@ -71,16 +294,52 @@
     <fieldType name="long"   class="solr.TrieLongField"    precisionStep="8" positionIncrementGap="0"/>
     <fieldType name="double" class="solr.TrieDoubleField"  precisionStep="8" positionIncrementGap="0"/>
 
+    <!-- PointField numeric field types for faster range queries -->
+    <fieldType name="tint" class="solr.IntPointField" docValues="true" />
+    <fieldType name="tfloat" class="solr.FloatPointField" docValues="true" />
+    <fieldType name="tlong" class="solr.LongPointField" docValues="true" />
+    <fieldType name="tdouble" class="solr.DoublePointField" docValues="true" />
+
     <!-- The format for this date field is of the form 1995-12-31T23:59:59Z.
          The trailing "Z" designates UTC time and is mandatory.
          A Trie based date field for faster date range queries and date faceting. -->
     <fieldType name="date" class="solr.TrieDateField" precisionStep="6" positionIncrementGap="0"/>
+
+    <!-- A PointField based date field for faster date range queries and date faceting. -->
+    <fieldType name="tdate" class="solr.DatePointField" docValues="true" />
 
     <!-- A DateRange based date field for truly faster date range queries. -->
     <fieldType name="dateRange" class="solr.DateRangeField"/>
 
     <!--Binary data type. The data should be sent/retrieved in as Base64 encoded Strings -->
     <fieldtype name="binary" class="solr.BinaryField"/>
+
+    <fieldType name="text" class="solr.TextField">
+      <analyzer>
+        <tokenizer class="solr.ICUTokenizerFactory" />
+        <filter class="solr.ICUFoldingFilterFactory" />  <!-- NFKC, case folding, diacritics removed -->
+        <filter class="solr.TrimFilterFactory" />
+      </analyzer>
+    </fieldType>
+
+    <!-- single token analyzed text, for sorting.  Punctuation is significant. -->
+    <fieldtype name="alphaSort" class="solr.TextField" sortMissingLast="true">
+      <analyzer>
+        <tokenizer class="solr.KeywordTokenizerFactory" />
+        <filter class="solr.ICUFoldingFilterFactory" />
+        <filter class="solr.TrimFilterFactory" />
+      </analyzer>
+    </fieldtype>
+
+    <!-- for alpha sorting as a single token -->
+    <fieldType name="text_sort" class="solr.TextField" sortMissingLast="true" omitNorms="true">
+      <analyzer>
+        <tokenizer class="solr.KeywordTokenizerFactory"/>
+        <filter class="solr.LowerCaseFilterFactory" />
+        <filter class="solr.TrimFilterFactory" />
+        <filter class="solr.PatternReplaceFilterFactory" pattern="([^a-z0-9 ])" replacement="" replace="all"/>
+      </analyzer>
+    </fieldType>
 
     <!-- A text field with defaults appropriate for English: it
          tokenizes with StandardTokenizer, removes English stop words
@@ -107,15 +366,7 @@
       </analyzer>
     </fieldType>
 
-    <!-- for alpha sorting as a single token -->
-    <fieldType name="text_sort" class="solr.TextField" sortMissingLast="true" omitNorms="true">
-      <analyzer>
-        <tokenizer class="solr.KeywordTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory" />
-        <filter class="solr.TrimFilterFactory" />
-        <filter class="solr.PatternReplaceFilterFactory" pattern="([^a-z0-9 ])" replacement="" replace="all"/>
-      </analyzer>
-    </fieldType>
+
 
     <!-- for spell checking -->
     <fieldType name="textSpell" class="solr.TextField" positionIncrementGap="100" >
@@ -155,21 +406,21 @@
   </types>
 
   <!-- for scoring formula -->
-  <copyField source="dct_spatial_sm"       dest="dct_spatial_tmi"      maxChars="10000"/>
-  <copyField source="dct_temporal_sm"      dest="dct_temporal_tmi"     maxChars="10000"/>
-  <copyField source="dct_creator_sm"       dest="dct_creator_tmi"      maxChars="1000"/>
-  <copyField source="dct_description_sm"   dest="dct_description_tmi"  maxChars="10000"/>
-  <copyField source="dct_format_s"         dest="dct_format_ti"        maxChars="100"/>
-  <copyField source="dct_identifier_sm"    dest="dct_identifier_tmi"   maxChars="100"/>
-  <copyField source="dct_publisher_sm"     dest="dct_publisher_tmi"    maxChars="1000"/>
-  <copyField source="dct_accessRights_s"   dest="dct_accessRights_ti"  maxChars="100"/>
-  <copyField source="schema_provider_s"    dest="dct_provider_ti"      maxChars="1000"/>
-  <copyField source="dct_subject_sm"       dest="dct_subject_tmi"      maxChars="10000"/>
-  <copyField source="dct_title_s"          dest="dct_title_ti"         maxChars="1000"/>
-  <copyField source="dct_isPartOf_sm"      dest="dct_isPartOf_tmi"     maxChars="1000"/>
-  <copyField source="gbl_resourceClass_sm" dest="gbl_resourceClass_tmi" maxChars="100"/>
-  <copyField source="gbl_resourceType_sm"  dest="gbl_resourceType_tmi"  maxChars="1000"/>
-  <copyField source="id"                   dest="id_ti"                maxChars="100"/>
+  <copyField source="dct_spatial_sm"       dest="dct_spatial_teim"      maxChars="10000"/>
+  <copyField source="dct_temporal_sm"      dest="dct_temporal_teim"     maxChars="10000"/>
+  <copyField source="dct_creator_sm"       dest="dct_creator_teim"      maxChars="1000"/>
+  <copyField source="dct_description_sm"   dest="dct_description_teim"  maxChars="10000"/>
+  <copyField source="dct_format_s"         dest="dct_format_tei"        maxChars="100"/>
+  <copyField source="dct_identifier_sm"    dest="dct_identifier_teim"   maxChars="100"/>
+  <copyField source="dct_publisher_sm"     dest="dct_publisher_teim"    maxChars="1000"/>
+  <copyField source="dct_accessRights_s"   dest="dct_accessRights_tei"  maxChars="100"/>
+  <copyField source="schema_provider_s"    dest="dct_provider_tei"      maxChars="1000"/>
+  <copyField source="dct_subject_sm"       dest="dct_subject_teim"      maxChars="10000"/>
+  <copyField source="dct_title_s"          dest="dct_title_tei"         maxChars="1000"/>
+  <copyField source="dct_isPartOf_sm"      dest="dct_isPartOf_teim"     maxChars="1000"/>
+  <copyField source="gbl_resourceClass_sm" dest="gbl_resourceClass_teim" maxChars="100"/>
+  <copyField source="gbl_resourceType_sm"  dest="gbl_resourceType_teim"  maxChars="1000"/>
+  <copyField source="id"                   dest="id_tei"                maxChars="100"/>
 
   <!-- core text search -->
   <copyField source="*_s"                dest="text" />

--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -117,37 +117,37 @@
       <str name="q.alt">*:*</str>
       <str name="qf">
         text^1
-        dct_description_ti^2
-        dct_creator_tmi^3
-        dct_publisher_ti^3
-        dct_isPartOf_tmi^4
-        dct_subject_tmi^5
-        dct_spatial_tmi^5
-        dct_temporal_tmi^5
-        dct_title_ti^6
-        dct_accessRights_ti^7
-        dct_provider_ti^8
-        gbl_resourceClass_ti^9
-        gbl_resourceType_ti^9
-        dct_identifier_ti^10
-        id_ti^10
+        dct_description_tei^2
+        dct_creator_teim^3
+        dct_publisher_tei^3
+        dct_isPartOf_teim^4
+        dct_subject_teim^5
+        dct_spatial_teim^5
+        dct_temporal_teim^5
+        dct_title_tei^6
+        dct_accessRights_tei^7
+        dct_provider_tei^8
+        gbl_resourceClass_tei^9
+        gbl_resourceType_tei^9
+        dct_identifier_tei^10
+        id_tei^10
       </str>
       <str name="pf"><!-- phrase boost within result set -->
         text^1
-        dct_description_ti^2
-        dct_creator_tmi^3
-        dct_publisher_ti^3
-        dct_isPartOf_tmi^4
-        dct_subject_tmi^5
-        dct_spatial_tmi^5
-        dct_temporal_tmi^5
-        dct_title_ti^6
-        dct_accessRights_ti^7
-        dct_provider_ti^8
-        gbl_resourceClass_ti^9
-        gbl_resourceType_ti^9
-        dct_identifier_ti^10
-        id_ti^10
+        dct_description_tei^2
+        dct_creator_teim^3
+        dct_publisher_tei^3
+        dct_isPartOf_teim^4
+        dct_subject_teim^5
+        dct_spatial_teim^5
+        dct_temporal_teim^5
+        dct_title_tei^6
+        dct_accessRights_tei^7
+        dct_provider_tei^8
+        gbl_resourceClass_tei^9
+        gbl_resourceType_tei^9
+        dct_identifier_tei^10
+        id_tei^10
       </str>
       <bool name="facet">true</bool>
       <int name="facet.mincount">1</int>


### PR DESCRIPTION
Fixes #1277

NOTE: This adds a number of duplicate field types that we're maintaining for backward compatibility:
* `*_b`
* `*_s`
* `*_sm`
* `*_sort`
* `*_im`
* `*_dt`

This might be the worst of both worlds. 