### PR TITLE
Remove unused methods

### DIFF
--- a/lib/geoblacklight/download.rb
+++ b/lib/geoblacklight/download.rb
@@ -7,10 +7,6 @@ module Geoblacklight
       @options = options
     end
 
-    def downloadable?
-      @document.downloadable?
-    end
-
     def file_name
       "#{@document.id}-#{@options[:type]}.#{@options[:extension]}"
     end
@@ -75,13 +71,6 @@ module Geoblacklight
       raise Geoblacklight::Exceptions::ExternalDownloadFailed,
         message: "Download timed out",
         url: conn.url_prefix.to_s
-    end
-
-    ##
-    # Creates a download url for the object
-    # @return [String]
-    def url_with_params
-      url + "/?" + URI.encode_www_form(@options[:request_params])
     end
 
     private

--- a/lib/geoblacklight/references.rb
+++ b/lib/geoblacklight/references.rb
@@ -44,13 +44,6 @@ module Geoblacklight
     end
 
     ##
-    # Preferred download (should be a file download)
-    # @return [Hash, nil]
-    def preferred_download
-      file_download if download.present?
-    end
-
-    ##
     # Download hash based off of format type
     # @return [Hash, nil]
     def downloads_by_format
@@ -90,13 +83,6 @@ module Geoblacklight
       else
         JSON.parse(@document[reference_field])
       end
-    end
-
-    ##
-    # Download hash for a static file download
-    # @return (see #downloads_by_format)
-    def file_download
-      {file_download: download.to_hash}
     end
 
     ##

--- a/spec/lib/geoblacklight/download_spec.rb
+++ b/spec/lib/geoblacklight/download_spec.rb
@@ -20,15 +20,6 @@ RSpec.describe Geoblacklight::Download do
     end
   end
 
-  describe "#downloadable?" do
-    before do
-      allow(document).to receive(:downloadable?).and_return(true)
-    end
-    it "determines whether or not the resource can be downloaded" do
-      expect(download.downloadable?).to be true
-    end
-  end
-
   describe "#file_name" do
     it "gives the file name with path and extension" do
       expect(download.file_name).to eq "test-shapefile.zip"
@@ -162,27 +153,6 @@ RSpec.describe Geoblacklight::Download do
       expect(faraday_connection).to receive(:get).and_raise(Faraday::TimeoutError)
       expect(Faraday).to receive(:new).with(url: "http://www.example.com/wms").and_return(faraday_connection)
       expect { download.initiate_download }.to raise_error(Geoblacklight::Exceptions::ExternalDownloadFailed)
-    end
-  end
-  describe "#url_with_params" do
-    let(:options) do
-      {
-        service_type: "wms",
-        request_params: {
-          service: "wfs",
-          version: "2.0.0",
-          request: "GetFeature",
-          srsName: "EPSG:4326",
-          outputformat: "SHAPE-ZIP",
-          typeName: ""
-        }
-      }
-    end
-
-    it "creates a download url with params" do
-      expect(download.url_with_params).to eq "http://www.example.com/wms/?ser" \
-                                             "vice=wfs&version=2.0.0&request=GetFeature&srsName=EPSG%3A4326&output" \
-                                             "format=SHAPE-ZIP&typeName="
     end
   end
 end

--- a/spec/lib/geoblacklight/references_spec.rb
+++ b/spec/lib/geoblacklight/references_spec.rb
@@ -165,16 +165,6 @@ RSpec.describe Geoblacklight::References do
       expect(typical_ogp_shapefile.download).to be_nil
     end
   end
-  describe "preferred_download" do
-    it "returns the direct download if available" do
-      expect(complex_shapefile.preferred_download[:file_download][:download]).to eq "http://example.com/urn:hul.harvard.edu:HARVARD.SDE2.TG10USAIANNH/data.zip"
-      expect(direct_download_only.preferred_download[:file_download][:download]).to eq "http://example.com/layer-id-geotiff.tiff"
-    end
-    it "returns nil if there is no direct download" do
-      expect(typical_ogp_shapefile.preferred_download).to be_nil
-      expect(typical_ogp_geotiff.preferred_download).to be_nil
-    end
-  end
   describe "download_types" do
     it "returns available downloads by format" do
       types = complex_shapefile.download_types


### PR DESCRIPTION
Automated analysis showed that these were only referenced in
tests.
