### PR TITLE
Remove rsolr dependency and injection step

### DIFF
--- a/geoblacklight.gemspec
+++ b/geoblacklight.gemspec
@@ -28,7 +28,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "geo_combine", "~> 0.10"
   spec.add_dependency "mime-types"
   spec.add_dependency "rgeo-geojson"
-  spec.add_dependency "rsolr"
 
   spec.add_development_dependency "rails-controller-testing"
   spec.add_development_dependency "rspec-rails"

--- a/lib/generators/geoblacklight/install_generator.rb
+++ b/lib/generators/geoblacklight/install_generator.rb
@@ -62,10 +62,6 @@ module Geoblacklight
       directory "../../../../solr", "solr"
     end
 
-    def add_rsolr_gem
-      gem "rsolr", ">= 1.0", "< 3"
-    end
-
     def docker_compose
       copy_file "../../../../compose.yml", "compose.yml"
     end

--- a/spec/test_app_templates/lib/generators/test_app_generator.rb
+++ b/spec/test_app_templates/lib/generators/test_app_generator.rb
@@ -16,7 +16,7 @@ class TestAppGenerator < Rails::Generators::Base
   # Install blacklight
   def run_blacklight_generator
     say_status("warning", "GENERATING BL", :yellow)
-    generate "blacklight:install", "--devise", "--skip-solr"
+    generate "blacklight:install", "--devise"
   end
 
   # Install geoblacklight


### PR DESCRIPTION
Blacklight already handles adding this to the built app's Gemfile
for us: https://github.com/projectblacklight/blacklight/blob/34d83482d341b51be40cf8fd07a3038de8c2ca1f/lib/generators/blacklight/solr_generator.rb#L33-L35
