### PR TITLE
Revert removal of --skip-solr during build

### DIFF
--- a/geoblacklight.gemspec
+++ b/geoblacklight.gemspec
@@ -28,7 +28,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "geo_combine", "~> 0.10"
   spec.add_dependency "mime-types"
   spec.add_dependency "rgeo-geojson"
-  spec.add_dependency "rsolr"
 
   spec.add_development_dependency "rails-controller-testing"
   spec.add_development_dependency "rspec-rails"

--- a/geoblacklight.gemspec
+++ b/geoblacklight.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "geo_combine", "~> 0.10"
   spec.add_dependency "mime-types"
   spec.add_dependency "rgeo-geojson"
+  spec.add_dependency "rsolr"
 
   spec.add_development_dependency "rails-controller-testing"
   spec.add_development_dependency "rspec-rails"

--- a/lib/generators/geoblacklight/install_generator.rb
+++ b/lib/generators/geoblacklight/install_generator.rb
@@ -62,6 +62,10 @@ module Geoblacklight
       directory "../../../../solr", "solr"
     end
 
+    def add_rsolr_gem
+      gem "rsolr", ">= 1.0", "< 3"
+    end
+
     def docker_compose
       copy_file "../../../../compose.yml", "compose.yml"
     end

--- a/spec/test_app_templates/lib/generators/test_app_generator.rb
+++ b/spec/test_app_templates/lib/generators/test_app_generator.rb
@@ -16,7 +16,7 @@ class TestAppGenerator < Rails::Generators::Base
   # Install blacklight
   def run_blacklight_generator
     say_status("warning", "GENERATING BL", :yellow)
-    generate "blacklight:install", "--devise"
+    generate "blacklight:install", "--devise", "--skip-solr"
   end
 
   # Install geoblacklight


### PR DESCRIPTION
- **Revert "Remove rsolr dependency and injection step"**
  This reverts commit 0edee5d8aaaa994e270f59a749d87aa2c0f2990c.
  

- **Do not directly depend on rsolr**
  It's more of a peer dependency generated into the gemfile by blacklight.
  
  Reverts part of #1612
  