### PR TITLE
Fixed metadata modal button issue

### DIFF
--- a/app/javascript/geoblacklight/initializers/metadata_download.js
+++ b/app/javascript/geoblacklight/initializers/metadata_download.js
@@ -28,23 +28,19 @@ export class GeoBlacklightMetadataDownloadButton {
 export default function initializeMetadataDownload() {
   const modal = document.getElementById("blacklight-modal")
 
-  modal.addEventListener("focus", (e) => {
-    if (!Array.from(e.target.classList).includes("show")) {
-      return
-    }
+  // Use Blacklight's dialog-based modal dispatches these custom events
+  modal.addEventListener("show.blacklight.blacklight-modal", (e) => {
     e.target.querySelectorAll(".metadata-body").forEach((el) => {
       el.closest(".modal-content").classList.add("metadata-modal")
     })
 
     e.target.querySelectorAll(".pill-metadata").forEach((element, i) => {
+      console.log(element)
       new GeoBlacklightMetadataDownloadButton(element, i)
     })
   })
 
-  modal.addEventListener("blur", (e) => {
-    if (Array.from(e.target.classList).includes("show")) {
-      return
-    }
+  modal.addEventListener("hide.blacklight.blacklight-modal", (e) => {
     e.target.querySelectorAll(".metadata-body").forEach((el) => {
       el.closest(".modal-content").classList.remove("metadata-modal")
     })

--- a/app/views/catalog/metadata.html.erb
+++ b/app/views/catalog/metadata.html.erb
@@ -8,7 +8,7 @@
     </div>
   <% end %>
   <% component.with_footer do %>
-    <a href="#" target="_blank" rel="noopener noreferrer" id="btn-metadata-download" class="btn btn-primary"><%= t('geoblacklight.download.download') %></a>
+    <a href="#" target="_blank" rel="noopener noreferrer" id="btn-metadata-download" class="btn btn-primary" aria-label="<%= t('geoblacklight.download.download_metadata_new_tab') %>"><%= t('geoblacklight.download.download') %></a>
     <button type="button" class="btn btn-secondary" data-bl-dismiss="modal"><%= t('blacklight.modal.close') %></button>
   <% end %>
 <% end %>

--- a/config/locales/geoblacklight.en.yml
+++ b/config/locales/geoblacklight.en.yml
@@ -11,6 +11,7 @@ en:
       generated_link: "Generated %{download_format}"
       iiif_image_link: "Full-size image"
       iiif_manifest_link: "IIIF manifest"
+      download_metadata_new_tab: 'Download metadata (opens in a new tab)'
     home:
       headline: "Explore and discover..."
       search_heading: "Find the maps and data you need"

--- a/config/locales/geoblacklight.en.yml
+++ b/config/locales/geoblacklight.en.yml
@@ -11,7 +11,7 @@ en:
       generated_link: "Generated %{download_format}"
       iiif_image_link: "Full-size image"
       iiif_manifest_link: "IIIF manifest"
-      download_metadata_new_tab: 'Download metadata (opens in a new tab)'
+      download_metadata_new_tab: "Download metadata (opens in a new tab)"
     home:
       headline: "Explore and discover..."
       search_heading: "Find the maps and data you need"


### PR DESCRIPTION
1. Use the Blacklight modal to dispatch custom events within the metadata modal
2. Add `aria-label `to the metadata download link to improve accessibility 