### PR TITLE
Do not directly depend on rsolr

### DIFF
--- a/geoblacklight.gemspec
+++ b/geoblacklight.gemspec
@@ -28,7 +28,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "geo_combine", "~> 0.10"
   spec.add_dependency "mime-types"
   spec.add_dependency "rgeo-geojson"
-  spec.add_dependency "rsolr"
 
   spec.add_development_dependency "rails-controller-testing"
   spec.add_development_dependency "rspec-rails"


### PR DESCRIPTION
It's more of a peer dependency generated into the gemfile by blacklight.

Reverts part of #1612