### PR TITLE
Add configurable thumbnails to search results

### DIFF
--- a/app/assets/stylesheets/geoblacklight/search.css
+++ b/app/assets/stylesheets/geoblacklight/search.css
@@ -7,6 +7,43 @@
   .document {
     border: 0;
     padding-bottom: var(--bl-results-document-padding-top);
+
+    .document-thumbnail {
+      padding: 0;
+      margin: 0 1rem 0 0;
+
+      a {
+        color: var(--bs-body-color);
+        background-color: var(--bs-body-bg);
+        text-decoration: none;
+        border: var(--bs-border-width) solid var(--bs-border-color);
+        border-radius: var(--bs-border-radius);
+        box-shadow: var(--bs-box-shadow);
+        overflow: hidden;
+        display: flex;
+        place-content: center;
+        place-items: center;
+        width: 6rem;
+        height: 6rem;
+      }
+
+      img {
+        max-height: 6rem;
+        width: auto;
+        object-fit: cover;
+      }
+
+      .blacklight-icons {
+        display: block;
+        height: fit-content;
+        width: fit-content;
+
+        svg {
+          height: 3rem;
+          width: 3rem;
+        }
+      }
+    }
   }
 }
 

--- a/app/components/geoblacklight/document_component.html.erb
+++ b/app/components/geoblacklight/document_component.html.erb
@@ -30,8 +30,6 @@
         <%= partial %>
       <% end %>
     </div>
-
-    <%= thumbnail %>
   <% end %>
   <%= footer %>
 <% end %>

--- a/app/components/geoblacklight/search_result_component.html.erb
+++ b/app/components/geoblacklight/search_result_component.html.erb
@@ -14,6 +14,7 @@
   itemtype: @document.itemtype,
   class: classes do %>
 
+  <%= thumbnail %>
   <%= content_tag :div, class: 'document-main-section' do %>
   <%= content_tag :header, class: 'documentHeader index-split', data: { layer_id: @document.id, geom: @document.geometry.geojson } do %>
     <div class="document-counter">

--- a/app/helpers/geoblacklight_helper.rb
+++ b/app/helpers/geoblacklight_helper.rb
@@ -76,4 +76,42 @@ module GeoblacklightHelper
       "index"
     end
   end
+
+  ##
+  # Blacklight view_config.thumbnail_method contract. Renders the document's
+  # configured thumbnail_url as an <img>, or nil if unavailable/disabled.
+  # @param [SolrDocument] document
+  # @param [Hash] image_options
+  # @return [String, nil]
+  def geoblacklight_thumbnail(document, image_options = {})
+    return unless Geoblacklight.configuration.thumbnails_enabled
+
+    url = document.thumbnail_url
+    return if url.blank?
+
+    image_tag url, {loading: "lazy"}.merge(image_options)
+  end
+
+  ##
+  # Blacklight view_config.default_thumbnail (Symbol) contract. Falls back to
+  # a placeholder icon based on the document's resource/data type.
+  # @param [SolrDocument] document
+  # @param [Hash] _image_options unused; icons aren't rendered as <img>
+  # @return [String, nil]
+  def geoblacklight_default_thumbnail(document, _image_options = {})
+    return unless Geoblacklight.configuration.thumbnails_enabled
+
+    default_thumbnail_icon(document)
+  end
+
+  private
+
+  ##
+  # @param [SolrDocument] document
+  # @return [String]
+  def default_thumbnail_icon(document)
+    dataset_type = document.resource_type&.find { |type| type.include?(" data") }&.gsub(" data", "")
+    name = [dataset_type, document.resource_class&.first].compact.first
+    geoblacklight_icon(name)
+  end
 end

--- a/app/models/concerns/geoblacklight/solr_document.rb
+++ b/app/models/concerns/geoblacklight/solr_document.rb
@@ -84,6 +84,10 @@ module Geoblacklight
       references.url&.endpoint
     end
 
