### PR TITLE
Move the record title to the top of the page

### DIFF
--- a/app/assets/stylesheets/geoblacklight/record.css
+++ b/app/assets/stylesheets/geoblacklight/record.css
@@ -1,11 +1,15 @@
 /* Record show page styles */
 
 /* Document header */
-.blacklight-catalog-show .documentHeader h1 > * {
+.documentHeader h1 {
+  margin-bottom: 0.5em;
+}
+
+.documentHeader h1 > * {
   vertical-align: middle;
 }
 
-.blacklight-catalog-show .documentHeader .blacklight-icons {
+.documentHeader .blacklight-icons {
   display: inline-flex;
   justify-content: center;
   align-items: center;
@@ -14,7 +18,12 @@
 
 /* Attribute table */
 [data-sidebar=false] .attribute-data {
-  margin: 1rem 0;
+  margin-top: 1rem;
+}
+
+/* Metadata */
+.document-metadata {
+  margin-top: 1rem;
 }
 
 /* Sidebar */

--- a/app/components/geoblacklight/document_component.html.erb
+++ b/app/components/geoblacklight/document_component.html.erb
@@ -12,6 +12,7 @@
     <%= body %>
   <% else %>
     <div class="document-main-section">
+      <%= title %>
       <% @document.display_note.each do |display_note| %>
         <%= render Geoblacklight::DisplayNoteComponent.new(display_note: display_note) %>
       <% end %>
@@ -23,8 +24,6 @@
       </div>
       <%= render Geoblacklight::AttributeTableComponent.new(document: @document) %>
       <%= render Geoblacklight::IndexMapInspectComponent.new(document: @document) %>
-      <% title.with_after_title { render Geoblacklight::HeaderIconsComponent.new(document: @document) } %>
-      <%= title %>
       <%= embed %>
       <%= content %>
       <%= metadata %>


### PR DESCRIPTION
Also removes the icons from the record title on the show page.

This helps create a more consistent UI so that the title isn't
pushed down the page by the viewer and attribute table. The icons
aren't as necessary on the show page and often wrap awkwardly.

Closes #1773
