### PR TITLE
Update description UI on search results

### DIFF
--- a/app/assets/stylesheets/geoblacklight/record.css
+++ b/app/assets/stylesheets/geoblacklight/record.css
@@ -65,7 +65,7 @@
   .read-more,
   .browse-all,
   .card-footer,
-  .status-icons {
+  .badges {
     font-size: calc(var(--bs-body-font-size) * 0.75); 
   }
 

--- a/app/assets/stylesheets/geoblacklight/search.css
+++ b/app/assets/stylesheets/geoblacklight/search.css
@@ -61,24 +61,12 @@
     line-height: 1.25;
     gap: 0.25em;
 
-    .status-icons {
+    .badges {
       flex: none;
       display: flex;
       justify-content: flex-start;
       align-items: center;
       gap: 0.2em;
-    }
-
-    /* More info dropdown and area */
-    .dropdown-toggle {
-      width: 1.5em;
-      height: 1.5em;
-    }
-
-    .dropdown-toggle::after {
-      vertical-align: top;
-      margin-left: -0.25em;
-      margin-top: 0.25em;
     }
   }
 
@@ -88,10 +76,19 @@
     flex-grow: 1;
     flex-shrink: 1;
   }
-}
 
-.more-info-area > div {
-  padding-left: var(--bl-results-document-padding-top);
-  padding-right: var(--bl-results-document-padding-top);
-  padding-bottom: var(--bl-results-document-padding-top);
+  .document-main-section {
+    .metadata {
+      padding: 0.5em 1.5em;
+    }
+
+    .badges {
+      margin-bottom: 0.5em;
+    }
+
+    .description p {
+      display: inline;
+      margin: 0;
+    }
+  }
 }

--- a/app/components/geoblacklight/header_icons_component.html.erb
+++ b/app/components/geoblacklight/header_icons_component.html.erb
@@ -1,3 +1,5 @@
-<% @fields.each do |field| %>
-  <%= render_badge(field) %>
-<% end %>
+<div class="badges">
+  <% @fields.each do |field| %>
+    <%= render_badge(field) %>
+  <% end %>
+</div>

--- a/app/components/geoblacklight/relations/relation_component.html.erb
+++ b/app/components/geoblacklight/relations/relation_component.html.erb
@@ -1,8 +1,6 @@
 <li class="list-group-item">
   <%= link_to document.title, solr_document_path(document) %>
-  <div class="status-icons">
-    <%= render Geoblacklight::HeaderIconsComponent.new(document: document) %>
-  </div>
+  <%= render Geoblacklight::HeaderIconsComponent.new(document: document) %>
   <% if document.description.present? %>
     <div class="truncate-abstract description" data-read-more-text="<%= t("geoblacklight.truncate.read_more") %>" data-close-text="<%= t("geoblacklight.truncate.close") %>" data-max-lines=5>
       <%= description %>

--- a/app/components/geoblacklight/search_result_component.html.erb
+++ b/app/components/geoblacklight/search_result_component.html.erb
@@ -1,6 +1,6 @@
 <%# This template copies from Blacklight's components/document_component.html.erb
       # for the wrapping `content_tag @component` structure
-      # and adds custom layout within for the document header, status-icons and more-info areas %>
+      # and adds custom layout within for the document header, badges and description area %>
 
 <%= content_tag @component,
   id: @id,
@@ -12,36 +12,17 @@
   itemscope: true,
   itemtype: @document.itemtype,
   class: classes do %>
-
+  <%= header %>
   <%= thumbnail %>
-  <%= content_tag :div, class: 'document-main-section' do %>
-  <%= content_tag :header, class: 'documentHeader index-split' do %>
-    <div class="document-counter">
-      <%= t('blacklight.search.documents.counter', :counter => @counter) if @counter %>
+  <div class="document-main-section">
+    <%= title %>
+    <div class="metadata">
+      <%= render Geoblacklight::HeaderIconsComponent.new(document: @document) %>
+      <% if document.description.present? %>
+        <div class="truncate-abstract description" data-read-more-text="<%= t("geoblacklight.truncate.read_more") %>" data-close-text="<%= t("geoblacklight.truncate.close") %>" data-max-lines=4 itemprop="description">
+          <%= description %>
+        </div>
+      <% end %>
     </div>