+    def thumbnail_url
+      references.find_by_uri(Geoblacklight.configuration.thumbnail_reference_key)&.endpoint
+    end
+
     def item_viewer
       ItemViewer.new(references)
     end

--- a/lib/generators/geoblacklight/templates/catalog_controller.rb
+++ b/lib/generators/geoblacklight/templates/catalog_controller.rb
@@ -39,6 +39,8 @@ class CatalogController < ApplicationController
     # config.index.show_link = 'title_display'
     # config.index.record_display_type = 'format'
     config.index.document_component = Geoblacklight::SearchResultComponent
+    config.index.thumbnail_method = :geoblacklight_thumbnail
+    config.index.default_thumbnail = :geoblacklight_default_thumbnail
     config.index.title_field = field_config.title
 
     # solr field configuration for document/show views

--- a/lib/generators/geoblacklight/templates/settings.yml
+++ b/lib/generators/geoblacklight/templates/settings.yml
@@ -284,3 +284,9 @@
 #     - "xyz"
 
 # iiif_drag_drop_link: "@manifest?manifest=@manifest"
+
+# # Toggle thumbnail images in the search results (index) view
+# thumbnails_enabled: true
+
+# # The dct_references_s URI key to use as a document's thumbnail image URL
+# thumbnail_reference_key: "http://schema.org/thumbnailUrl"

--- a/lib/geoblacklight/configuration.rb
+++ b/lib/geoblacklight/configuration.rb
@@ -32,6 +32,12 @@ module Geoblacklight
 
     attribute :iiif_drag_drop_link, :string, default: "@manifest?manifest=@manifest"
 
+    # Toggle thumbnail images in the search results (index) view
+    attribute :thumbnails_enabled, :boolean, default: true
+
+    # The dct_references_s URI key to use as a document's thumbnail image URL
+    attribute :thumbnail_reference_key, :string, default: "http://schema.org/thumbnailUrl"
+
     # Configure basemap provider for GeoBlacklight maps
     # Valid basemaps include:
     # 'positron'

--- a/lib/geoblacklight/configuration/settings_builder.rb
+++ b/lib/geoblacklight/configuration/settings_builder.rb
@@ -20,6 +20,8 @@ module Geoblacklight
           assign(config, :institution, settings.INSTITUTION)
           assign(config, :help_text, settings.HELP_TEXT&.to_h)
           assign(config, :iiif_drag_drop_link, settings.IIIF_DRAG_DROP_LINK)
+          assign(config, :thumbnails_enabled, settings.THUMBNAILS_ENABLED)
+          assign(config, :thumbnail_reference_key, settings.THUMBNAIL_REFERENCE_KEY)
           assign(config, :homepage_map_geom, settings.HOMEPAGE_MAP_GEOM)
           assign(config, :metadata_shown, settings.METADATA_SHOWN)
           assign(config, :webservices_shown, settings.WEBSERVICES_SHOWN)

--- a/lib/geoblacklight/reference.rb
+++ b/lib/geoblacklight/reference.rb
@@ -34,8 +34,6 @@ module Geoblacklight
       {type => endpoint}
     end
 
-    private
-
     ##
     # The URI used for this instance's creation
     # Remove any trailing slashes

--- a/lib/geoblacklight/references.rb
+++ b/lib/geoblacklight/references.rb
@@ -44,6 +44,17 @@ module Geoblacklight
     end
 
     ##
+    # Finds a reference by its literal dct:references URI key, rather than by
+    # its registered Constants::URI type. Needed for configurable URI keys
+    # (e.g. Geoblacklight.configuration.thumbnail_reference_key) that aren't
+    # necessarily registered in Constants::URI.
+    # @param [String] uri
+    # @return [Geoblacklight::Reference, nil]
+    def find_by_uri(uri)
+      @refs.find { |reference| reference.uri == uri }
+    end
+
+    ##
     # Returns all of the Esri webservices for given set of references
     def esri_webservices
       %w[tiled_map_layer dynamic_map_layer feature_layer image_map_layer].filter_map do |layer_type|
