### PR TITLE
Fix a bug with turbo-permanent maps

### DIFF
--- a/app/javascript/geoblacklight/controllers/leaflet_viewer_controller.js
+++ b/app/javascript/geoblacklight/controllers/leaflet_viewer_controller.js
@@ -45,6 +45,10 @@ export default class LeafletViewerController extends Controller {
     // Use leaflet icon images from CDN
     Icon.Default.imagePath = "https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/"
 
+    // The map can be turbo-permanent; if we're reconnected but the map already
+    // exists, no need to destroy and recreate the layers and controls.
+    if (this.map) return
+
     // Set up layers
     this.basemap = this.getBasemap()
     this.overlay = layerGroup()


### PR DESCRIPTION
When we made the location map permanent in
cc99b36352752dd80a6fc2adfe0aa64b09ba780a,
it caused an issue with the geosearch where bounding box highlighting
would stop working after turbo page navigation.

That's because the leaflet map controls and layers were being
destroyed and recreated every connect(), even though the map
was already available because it wasn't a full page load.

This fixes that issue.
