### PR TITLE
Drop Rails 7 support

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -51,7 +51,7 @@ jobs:
     strategy:
       matrix:
         ruby_version: ["3.3", "3.4", "4.0"]
-        rails_version: ["7.2.3", "8.1.1"]
+        rails_version: ["8.1.1"]
 
     name: test ruby ${{ matrix.ruby_version }} / rails ${{ matrix.rails_version }}
     steps:

--- a/geoblacklight.gemspec
+++ b/geoblacklight.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 3.2.0"
   spec.required_rubygems_version = ">= 2.5.2"
 
-  spec.add_dependency "rails", ">= 6.1", "< 9"
+  spec.add_dependency "rails", ">= 8", "< 9"
   spec.add_dependency "blacklight", ">= 8.0", "< 10"
   spec.add_dependency "config"
   spec.add_dependency "faraday", "~> 2.0"
@@ -28,7 +28,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "mime-types"
   spec.add_dependency "rgeo-geojson"
   spec.add_dependency "rsolr"
-  spec.add_dependency "zeitwerk"
 
   spec.add_development_dependency "rails-controller-testing"
   spec.add_development_dependency "rspec-rails"

--- a/lib/geoblacklight.rb
+++ b/lib/geoblacklight.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "active_support/dependencies"
 require "zeitwerk"
 loader = Zeitwerk::Loader.for_gem
 loader.ignore("#{__dir__}/generators")


### PR DESCRIPTION
Rails 7 is EOL on 09 Aug 2026, so nobody should be using it for a new major version of GeoBlacklight