@@ -57,11 +68,12 @@ module Geoblacklight
     # Parses the references field of a document
     # @return [Hash]
     def parse_references
-      if @document[reference_field].nil?
-        {}
-      else
-        JSON.parse(@document[reference_field])
-      end
+      return {} if @document[reference_field].nil?
+
+      JSON.parse(@document[reference_field])
+    rescue JSON::ParserError
+      Geoblacklight.logger.warn("Could not parse #{reference_field} on document #{@document.id}: invalid JSON")
+      {}
     end
 
     ##

--- a/spec/components/geoblacklight/search_result_component_spec.rb
+++ b/spec/components/geoblacklight/search_result_component_spec.rb
@@ -27,7 +27,9 @@ RSpec.describe Geoblacklight::SearchResultComponent, type: :component do
   end
   before do
     allow(request_context).to receive(:snippit)
-    allow_any_instance_of(BlacklightHelper).to receive(:link_to_document)
+    allow_any_instance_of(BlacklightHelper).to receive(:link_to_document) do |_instance, _doc, value = nil, *|
+      value
+    end
     allow_any_instance_of(GeoblacklightHelper).to receive(:blacklight_config).and_return(blacklight_config)
     render_inline(described_class.new(document: presenter))
   end
@@ -61,6 +63,52 @@ RSpec.describe Geoblacklight::SearchResultComponent, type: :component do
     context "with document empty configured index field" do
       it "does not render a period followed by a space" do
         expect(index_fields_display).not_to include(". .")
+      end
+    end
+  end
+
+  describe "thumbnails" do
+    let(:blacklight_config) do
+      Blacklight::Configuration.new.configure do |config|
+        config.index.thumbnail_method = :geoblacklight_thumbnail
+        config.index.default_thumbnail = :geoblacklight_default_thumbnail
+      end
+    end
+    let(:presenter) do
+      Blacklight::IndexPresenter.new(document, request_context, blacklight_config)
+    end
+
+    context "when a thumbnail is available" do
+      let(:request_context) do
+        double(document_index_view_type: "list", action_name: :index,
+          geoblacklight_thumbnail: '<img src="http://example.com/thumb.jpg" alt="">'.html_safe)
+      end
+
+      it "renders the thumbnail image" do
+        expect(page).to have_css ".document-thumbnail img[src='http://example.com/thumb.jpg']"
+      end
+    end
+
+    context "when no thumbnail is available but a default exists" do
+      let(:request_context) do
+        double(document_index_view_type: "list", action_name: :index,
+          geoblacklight_thumbnail: nil,
+          geoblacklight_default_thumbnail: '<span class="blacklight-icons"></span>'.html_safe)
+      end
+
+      it "renders the default thumbnail" do
+        expect(page).to have_css ".document-thumbnail .blacklight-icons"
+      end
+    end
+
+    context "when neither a thumbnail nor a default is available" do
+      let(:request_context) do
+        double(document_index_view_type: "list", action_name: :index,
+          geoblacklight_thumbnail: nil, geoblacklight_default_thumbnail: nil)
+      end
+
+      it "does not render a thumbnail" do
+        expect(page).not_to have_css ".document-thumbnail"
       end
     end
   end

--- a/spec/helpers/geoblacklight_helper_spec.rb
+++ b/spec/helpers/geoblacklight_helper_spec.rb
@@ -71,6 +71,90 @@ RSpec.describe GeoblacklightHelper, type: :helper do
     end
   end
 
