### PR TITLE
Fix truncator CSS so descriptions are partially shown

### DIFF
--- a/app/assets/stylesheets/geoblacklight/global.css
+++ b/app/assets/stylesheets/geoblacklight/global.css
@@ -5,3 +5,33 @@
   width: 1em;
   height: 1em;
 }
+
+/* Truncation */
+.truncate-abstract {
+  transition: none; /* No animation */
+  position: relative;
+}
+
+.truncate-abstract.collapse:not(.show),
+.truncate-abstract.collapsing {
+  display: block;
+  display: -webkit-box;
+  height: auto;
+  min-height: 8rem;
+  max-height: 8rem;
+  overflow-y: hidden;
+  line-clamp: 8;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 8;
+
+  /* Gradient fade effect */
+  &::after {
+    content: "";
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: 2rem;
+    background-image: linear-gradient(to bottom, rgba(255, 255, 255, 0), #fff);
+  }
+}


### PR DESCRIPTION
We lost some CSS that applied to the truncated abstracts as part
of the move to pure CSS. As a result, long descriptions were fully
truncated to just the "read more" link, instead of a preview of a
few lines before the link.

This restores the needed CSS, and adds a small gradient effect to
make the bottom of the truncated area a little cleaner.
