### PR TITLE
Fix download link badge wrapping for long titles

### DIFF
--- a/app/assets/stylesheets/geoblacklight/record.css
+++ b/app/assets/stylesheets/geoblacklight/record.css
@@ -70,19 +70,12 @@
 
 /* Downloads */
 .download a {
-  display: block;
+  .badge {
+    display: inline;
+    margin-inline-end: 0.5em;
+  }
 
   .title {
-    margin: 0;
-    display: inline;
-  }
-
-  .badge {
-    float: inline-end;
-    margin-top: 0.1em;
-  }
-
-  .badge + .title {
-    word-break: break-all;
+    overflow-wrap: break-word;
   }
 }

--- a/app/components/geoblacklight/document/download_link_component.html.erb
+++ b/app/components/geoblacklight/document/download_link_component.html.erb
@@ -1,6 +1,5 @@
 <li class="download list-group-item list-group-item-action">
   <%= link_to url, class: 'nav-link', data: @data do %>
-    <% if file_type.present? %><span class="badge text-bg-secondary"><%= file_type %></span><% end %>
-    <p class="title"><%= title %></p>
+    <% if file_type.present? %><span class="badge text-bg-secondary"><%= file_type %></span><% end %><span class="title"><%= title %></span>
   <% end %>
 </li>


### PR DESCRIPTION
Items with download links that are URLs or filenames didn't wrap
very well insdie the download card. The float-based solution
worked, but not on Firefox. This fixes it for all browsers.