+  describe "#geoblacklight_thumbnail" do
+    let(:references_field) { Geoblacklight.configuration.fields.references }
+    let(:document) { SolrDocument.new(document_attributes) }
+
+    context "with a thumbnail URL" do
+      let(:document_attributes) do
+        {
+          references_field => {
+            "http://schema.org/thumbnailUrl" => "http://example.com/thumb.jpg"
+          }.to_json
+        }
+      end
+      it "renders an image tag" do
+        html = Capybara.string(helper.geoblacklight_thumbnail(document))
+        expect(html).to have_css "img[src='http://example.com/thumb.jpg']"
+      end
+    end
+
+    context "without a thumbnail URL" do
+      let(:document_attributes) { {} }
+      it "returns nil" do
+        expect(helper.geoblacklight_thumbnail(document)).to be_nil
+      end
+    end
+
+    context "when thumbnails are disabled" do
+      let(:document_attributes) do
+        {
+          references_field => {
+            "http://schema.org/thumbnailUrl" => "http://example.com/thumb.jpg"
+          }.to_json
+        }
+      end
+      it "returns nil even though a thumbnail URL is present" do
+        allow(Geoblacklight.configuration).to receive_messages(thumbnails_enabled: false)
+        expect(helper.geoblacklight_thumbnail(document)).to be_nil
+      end
+    end
+  end
+
+  describe "#geoblacklight_default_thumbnail" do
+    let(:resource_type_field) { Geoblacklight.configuration.fields.resource_type }
+    let(:resource_class_field) { Geoblacklight.configuration.fields.resource_class }
+    let(:document) { SolrDocument.new(document_attributes) }
+
+    context "with a recognized data-type resource_type" do
+      let(:document_attributes) { {resource_type_field => ["Raster data"]} }
+      it "renders the data-type icon" do
+        html = Capybara.string(helper.geoblacklight_default_thumbnail(document))
+        expect(html).to have_xpath "//*[local-name() = 'svg']"
+      end
+    end
+
+    context "without a matching resource_type icon, but a recognized resource_class" do
+      let(:document_attributes) { {resource_class_field => ["Datasets"]} }
+      it "falls back to the resource_class icon" do
+        html = Capybara.string(helper.geoblacklight_default_thumbnail(document))
+        expect(html).to have_xpath "//*[local-name() = 'svg']"
+      end
+    end
+
+    context "with neither a recognized resource_type nor resource_class" do
+      let(:document_attributes) { {resource_type_field => ["Nonexistent data"], resource_class_field => ["TotallyUnknown"]} }
+      it "uses the 'missing icon' icon as a fallback" do
+        expect(helper.geoblacklight_default_thumbnail(document)).to eq "<span class=\"icon-missing geoblacklight-none\"></span>"
+      end
+    end
+
+    context "without any resource_type or resource_class" do
+      let(:document_attributes) { {} }
+      it "uses the 'missing icon' icon as a fallback" do
+        expect(helper.geoblacklight_default_thumbnail(document)).to eq "<span class=\"icon-missing geoblacklight-none\"></span>"
+      end
+    end
+
+    context "when thumbnails are disabled" do
+      let(:document_attributes) { {resource_class_field => ["Datasets"]} }
+      it "returns nil even though a matching icon exists" do
+        allow(Geoblacklight.configuration).to receive_messages(thumbnails_enabled: false)
+        expect(helper.geoblacklight_default_thumbnail(document)).to be_nil
+      end
+    end
+  end
+
   describe "#results_js_map_selector" do
     context "viewing bookmarks" do
       let(:controller_name) { "bookmarks" }

--- a/spec/lib/geoblacklight/references_spec.rb
+++ b/spec/lib/geoblacklight/references_spec.rb
@@ -99,6 +99,21 @@ RSpec.describe Geoblacklight::References do
       SolrDocument.new, :new_ref_field
     )
   end
+  let(:with_thumbnail) do
+    described_class.new(
+      SolrDocument.new(
+        references_field => {
+          "http://schema.org/thumbnailUrl" => "http://example.com/thumb.jpg",
+          "http://www.isotc211.org/schemas/2005/gmd/" => "http://example.com/iso19139.xml"
+        }.to_json
+      )
+    )
+  end
+  let(:malformed_references) do
+    described_class.new(
+      SolrDocument.new(references_field => "not valid json")
+    )
+  end
   describe "#initialize" do
     it "parses configured references field to @refs" do
       expect(typical_ogp_shapefile.instance_variable_get(:@refs)).to be_an Array
