### PR TITLE
Make the download card header an h2

### DIFF
--- a/app/components/geoblacklight/document/download_links_component.html.erb
+++ b/app/components/geoblacklight/document/download_links_component.html.erb
@@ -1,5 +1,7 @@
 <div data-controller="downloads" class="downloads card">
-  <div class="card-header"><%= t("geoblacklight.download.downloads") %></div>
+  <div class="card-header">
+    <h2 class="mb-0 h6"><%= t("geoblacklight.download.downloads") %></h2>
+  </div>
   <ul class="list-group list-group-flush">
     <% download_links.each do |link| %>
       <%= render link %>


### PR DESCRIPTION
This conforms to how the other card headers are expressed in the semantic html

no visual change.
<img width="345" height="479" alt="Screenshot 2026-07-15 at 4 26 19 PM" src="https://github.com/user-attachments/assets/73b4f4f0-3c51-495f-9c33-446f4ea27a54" />