-
-    <h3 class="index_title">
-      <%= helpers.link_to_document(@document, counter: @counter, itemprop: "name") %>
-    </h3>
-
-    <button
-        class="btn dropdown-toggle collapsed"
-        data-bs-toggle="collapse"
-        data-bs-target="#doc-<%= @document.id %>-fields-collapse"
-        aria-label="<%= t('geoblacklight.metadata.toggle_summary') %>"
-        aria-expanded="false"
-        aria-controls="doc-<%= @document.id %>-fields-collapse">
-    </button>
-  <% end %>
-  <div class="status-icons mx-4 mt-2">
-    <%= render Geoblacklight::HeaderIconsComponent.new(document: @document) %>
   </div>
-  <% end %>
 <% end %>
-<div class="more-info-area border-bottom">
-  <div id="doc-<%= @document.id %>-fields-collapse" class="collapse">
-    <small itemprop="description">
-      <%= index_fields_display %>
-    </small>
-  </div>
-</div>

--- a/app/components/geoblacklight/search_result_component.rb
+++ b/app/components/geoblacklight/search_result_component.rb
@@ -9,20 +9,8 @@ module Geoblacklight
   #    Otherwise view_component will not provide the count value when calling the component.
   #
   class SearchResultComponent < Blacklight::DocumentComponent
-    # Presents configured index fields in search results. Passes values through
-    # configured helper_method. Multivalued fields separated by presenter
-    # field_value_separator (default: comma). Fields separated by period.
-    # @return [String]
-    def index_fields_display
-      fields_values = []
-      @presenter.configuration.index_fields.each_value do |field_config|
-        val = @presenter.field_value(field_config).to_sentence
-        if val.present?
-          val += "." unless val.end_with?(".")
-          fields_values << val
-        end
-      end
-      safe_join(fields_values, " ")
+    def description
+      safe_join(Array(document.description).map { |value| helpers.markdown_to_html(value) })
     end
   end
 end

--- a/app/helpers/geoblacklight_helper.rb
+++ b/app/helpers/geoblacklight_helper.rb
@@ -39,14 +39,6 @@ module GeoblacklightHelper
   end
 
   ##
-  # Blacklight catalog controller helper method to truncate field value to 150 chars
-  # @param [SolrDocument] args
-  # @return [String]
-  def snippit(args)
-    truncate(Array(args[:value]).flatten.join(" "), length: 150)
-  end
-
-  ##
   # Transform markdown into HTML
   # @param [String] value markdown to transform
   # @return [ActiveSupport::SafeBuffer] rendered HTML

--- a/config/locales/geoblacklight.en.yml
+++ b/config/locales/geoblacklight.en.yml
@@ -133,7 +133,6 @@ en:
       metadata_error: The metadata view for selected schema is not available
       metadata_trace: Please select another metadata view. Alternately, try downloading the file or reaching out to the holding institution.
       more_details: More details at
-      toggle_summary: Toggle summary
       transform_error: HTML view for selected schema is not available
       view_metadata: View Metadata
     truncate:

--- a/lib/generators/geoblacklight/templates/catalog_controller.rb
+++ b/lib/generators/geoblacklight/templates/catalog_controller.rb
@@ -140,19 +140,6 @@ class CatalogController < ApplicationController
     # handler defaults, or have no facets.
     config.add_facet_fields_to_solr_request!
 
-    # SEARCH RESULTS FIELDS
-
-    # solr fields to be displayed in the index (search results) view
-    #   The ordering of the field names is the order of the display
-    # config.add_index_field field_config.provider, :label => 'Institution:'
-    # config.add_index_field field_config.rights, :label => 'Access:'
-    # # config.add_index_field 'Area', :label => 'Area:'
-    # config.add_index_field field_config.subject, :label => 'Keywords:'
-    config.add_index_field field_config.index_year
-    config.add_index_field field_config.creator
-    config.add_index_field field_config.description, helper_method: :snippit
-    config.add_index_field field_config.publisher
-
     # ITEM VIEW FIELDS
 
     # solr fields to be displayed in the show (single result) view

