### PR TITLE
[backport] Don't wait for basemap tiles when running the feature tests with javascript

### DIFF
--- a/spec/features/relations_spec.rb
+++ b/spec/features/relations_spec.rb
@@ -33,10 +33,9 @@ feature "Display related documents" do
   end
 
   scenario "Relationship browse link returns relationship-scoped results", js: true do
-    # Wabash Topo parent record
-    visit solr_document_path("eee6150b-ce2f-4837-9d17-ce72a0c1c26f")
+    visit solr_document_path("princeton-1r66j405w")
 
-    expect(page).to have_content(:all, "Has part...")
+    expect(page).to have_content(:all, "Derived records...")
     expect(page).to have_link("Browse all 4 records...", visible: :all)
     click_link("Browse all 4 records...", visible: :all)
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,7 +36,28 @@ require "selenium-webdriver"
 require "webmock/rspec"
 WebMock.allow_net_connect!(net_http_connect_on_start: true)
 
-Capybara.javascript_driver = :selenium_chrome_headless
+Capybara.register_driver :chrome_headless do |app|
+  # Set up Chrome options
+  options = Selenium::WebDriver::Chrome::Options.new
+  options.add_argument("--headless")
+  options.add_argument("--disable-gpu")
+  options.add_argument("--no-sandbox")
+  options.add_argument("--window-size=1280,1024")
+  # Return from #visit at DOMContentLoaded instead of waiting for the full
+  # window `load` event. GeoBlacklight pages pull basemap tiles and WMS/TMS
+  # layers from external hosts; in CI those requests can hang and prevent
+  # `load` from ever firing, causing Net::ReadTimeout on #visit.
+  options.page_load_strategy = :eager
+
+  # Allow longer TCP reads to prevent timeout in the case of loading fixture
+  # eee6150b-ce2f-4837-9d17-ce72a0c1c26f, as part of relations_spec.rb
+  client = Selenium::WebDriver::Remote::Http::Default.new
+  client.read_timeout = 120 # seconds
+
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options: options, http_client: client)
+end
+
+Capybara.javascript_driver = :chrome_headless
 
 require "geoblacklight"
 


### PR DESCRIPTION
This backports 18d7af320390aff054220cdd305b297aa7f3dba0 and some other
related changes to the test setup to handle timeouts in the CI suite.