@@ -168,6 +183,26 @@ RSpec.describe Geoblacklight::References do
   describe "#esri_webservices" do
     it "returns webservices that are esri specific" do
       expect(some_esri_services.esri_webservices.length).to eq 3
+    end
+  end
+  describe "#find_by_uri" do
+    it "finds a reference by its literal URI key" do
+      reference = with_thumbnail.find_by_uri("http://schema.org/thumbnailUrl")
+      expect(reference).to be_an Geoblacklight::Reference
+      expect(reference.endpoint).to eq "http://example.com/thumb.jpg"
+    end
+    it "normalizes trailing slashes, like Reference#uri" do
+      reference = with_thumbnail.find_by_uri("http://www.isotc211.org/schemas/2005/gmd")
+      expect(reference.endpoint).to eq "http://example.com/iso19139.xml"
+    end
+    it "returns nil when no reference matches the URI" do
+      expect(with_thumbnail.find_by_uri("http://schema.org/notARealKey")).to be_nil
+    end
+  end
+  describe "#initialize with malformed JSON" do
+    it "does not raise and treats the references field as empty" do
+      expect { malformed_references }.not_to raise_error
+      expect(malformed_references.refs).to eq []
     end
   end
   describe "#method_missing" do

--- a/spec/models/concerns/geoblacklight/solr_document_spec.rb
+++ b/spec/models/concerns/geoblacklight/solr_document_spec.rb
@@ -125,6 +125,53 @@ RSpec.describe Geoblacklight::SolrDocument do
       expect(document.direct_download).to be_nil
     end
   end
+  describe "#thumbnail_url" do
+    describe "with a thumbnail reference at the default key" do
+      let(:document_attributes) do
+        {
+          references_field => {
+            "http://schema.org/thumbnailUrl" => "http://example.com/thumb.jpg"
+          }.to_json
+        }
+      end
+      it "returns the thumbnail URL" do
+        expect(document.thumbnail_url).to eq "http://example.com/thumb.jpg"
+      end
+    end
+    describe "without a dct_references_s field" do
+      let(:document_attributes) { {} }
+      it "returns nil" do
+        expect(document.thumbnail_url).to be_nil
+      end
+    end
+    describe "with a dct_references_s field missing the thumbnail key" do
+      let(:document_attributes) do
+        {
+          references_field => {
+            "http://schema.org/url" => "http://example.com/homepage"
+          }.to_json
+        }
+      end
+      it "returns nil" do
+        expect(document.thumbnail_url).to be_nil
+      end
+    end
+    describe "with a configured thumbnail_reference_key" do
+      let(:document_attributes) do
+        {
+          references_field => {
+            "http://example.com/custom-thumbnail-key" => "http://example.com/custom-thumb.jpg"
+          }.to_json
+        }
+      end
+      it "resolves the configured key instead of the default" do
+        allow(Geoblacklight.configuration).to receive_messages(
+          thumbnail_reference_key: "http://example.com/custom-thumbnail-key"
+        )
+        expect(document.thumbnail_url).to eq "http://example.com/custom-thumb.jpg"
+      end
+    end
+  end
   describe "#oembed" do
     describe "with an oembed url" do
       let(:document_attributes) do


### PR DESCRIPTION
Renders a thumbnail per document in search results, sourced from a
configurable dct_references_s key (defaulting to
http://schema.org/thumbnailUrl) and falling back to a resource-type
icon when no image is available. Reuses Blacklight's existing
thumbnail_method/default_thumbnail/ThumbnailComponent machinery
rather than adding new rendering infrastructure.

Closes #1898