--- a/spec/components/geoblacklight/relations/relation_component_spec.rb
+++ b/spec/components/geoblacklight/relations/relation_component_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Geoblacklight::Relations::RelationComponent, type: :component do
     end
 
     it "renders the document's status icon badges" do
-      expect(page).to have_css(".status-icons")
+      expect(page).to have_css(".badges")
     end
 
     it "does not render a description block when there is no description" do

--- a/spec/components/geoblacklight/search_result_component_spec.rb
+++ b/spec/components/geoblacklight/search_result_component_spec.rb
@@ -4,29 +4,15 @@ require "spec_helper"
 
 RSpec.describe Geoblacklight::SearchResultComponent, type: :component do
   let(:request_context) { double(document_index_view_type: "list", action_name: :index) }
-  let(:blacklight_config) do
-    Blacklight::Configuration.new.configure do |config|
-      config.add_index_field "gbl_wxsIdentifier_s"
-      config.add_index_field "index_display"
-      config.add_index_field "period"
-      config.add_index_field "multi_display"
-    end
-  end
+  let(:blacklight_config) { Blacklight::Configuration.new }
   let(:presenter) do
     Blacklight::DocumentPresenter.new(document, request_context, blacklight_config)
   end
 
-  let(:document) do
-    SolrDocument.new(
-      id: 1,
-      gbl_wxsIdentifier_s: "druid:abc123",
-      non_index_field: "do not render",
-      period: "Ends with period.",
-      multi_display: %w[blue blah]
-    )
-  end
+  let(:document) { SolrDocument.new(id: 1, dct_description_sm: description) }
+  let(:description) { [] }
+
   before do
-    allow(request_context).to receive(:snippit)
     allow_any_instance_of(BlacklightHelper).to receive(:link_to_document) do |_instance, _doc, value = nil, *|
       value
     end
@@ -34,35 +20,28 @@ RSpec.describe Geoblacklight::SearchResultComponent, type: :component do
     render_inline(described_class.new(document: presenter))
   end
 
-  describe "#index_fields_display" do
-    let(:multi_valued_text) { document["multi_display"].join(" and ") }
-    let(:combined_fields) { document["gbl_wxsIdentifier_s"] + ". " + document["period"] }
+  describe "#description" do
+    it "does not render a description block when there is no description" do
+      expect(page).to have_no_css(".truncate-abstract")
+    end
 
-    subject(:index_fields_display) { page.find("[itemprop=description]").text }
+    context "when the document has a description" do
+      let(:description) { ["First paragraph.", "Second paragraph."] }
 
-    context "with multi-valued field" do
-      it "each value is separated by comma" do
-        expect(index_fields_display).to include(multi_valued_text)
+      it "renders each description value as its own paragraph" do
+        expect(page).to have_css(".truncate-abstract p", count: 2)
+        expect(page).to have_content("First paragraph.")
+        expect(page).to have_content("Second paragraph.")
       end
-    end
-    context "with document fields not configured as index field" do
-      it "does not render" do
-        expect(index_fields_display).not_to include(document["non_index_field"])
+
+      it "sets up the truncation data attributes for the JS initializer" do
+        expect(page).to have_css(
+          ".truncate-abstract[data-max-lines='4'][data-read-more-text='Read more'][data-close-text='Close']"
+        )
       end
-    end
-    context "with multiple document index fields present" do
-      it "separates fields by period followed by a space" do
-        expect(index_fields_display).to include(combined_fields)
-      end
-      context "with index field ending in period" do
-        it "renders only 1 period" do
-          expect(index_fields_display).to include(document["period"] + " ")
-        end
-      end
-    end
-    context "with document empty configured index field" do
-      it "does not render a period followed by a space" do
-        expect(index_fields_display).not_to include(". .")
+
+      it "exposes the description as schema.org markup" do
+        expect(page).to have_css(".truncate-abstract[itemprop='description']")
       end
     end
   end

--- a/spec/features/index_view_spec.rb
+++ b/spec/features/index_view_spec.rb
@@ -8,14 +8,6 @@ RSpec.feature "Index view", js: true do
     visit search_catalog_path(q: "*")
   end
 
