### PR TITLE
Fix flaky sign_in test helper and relations spec

### DIFF
--- a/spec/features/relations_spec.rb
+++ b/spec/features/relations_spec.rb
@@ -5,8 +5,8 @@ require "spec_helper"
 RSpec.feature "Display related documents" do
   scenario "Record with relations should render widget in catalog#show", js: true do
     visit solr_document_path("nyu_2451_34635")
-    expect(page).to have_css(".card.relations", visible: :all)
-    expect(page).to have_css("div.card-header", text: "Derived records...", visible: :all)
+    expect(page).to have_css(".card.relations", visible: :all, wait: 10)
+    expect(page).to have_css("div.card-header", text: "Derived records...", visible: :all, wait: 10)
   end
 
   scenario "Record without relations should not render widget in catalog#show", js: true do
@@ -18,7 +18,7 @@ RSpec.feature "Display related documents" do
     # Wabash Topo parent record
     visit solr_document_path("eee6150b-ce2f-4837-9d17-ce72a0c1c26f")
 
-    expect(page).to have_content(:all, "Has part...")
+    expect(page).to have_content(:all, "Has part...", wait: 10)
     expect(page).to have_link("Browse all 4 records...", visible: :all)
     click_link("Browse all 4 records...", visible: :all)
 
@@ -28,24 +28,24 @@ RSpec.feature "Display related documents" do
   scenario "Record with dct_isPartOf_sm value(s) should link to relations", js: true do
     # All Relationships
     visit solr_document_path("all-relationships")
-    expect(page).to have_content(:all, "Is part of...")
+    expect(page).to have_content(:all, "Is part of...", wait: 10)
   end
 
   scenario "Record pointed at by a parent with dct_isPartOf_sm value(s) should link back", js: true do
     # The Related Record
     visit solr_document_path("the-related-record")
-    expect(page).to have_content(:all, "Has part...")
+    expect(page).to have_content(:all, "Has part...", wait: 10)
   end
 
   scenario "Record with pcdm_memberOf_sm value(s) should link to relations", js: true do
     # All Relationships
     visit solr_document_path("all-relationships")
-    expect(page).to have_content(:all, "Belongs to collection...")
+    expect(page).to have_content(:all, "Belongs to collection...", wait: 10)
   end
 
   scenario "Record pointed at by a parent with pcdm_memberOf_sm value(s) should link back", js: true do
     # The Related Record
     visit solr_document_path("the-related-record")
-    expect(page).to have_content(:all, "Collection records...")
+    expect(page).to have_content(:all, "Collection records...", wait: 10)
   end
 end

--- a/spec/support/features/session_helpers.rb
+++ b/spec/support/features/session_helpers.rb
@@ -16,7 +16,10 @@ module Features
       fill_in "user_email", with: user.email
       fill_in "user_password", with: user.password
       click_button "Log in"
-      expect(page).to have_content "Signed in successfully."
+      # Wait for the persistent "Log Out" nav link rather than the one-shot
+      # "Signed in successfully." flash, which can render and then become
+      # non-visible before Capybara's default wait time elapses.
+      expect(page).to have_link "Log Out"
     end
   end
 end


### PR DESCRIPTION
## Summary
- The `sign_in` feature-spec helper asserted on the one-shot "Signed in successfully." Devise flash, which can render and then become non-visible before Capybara's default wait time elapses on a slower/contended CI runner.
  - This caused intermittent failures in `axe_spec.rb` — in [run 32997463517](https://github.com/geoblacklight/geoblacklight/actions/runs/32997463517) it hit two different Ruby matrix jobs on two different examples ("validates the home page" and "validates the bookmarks page"), both failing at the same `sign_in` line with `have_content` reporting the flash text was present but non-visible.
  - Swapped the assertion to wait for the persistent "Log Out" nav link instead, which confirms the same signed-in state without depending on catching a transient flash message mid-render.
- CI on this PR then surfaced a second, unrelated flake in `relations_spec.rb` ([run 32999966802](https://github.com/geoblacklight/geoblacklight/actions/runs/32999966802/job/98278916343)).
  - The relations widget is rendered by a Turbo Frame with a `src=` attribute (`relations_container_component.html.erb`), which lazy-loads asynchronously after the initial page render and fires one Solr query per relationship type shown (`relation_response.rb`). On a contended CI runner those sequential round-trips can outrun Capybara's default 2s wait.
  - Added explicit `wait: 10` to the `relations_spec.rb` assertions that depend on this frame's content, matching the existing convention used elsewhere in the suite for other async/slow-loading content (`locator_map_spec.rb`, `search_results_map_spec.rb`, `index_view_spec.rb`).

## Test plan
- [x] Ran `spec/features/axe_spec.rb` locally against Solr + headless Chrome — 8/8 examples passing
- [x] Ran `spec/features/citations_spec.rb`, `spec/features/viewer_requests_spec.rb`, `spec/features/web_services_modal_spec.rb` (other consumers of `sign_in`) — all passing
- [x] Ran `spec/features/relations_spec.rb` locally — 7/7 examples passing
- [x] `bundle exec standardrb` on both changed files — clean