### PR TITLE
Add height style for openlayers viewer

### DIFF
--- a/app/assets/stylesheets/geoblacklight/viewers.css
+++ b/app/assets/stylesheets/geoblacklight/viewers.css
@@ -1,6 +1,8 @@
 /* Styles for map viewers */
 
-#leaflet-viewer {
+/* Geo viewers */
+#leaflet-viewer,
+#openlayers-viewer {
   height: 500px;
 }
 


### PR DESCRIPTION
We currently use this for COGs and PMTiles. Without this style,
it doesn't take up any space on the page and is invisible.