-  scenario "click on a record area to expand collapse" do
-    within("article", match: :first) do
-      expect(page).to have_css(".collapsed")
-      find("button").click
-      expect(page).not_to have_css(".collapsed")
-    end
-  end
-
   scenario "searching the map should retain current search parameters" do
     visit "/?f[#{subject_field}][]=Population"
 

--- a/spec/helpers/geoblacklight_helper_spec.rb
+++ b/spec/helpers/geoblacklight_helper_spec.rb
@@ -53,54 +53,6 @@ RSpec.describe GeoblacklightHelper, type: :helper do
     end
   end
 
-  describe "#snippit" do
-    let(:document) { SolrDocument.new(document_attributes) }
-    let(:references_field) { Geoblacklight.configuration.fields.references }
-    context "as a String" do
-      let(:document_attributes) do
-        {
-          value: "This is a really long string that should get truncated when it gets rendered" \
-                 "in the index view to give a brief description of the contents of a particular document" \
-                 "indexed into Solr"
-        }
-      end
-      it "truncates longer strings to 150 characters" do
-        expect(helper.snippit(document).length).to eq 150
-      end
-      it "truncated string ends with ..." do
-        expect(helper.snippit(document)[-3..]).to eq "..."
-      end
-    end
-    context "as an Array" do
-      let(:document_attributes) do
-        {
-          value: ["This is a really long string that should get truncated when it gets rendered" \
-                  "in the index view to give a brief description of the contents of a particular document" \
-                  "indexed into Solr"]
-        }
-      end
-      it "truncates longer strings to 150 characters" do
-        expect(helper.snippit(document).length).to eq 150
-      end
-      it "truncated string ends with ..." do
-        expect(helper.snippit(document)[-3..]).to eq "..."
-      end
-    end
-    context "as a multivalued Array" do
-      let(:document_attributes) do
-        {
-          value: %w[short description]
-        }
-      end
-      it "uses both values" do
-        expect(helper.snippit(document)).to eq "short description"
-      end
-      it "does not truncate" do
-        expect(helper.snippit(document)[-3..]).not_to eq "..."
-      end
-    end
-  end
-
   describe "#markdown_to_html" do
     it "transforms markdown into HTML" do
       expect(helper.markdown_to_html("a **short** description")).to eq "<p>a <strong>short</strong> description</p>\n"

--- a/spec/requests/index_view_spec.rb
+++ b/spec/requests/index_view_spec.rb
@@ -48,6 +48,11 @@ RSpec.describe "Catalog index view", type: :request do
 
   it "renders schema.org properties" do
     expect(response_page.first(".documentHeader")).to have_css("a[itemprop='name']")
-    expect(response_page.first(".more-info-area")).to have_css("small[itemprop='description']")
+    expect(response_page).to have_css(".metadata [itemprop='description']")
+  end
+
+  it "renders a truncated description alongside the badges for results that have one" do
+    expect(response_page).to have_css(".metadata .badges")
+    expect(response_page).to have_css(".metadata .description")
   end
 end

--- a/spec/requests/search_results_spec.rb
+++ b/spec/requests/search_results_spec.rb
@@ -28,8 +28,8 @@ RSpec.describe "Search results", type: :request do
   it "renders the geometry and access icons for a result" do
     get search_catalog_path(search_field: "all_fields", q: "berkeley-s76d73")
 
-    expect(response_page).to have_css(".status-icons .blacklight-icons-line")
-    expect(response_page).to have_css(".status-icons .blacklight-icons-restricted")
+    expect(response_page).to have_css(".badges .blacklight-icons-line")
+    expect(response_page).to have_css(".badges .blacklight-icons-restricted")
   end
 
   it "uses overlap ratio to rank fully contained bounding boxes" do


### PR DESCRIPTION
This creates parity with the show page and the relations widget;
now all 3 locations feature a CSS-truncated expandable description.

Prior to this we had a bespoke method that concatenated together
configured fields from the index, as part of a DocumentComponent
override. Now we override no behavior of BL's DocumentComponent and
less of its template.