### PR TITLE
Require geo_combine in the engine

### DIFF
--- a/lib/geoblacklight/engine.rb
+++ b/lib/geoblacklight/engine.rb
@@ -7,6 +7,7 @@ require "faraday"
 require "geoblacklight/version"
 require "nokogiri"
 require "mime/types"
+require "geo_combine"
 
 module Geoblacklight
   class Engine < ::Rails::Engine

--- a/lib/geoblacklight/metadata/base.rb
+++ b/lib/geoblacklight/metadata/base.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "geo_combine"
-
 module Geoblacklight
   module Metadata
     ##

--- a/lib/geoblacklight/metadata_transformer.rb
+++ b/lib/geoblacklight/metadata_transformer.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "geo_combine"
-
 module Geoblacklight
   module MetadataTransformer
     ##


### PR DESCRIPTION
This enables the geo_combine rake tasks to be loaded into the application.

Fixes #1798