### PR TITLE
Render multivalued descriptions as separate paragraphs

### DIFF
--- a/app/assets/stylesheets/geoblacklight/record.css
+++ b/app/assets/stylesheets/geoblacklight/record.css
@@ -27,6 +27,10 @@
   margin-top: 1rem;
 }
 
+.blacklight-dct_description_sm p:last-of-type {
+  margin-bottom: 0;
+}
+
 /* Sidebar */
 .page-sidebar {
   .card + .card {

--- a/app/helpers/geoblacklight_helper.rb
+++ b/app/helpers/geoblacklight_helper.rb
@@ -44,7 +44,7 @@ module GeoblacklightHelper
       read_more_text: t("geoblacklight.truncate.read_more"),
       close_text: t("geoblacklight.truncate.close")
     } do
-      Array(args[:value]).flatten.join(" ")
+      Array(args[:value]).flatten.collect { |v| concat tag.p(v) }
     end
   end
 

--- a/spec/helpers/geoblacklight_helper_spec.rb
+++ b/spec/helpers/geoblacklight_helper_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe GeoblacklightHelper, type: :helper do
     context "with multiple values" do
       let(:document) { SolrDocument.new(value: %w[short description]) }
       it "wraps in correct DIV class" do
-        expect(helper.render_value_as_truncate_abstract(document)).to eq '<div class="truncate-abstract" data-read-more-text="Read more" data-close-text="Close">short description</div>'
+        expect(helper.render_value_as_truncate_abstract(document)).to eq '<div class="truncate-abstract" data-read-more-text="Read more" data-close-text="Close"><p>short</p><p>description</p></div>'
       end
     end
   end


### PR DESCRIPTION
Some records have multiple descriptions; we can honor the separation
a little more by rendering them using `<p>` tags instead of just
smushing everything together into one `<div>`.
