### PR TITLE
Fix padding for result badges and descriptions

### DIFF
--- a/app/assets/stylesheets/geoblacklight/search.css
+++ b/app/assets/stylesheets/geoblacklight/search.css
@@ -79,7 +79,7 @@
 
   .document-main-section {
     .metadata {
-      padding: 0.5em 1.5em;
+      padding: 0.5em;
     }
 
     .badges {


### PR DESCRIPTION
The old value didn't take into account multiline titles.
