### PR TITLE
Fix basemap configuration for leaflet viewer; add dark mode basemap

### DIFF
--- a/app/components/geoblacklight/item_map_viewer_component.rb
+++ b/app/components/geoblacklight/item_map_viewer_component.rb
@@ -84,7 +84,8 @@ module Geoblacklight
         data: {
           "controller" => viewer_name,
           "#{viewer_name}-available-value" => helpers.document_available?(@document),
-          "#{viewer_name}-basemap-value" => helpers.geoblacklight_basemap,
+          "#{viewer_name}-basemap-value" => Geoblacklight.configuration.basemap_provider,
+          "#{viewer_name}-dark-basemap-value" => Geoblacklight.configuration.dark_basemap_provider,
           "#{viewer_name}-protocol-value" => protocol,
           "#{viewer_name}-url-value" => @document.viewer_endpoint,
           "#{viewer_name}-map-geom-value" => @document.geometry.geojson,

--- a/app/components/geoblacklight/location_leaflet_map_component.rb
+++ b/app/components/geoblacklight/location_leaflet_map_component.rb
@@ -57,7 +57,8 @@ module Geoblacklight
     def leaflet_viewer_data_attributes
       {
         "controller" => "leaflet-viewer",
-        "leaflet-viewer-basemap-value" => helpers.geoblacklight_basemap,
+        "leaflet-viewer-basemap-value" => Geoblacklight.configuration.basemap_provider,
+        "leaflet-viewer-dark-basemap-value" => Geoblacklight.configuration.dark_basemap_provider,
         "leaflet-viewer-map-geom-value" => search_bbox || @map_geometry,
         "leaflet-viewer-data-map-value" => @data_map,
         "leaflet-viewer-page-value" => params[:action]&.upcase,

--- a/app/components/geoblacklight/static_map_component.rb
+++ b/app/components/geoblacklight/static_map_component.rb
@@ -25,7 +25,8 @@ module Geoblacklight
         class: "viewer border",
         data: {
           "controller" => "leaflet-viewer",
-          "leaflet-viewer-basemap-value" => helpers.geoblacklight_basemap,
+          "leaflet-viewer-basemap-value" => Geoblacklight.configuration.basemap_provider,
+          "leaflet-viewer-dark-basemap-value" => Geoblacklight.configuration.dark_basemap_provider,
           "leaflet-viewer-page-value" => "STATIC_MAP",
           "leaflet-viewer-map-geom-value" => @document.geometry.geojson,
           "leaflet-viewer-options-value" => leaflet_options.to_h,

--- a/app/helpers/geoblacklight_helper.rb
+++ b/app/helpers/geoblacklight_helper.rb
@@ -49,13 +49,6 @@ module GeoblacklightHelper
   end
 
   ##
-  # Selects the basemap used for map displays
-  # @return [String]
-  def geoblacklight_basemap
-    blacklight_config.basemap_provider || "positron"
-  end
-
-  ##
   # Renders the transformed metadata
   # (Renders a partial when the metadata isn't available)
   # @param [Geoblacklight::Metadata::Base] metadata the metadata object

--- a/app/javascript/geoblacklight/controllers/leaflet_viewer_controller.js
+++ b/app/javascript/geoblacklight/controllers/leaflet_viewer_controller.js
@@ -34,6 +34,7 @@ export default class LeafletViewerController extends Controller {
     available: Boolean,
     options: Object,
     basemap: String,
+    darkBasemap: String,
     mapGeom: Object,
     page: String,
     layerId: String,
@@ -103,11 +104,14 @@ export default class LeafletViewerController extends Controller {
     this.element.dataset.bounds = this.bounds.toBBoxString()
   }
 
-  // Select the configured basemap to use
+  // Select the configured basemaps to use
   getBasemap() {
-    const basemapName = this.basemapValue || "positron"
-    return tileLayer(basemaps[basemapName].url, {
-      ...basemaps[basemapName],
+    if (document.documentElement.getAttribute("data-bs-theme") === "dark")
+      this.basemapName = this.darkBasemapValue || "dark_matter"
+    else this.basemapName = this.basemapValue || "positron"
+
+    return tileLayer(basemaps[this.basemapName].url, {
+      ...basemaps[this.basemapName],
       detectRetina: this.optionsValue.layers.detect_retina || false,
     })
   }

--- a/app/javascript/geoblacklight/leaflet/basemaps.js
+++ b/app/javascript/geoblacklight/leaflet/basemaps.js
@@ -1,5 +1,5 @@
 export default {
-  darkMatter: {
+  dark_matter: {
     url: "https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{retina}.png",
     attribution:
       '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://carto.com/attributions">Carto</a>',
@@ -15,7 +15,7 @@ export default {
     worldCopyJump: true,
     retina: "@2x",
   },
-  positronLite: {
+  positron_lite: {
     url: "https://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}{retina}.png",
     attribution:
       '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://carto.com/attributions">Carto</a>',
@@ -23,7 +23,7 @@ export default {
     worldCopyJump: true,
     retina: "@2x",
   },
-  worldAntique: {
+  world_antique: {
     url: "https://cartocdn_{s}.global.ssl.fastly.net/base-antique/{z}/{x}/{y}{retina}.png",
     attribution:
       '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://carto.com/attributions">Carto</a>',
@@ -31,7 +31,7 @@ export default {
     worldCopyJump: true,
     retina: "@2x",
   },
-  worldEco: {
+  world_eco: {
     url: "https://cartocdn_{s}.global.ssl.fastly.net/base-eco/{z}/{x}/{y}{retina}.png",
     attribution:
       '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://carto.com/attributions">Carto</a>',
@@ -39,7 +39,7 @@ export default {
     worldCopyJump: true,
     retina: "@2x",
   },
-  flatBlue: {
+  flat_blue: {
     url: "https://cartocdn_{s}.global.ssl.fastly.net/base-flatblue/{z}/{x}/{y}{retina}.png",
     attribution:
       '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://carto.com/attributions">Carto</a>',
@@ -47,7 +47,7 @@ export default {
     worldCopyJump: true,
     retina: "@2x",
   },
-  midnightCommander: {
+  midnight_commander: {
     url: "https://cartocdn_{s}.global.ssl.fastly.net/base-midnight/{z}/{x}/{y}{retina}.png",
     attribution:
       '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://carto.com/attributions">Carto</a>',
@@ -55,7 +55,7 @@ export default {
     worldCopyJump: true,
     retina: "@2x",
   },
-  openstreetmapHot: {
+  openstreetmap_hot: {
     url: "https://{s}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png",
     attribution:
       '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>, Tiles courtesy of <a href="http://hot.openstreetmap.org/" target="_blank">Humanitarian OpenStreetMap Team</a>',
@@ -63,7 +63,7 @@ export default {
     worldCopyJump: true,
     retina: "@2x",
   },
-  openstreetmapStandard: {
+  openstreetmap_standard: {
     url: "https://tile.openstreetmap.org/{z}/{x}/{y}.png",
     attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
     maxZoom: 19,

--- a/app/javascript/geoblacklight/openlayers/basemaps.js
+++ b/app/javascript/geoblacklight/openlayers/basemaps.js
@@ -1,5 +1,5 @@
 export default {
-  darkMatter: {
+  dark_matter: {
     url: "https://{a-d}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png",
     attributions:
       '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://carto.com/attributionss">Carto</a>',
@@ -11,43 +11,43 @@ export default {
       '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://carto.com/attributionss">Carto</a>',
     maxZoom: 18,
   },
-  positronLite: {
+  positron_lite: {
     url: "https://{a-d}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}.png",
     attributions:
       '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://carto.com/attributionss">Carto</a>',
     maxZoom: 18,
   },
-  worldAntique: {
+  world_antique: {
     url: "https://cartocdn_{a-d}.global.ssl.fastly.net/base-antique/{z}/{x}/{y}.png",
     attributions:
       '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://carto.com/attributionss">Carto</a>',
     maxZoom: 18,
   },
-  worldEco: {
+  world_eco: {
     url: "https://cartocdn_{a-d}.global.ssl.fastly.net/base-eco/{z}/{x}/{y}.png",
     attributions:
       '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://carto.com/attributionss">Carto</a>',
     maxZoom: 18,
   },
-  flatBlue: {
+  flat_blue: {
     url: "https://cartocdn_{a-d}.global.ssl.fastly.net/base-flatblue/{z}/{x}/{y}.png",
     attributions:
       '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://carto.com/attributionss">Carto</a>',
     maxZoom: 18,
   },
-  midnightCommander: {
+  midnight_commander: {
     url: "https://cartocdn_{a-d}.global.ssl.fastly.net/base-midnight/{z}/{x}/{y}.png",
     attributions:
       '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://carto.com/attributionss">Carto</a>',
     maxZoom: 18,
   },
-  openstreetmapHot: {
+  openstreetmap_hot: {
     url: "https://{a-c}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png",
     attributions:
       '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>, Tiles courtesy of <a href="http://hot.openstreetmap.org/" target="_blank">Humanitarian OpenStreetMap Team</a>',
     maxZoom: 19,
   },
-  openstreetmapStandard: {
+  openstreetmap_standard: {
     url: "https://tile.openstreetmap.org/{z}/{x}/{y}.png",
     attributions: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
     maxZoom: 19,

--- a/lib/generators/geoblacklight/templates/catalog_controller.rb
+++ b/lib/generators/geoblacklight/templates/catalog_controller.rb
@@ -327,21 +327,6 @@ class CatalogController < ApplicationController
     config.add_show_tools_partial :web_services, component: Geoblacklight::WebServicesLinkComponent,
       if: proc { |_context, _config, options| options[:document] && (gbl_config.webservices_shown & options[:document].references.refs.map(&:type).map(&:to_s)).any? }
 
-    # Configure basemap provider for GeoBlacklight maps (uses https only basemap
-    # providers with open licenses)
-    # Valid basemaps include:
-    # 'positron'
-    # 'darkMatter'
-    # 'positronLite'
-    # 'worldAntique'
-    # 'worldEco'
-    # 'flatBlue'
-    # 'midnightCommander'
-    # 'openstreetmapHot'
-    # 'openstreetmapStandard'
-
-    config.basemap_provider = "positron"
-
     # Configuration for autocomplete suggestor
     config.autocomplete_enabled = true
     config.autocomplete_path = "suggest"

--- a/lib/geoblacklight/configuration.rb
+++ b/lib/geoblacklight/configuration.rb
@@ -35,6 +35,24 @@ module Geoblacklight
 
     attribute :iiif_drag_drop_link, :string, default: "@manifest?manifest=@manifest"
 
+    # Configure basemap provider for GeoBlacklight maps
+    # Valid basemaps include:
+    # 'positron'
+    # 'dark_matter'
+    # 'positron_lite'
+    # 'world_antique'
+    # 'world_eco'
+    # 'flat_blue'
+    # 'midnight_commander'
+    # 'openstreetmap_hot'
+    # 'openstreetmap_standard'
+
+    # Basemap used in light mode
+    attribute :basemap_provider, :string, default: "positron"
+
+    # Basemap used in dark mode
+    attribute :dark_basemap_provider, :string, default: "dark_matter"
+
     # Homepage Map Geometry
     # Leave null to default to entire world
     # Add a stringified GeoJSON object to scope initial render (example from UMass)

--- a/spec/features/configurable_basemap_spec.rb
+++ b/spec/features/configurable_basemap_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature "Configurable basemap", js: true do
 
   feature "without provided basemap config" do
     before do
-      CatalogController.blacklight_config.basemap_provider = nil
+      Geoblacklight.configuration.basemap_provider = nil
     end
     scenario "has Carto map" do
       visit root_path
@@ -18,21 +18,21 @@ RSpec.feature "Configurable basemap", js: true do
     end
   end
 
-  feature "using darkMatter" do
+  feature "using dark matter" do
     before do
-      CatalogController.blacklight_config.basemap_provider = "darkMatter"
+      Geoblacklight.configuration.basemap_provider = "dark_matter"
     end
-    scenario "has darkMatter map" do
+    scenario "has dark matter map" do
       visit root_path
       expect(page).to have_css "img[src*='dark_all']", visible: :all
     end
   end
 
-  feature "using openstreetmapHot" do
+  feature "using openstreetmap hot" do
     before do
-      CatalogController.blacklight_config.basemap_provider = "openstreetmapHot"
+      Geoblacklight.configuration.basemap_provider = "openstreetmap_hot"
     end
-    scenario "has openstreetmapHot map" do
+    scenario "has openstreetmap hot map" do
       visit root_path
       expect(page).to have_css "img[src*='hot']", visible: :all
     end

--- a/spec/helpers/geoblacklight_helper_spec.rb
+++ b/spec/helpers/geoblacklight_helper_spec.rb
@@ -23,18 +23,6 @@ RSpec.describe GeoblacklightHelper, type: :helper do
     end
   end
 
-  describe "#geoblacklight_basemap" do
-    let(:blacklight_config) { double }
-    it "without configuration" do
-      expect(blacklight_config).to receive(:basemap_provider).and_return(nil)
-      expect(geoblacklight_basemap).to eq "positron"
-    end
-    it "with custom configuration" do
-      expect(blacklight_config).to receive(:basemap_provider).and_return("positron")
-      expect(geoblacklight_basemap).to eq "positron"
-    end
-  end
-
   describe "#snippit" do
     let(:document) { SolrDocument.new(document_attributes) }
     let(:references_field) { Geoblacklight.configuration.fields.references }


### PR DESCRIPTION
The configuration that sets the basemap for the leaflet viewer
faced an issue stemming from data attributes, where names like
darkMatter were being lowercased because they were used as Stimulus
data attributes, and this resulted in not looking them up correctly
in the (case-sensitive) JavaScript object they were stored in.

This fixes that issue and moves the configuration into the existing
Configuration object, as well as adding a seam for configuring
separate light and dark basemaps. The dark basemap isn't used yet,
but could be when dark mode support is added.
