### PR TITLE
Import leaflet functions during inspection to fix overlay crash for point and line data

### DIFF
--- a/app/javascript/geoblacklight/leaflet/inspection.js
+++ b/app/javascript/geoblacklight/leaflet/inspection.js
@@ -1,4 +1,5 @@
 import { identifyFeatures } from "esri-leaflet"
+import { polygon, geoJSON, circleMarker, layerGroup } from "leaflet"
 import {
   appendErrorMessage,
   appendLoadingMessage,
@@ -73,7 +74,7 @@ export const overlayLayer = (map, data, layer) => {
   const color = map.options.selected_color
 
   if (data._latlngs) {
-    overlayLayer = L.polygon(data._latlngs, {
+    overlayLayer = polygon(data._latlngs, {
       color: color,
       weight: 2,
       layer: true,
@@ -82,13 +83,13 @@ export const overlayLayer = (map, data, layer) => {
       highlightLayer: true,
     })
   } else {
-    overlayLayer = L.geoJSON(data, {
+    overlayLayer = geoJSON(data, {
       color: color,
       opacity: opacity,
       addToOpacitySlider: true,
       highlightLayer: true,
       pointToLayer: function (feature, latlng) {
-        return L.circleMarker(latlng, {
+        return circleMarker(latlng, {
           radius: 8,
           fillColor: color,
           color: color,
@@ -99,7 +100,7 @@ export const overlayLayer = (map, data, layer) => {
       },
     })
   }
-  L.layerGroup([overlayLayer]).addTo(map)
+  layerGroup([overlayLayer]).addTo(map)
 }
 
 export const tiledMapLayerInspection = (map, layer) => {


### PR DESCRIPTION
Fixes https://github.com/geoblacklight/geoblacklight/issues/1856

Seems to be some conflict with the fact that the leaflet map is imported from leaflet in LeafletViewerController and the highlight layer is created with global L. The bounds for point and line data are undefined for the highlight layer, which errors and then fails to populate the feature inspection tables. This PR imports directly from "leaflet" in inspection.js so leaflet objects come from same instance - seems to fix the issue during local testing against test fixtures and a few cugir records.

I'd like to also backport this to release-5.x if this is merged.