### PR TITLE
Remove dynamic dispatch on SolrDocument

### DIFF
--- a/app/models/concerns/geoblacklight/solr_document.rb
+++ b/app/models/concerns/geoblacklight/solr_document.rb
@@ -87,29 +87,5 @@ module Geoblacklight
     def geometry
       @geometry ||= Geoblacklight::Geometry.new(geom_field)
     end
-
-    ##
-    # Provides a convenience method to access a SolrDocument's References
-    # endpoint url without having to check and see if it is available
-    # :type => a string which if its a Geoblacklight::Constants::URI key
-    #          will return a coresponding Geoblacklight::Reference
-    def checked_endpoint(type)
-      type = references.public_send(type)
-      type.endpoint if type.present?
-    end
-
-    private
-
-    def method_missing(method, *args, &block)
-      if /.*_url$/.match?(method.to_s)
-        checked_endpoint(method.to_s.gsub("_url", ""))
-      else
-        super
-      end
-    end
-
-    def respond_to_missing?(method, *args, &block)
-      /.*_url$/.match?(method.to_s) || super
-    end
   end
 end

--- a/spec/models/concerns/geoblacklight/solr_document_spec.rb
+++ b/spec/models/concerns/geoblacklight/solr_document_spec.rb
@@ -234,39 +234,4 @@ RSpec.describe Geoblacklight::SolrDocument do
       expect(document.viewer_endpoint).to eq ""
     end
   end
-  describe "checked_endpoint" do
-    let(:document_attributes) { {} }
-    let(:reference) { Geoblacklight::Reference.new(["http://www.opengis.net/def/serviceType/ogc/wms", "http://www.example.com/wms"]) }
-    it "returns endpoint if available" do
-      expect_any_instance_of(Geoblacklight::References).to receive(:wms).and_return(reference)
-      expect(document.checked_endpoint("wms")).to eq "http://www.example.com/wms"
-    end
-    it "return nil if not available" do
-      expect_any_instance_of(Geoblacklight::References).to receive(:wms).and_return(nil)
-      expect(document.checked_endpoint("wms")).to be_nil
-    end
-  end
-  describe "method_missing" do
-    let(:document_attributes) { {} }
-    it "calls checked_endpoint with parsed method name if matches" do
-      expect(document).to receive(:checked_endpoint).with("wms").and_return(nil)
-      expect(document.wms_url).to be_nil
-    end
-    it "raises no method error" do
-      expect { document.wms_urlz }.to raise_error NoMethodError
-    end
-  end
-  describe "#respond_to_missing?" do
-    let(:document_attributes) { {} }
-    context "with a valid method" do
-      it "returns true" do
-        expect(document.respond_to?(:wms_url)).to be true
-      end
-    end
-    context "with a invalid method" do
-      it "returns true" do
-        expect(document.respond_to?(:wms_urlz)).to be false
-      end
-    end
-  end
 end


### PR DESCRIPTION
This makes it harder to understand and analyze the code. It didn't seem to be used.
