### PR TITLE
Automatically infer when to render the static map

### DIFF
--- a/app/components/geoblacklight/static_map_component.rb
+++ b/app/components/geoblacklight/static_map_component.rb
@@ -9,8 +9,10 @@ module Geoblacklight
       super()
     end
 
+    # If there's no preview using the big map, or there is a IIIF preview that
+    # is not georeferenced, we need to see where the item is located.
     def render?
-      Geoblacklight.configuration.sidebar_static_map&.any? { |vp| @document.viewer_protocol == vp }
+      !@document.previewable? || (@document.iiif_preview? && !@document.georeferenced?)
     end
 
     def before_render

--- a/app/models/concerns/geoblacklight/solr_document.rb
+++ b/app/models/concerns/geoblacklight/solr_document.rb
@@ -29,6 +29,7 @@ module Geoblacklight
       attribute :identifiers, :array, field_config.identifier
       attribute :issued, :string, field_config.date_issued
       attribute :format, :string, field_config.format
+      attribute :georeferenced?, :boolean, field_config.georeferenced
     end
 
     def available?
@@ -45,6 +46,10 @@ module Geoblacklight
 
     def downloadable?
       (direct_download || iiif_download) && available?
+    end
+
+    def iiif_preview?
+      viewer_protocol == "iiif" || viewer_protocol == "iiif_manifest"
     end
 
     def previewable?

--- a/lib/generators/geoblacklight/templates/settings.yml
+++ b/lib/generators/geoblacklight/templates/settings.yml
@@ -283,9 +283,4 @@
 #     - "wmts"
 #     - "xyz"
 
-# # Enable catalog#show sidebar static map for items with the following viewer protocols
-# sidebar_static_map:
-#   - "iiif"
-#   - "iiif_manifest"
-
 # iiif_drag_drop_link: "@manifest?manifest=@manifest"

--- a/lib/geoblacklight/configuration.rb
+++ b/lib/geoblacklight/configuration.rb
@@ -30,9 +30,6 @@ module Geoblacklight
     # WMS Parameters
     attr_accessor :wms_params # typed as Hash
 
-    # Enable catalog#show sidebar static map for items with the following viewer protocols
-    attr_accessor :sidebar_static_map # typed as Array
-
     attribute :iiif_drag_drop_link, :string, default: "@manifest?manifest=@manifest"
 
     # Configure basemap provider for GeoBlacklight maps
@@ -143,8 +140,6 @@ module Geoblacklight
           note_prefix: "Warning: "
         )
       }
-
-      @sidebar_static_map = ["iiif", "iiif_manifest"]
     end
 
     def fields

--- a/lib/geoblacklight/configuration/settings_builder.rb
+++ b/lib/geoblacklight/configuration/settings_builder.rb
@@ -19,7 +19,6 @@ module Geoblacklight
           assign(config, :display_notes_shown, build_display_notes)
           assign(config, :institution, settings.INSTITUTION)
           assign(config, :help_text, settings.HELP_TEXT&.to_h)
-          assign(config, :sidebar_static_map, settings.SIDEBAR_STATIC_MAP)
           assign(config, :iiif_drag_drop_link, settings.IIIF_DRAG_DROP_LINK)
           assign(config, :homepage_map_geom, settings.HOMEPAGE_MAP_GEOM)
           assign(config, :metadata_shown, settings.METADATA_SHOWN)


### PR DESCRIPTION
Instead of making the static map render if an item has given
references, this uses some heuristics to decide if it's necessary.

If the big viewer is not rendered, or if the item is a IIIF item
without georeferencing, then a map won't be drawn – so that's
when we want the static map to show where the item is located.

Ref #1785
