### PR TITLE
Fix dead links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ communities. We're actively looking for community input and development partners
 
 ## Documentation
 
-Our full [GeoBlacklight Documentation](https://geoblacklight.org/latest/docs/) has how-to guides for installing, customizing, and maintaining a GeoBlacklight instance.
+Our full [GeoBlacklight Documentation](https://geoblacklight.org/documentation/) has how-to guides for installing, customizing, and maintaining a GeoBlacklight instance.
 
-See the [Quick Start](https://geoblacklight.org/latest/docs/geoblacklight_quick_start/) section to create a new GeoBlacklight application, or see [For Developers](https://geoblacklight.org/latest/docs/developers/) for more information about setting up a development environment.
+See the [Quick Start](https://geoblacklight.org/documentation/geoblacklight_quick_start/) section to create a new GeoBlacklight application, or see [For Developers](https://geoblacklight.org/documentation/developers/) for more information about setting up a development environment.
 
 ## Contributing
 

--- a/schema/readme.md
+++ b/schema/readme.md
@@ -2,6 +2,6 @@
 
 This directory contains a [JSON schema vocabulary](http://json-schema.org) file. It is provided for documentation and testing purposes.
 
-- geoblacklight-schema-aardvark.json : This document is formatted in the [OpenGeoMetadata, version Aardvark schema](https://opengeometadata.org/docs/ogm-aardvark), compatible with Geoblacklight version 4.0+.
+- geoblacklight-schema-aardvark.json : This document is formatted in the [OpenGeoMetadata, version Aardvark schema](https://opengeometadata.org/ogm-aardvark), compatible with Geoblacklight version 4.0+.
 
 For more information on the metadata schema for GeoBlacklight, see [opengeometadata.org](https://opengeometadata.org)


### PR DESCRIPTION
These got updated with the new Zensical-based release of the GBL
site, and there was also one stale one pointing to the OGM site.
