### PR TITLE
Fix dead relevance boosts: qf/pf referenced unpopulated *_ti fields

### DIFF
--- a/lib/generators/geoblacklight/templates/catalog_controller.rb
+++ b/lib/generators/geoblacklight/templates/catalog_controller.rb
@@ -236,7 +236,7 @@ class CatalogController < ApplicationController
 
     config.add_search_field "all_fields", label: "All Fields"
     # config.add_search_field 'dct_title_ti', :label => 'Title'
-    # config.add_search_field 'dct_description_ti', :label => 'Description'
+    # config.add_search_field 'dct_description_tmi', :label => 'Description'
 
     # Now we see how to over-ride Solr request handler defaults, in this
     # case for a BL "search field", which is really a dismax aggregate

--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -117,9 +117,9 @@
       <str name="q.alt">*:*</str>
       <str name="qf">
         text^1
-        dct_description_ti^2
+        dct_description_tmi^2
         dct_creator_tmi^3
-        dct_publisher_ti^3
+        dct_publisher_tmi^3
         dct_isPartOf_tmi^4
         dct_subject_tmi^5
         dct_spatial_tmi^5
@@ -127,16 +127,16 @@
         dct_title_ti^6
         dct_accessRights_ti^7
         dct_provider_ti^8
-        gbl_resourceClass_ti^9
-        gbl_resourceType_ti^9
-        dct_identifier_ti^10
+        gbl_resourceClass_tmi^9
+        gbl_resourceType_tmi^9
+        dct_identifier_tmi^10
         id_ti^10
       </str>
       <str name="pf"><!-- phrase boost within result set -->
         text^1
-        dct_description_ti^2
+        dct_description_tmi^2
         dct_creator_tmi^3
-        dct_publisher_ti^3
+        dct_publisher_tmi^3
         dct_isPartOf_tmi^4
         dct_subject_tmi^5
         dct_spatial_tmi^5
@@ -144,9 +144,9 @@
         dct_title_ti^6
         dct_accessRights_ti^7
         dct_provider_ti^8
-        gbl_resourceClass_ti^9
-        gbl_resourceType_ti^9
-        dct_identifier_ti^10
+        gbl_resourceClass_tmi^9
+        gbl_resourceType_tmi^9
+        dct_identifier_tmi^10
         id_ti^10
       </str>
       <bool name="facet">true</bool>

--- a/spec/solr_config_spec.rb
+++ b/spec/solr_config_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "Solr configuration" do
+  def parse(name)
+    Nokogiri::XML(File.read(File.expand_path("../solr/conf/#{name}", __dir__)))
+  end
+
+  let(:schema) { parse("schema.xml") }
+  let(:solrconfig) { parse("solrconfig.xml") }
+
+  # Every *_ti and *_tmi name matches a dynamicField, so boosting a field that no
+  # copyField populates is legal, queryable, and always empty -- Solr never
+  # complains, the boost just silently contributes nothing to scoring. That has
+  # happened twice now: renaming a copyField destination from *_ti to *_tmi
+  # (multiValued sources need multiValued destinations) left the matching qf/pf
+  # entry behind. Deliberately ignores dynamicFields, since resolving through one
+  # is exactly the bug being guarded against.
+  def populated_fields
+    schema.xpath("//fields/field/@name").map(&:value) +
+      schema.xpath("//copyField/@dest").map(&:value)
+  end
+
+  # Reads the /text() children rather than the <str> node's own text, so the XML
+  # comment inside <str name="pf"> cannot leak words into the field list.
+  def boosted_fields(param)
+    solrconfig.xpath("//requestHandler[@name='/select']//str[@name='#{param}']/text()")
+      .map(&:text).join(" ")
+      .split.map { |entry| entry.split("^").first }
+  end
+
+  %w[qf pf].each do |param|
+    it "only boosts #{param} fields that something populates" do
+      dead = boosted_fields(param) - populated_fields
+
+      expect(dead).to be_empty,
+        "#{param} boosts fields no copyField or <field> populates: #{dead.join(", ")}"
+    end
+  end
+end


### PR DESCRIPTION
## Problem

`solr/conf/solrconfig.xml` boosts five fields in `qf`/`pf` that no `copyField` ever populates, so those boosts contribute nothing to scoring:

| Boost in `qf`/`pf` | What `schema.xml` actually populates |
| --- | --- |
| `dct_description_ti^2` | `dct_description_sm` → `dct_description_tmi` |
| `dct_publisher_ti^3` | `dct_publisher_sm` → `dct_publisher_tmi` |
| `gbl_resourceClass_ti^9` | `gbl_resourceClass_sm` → `gbl_resourceClass_tmi` |
| `gbl_resourceType_ti^9` | `gbl_resourceType_sm` → `gbl_resourceType_tmi` |
| `dct_identifier_ti^10` | `dct_identifier_sm` → `dct_identifier_tmi` |

The failure is silent by construction: `*_ti` matches the `*_ti` dynamicField, so `gbl_resourceClass_ti` is a legal, queryable field — it is simply always empty. Solr never warns. Measured against a freshly seeded index of all 55 fixtures:

```
gbl_resourceClass_ti    0 hits   |   gbl_resourceClass_tmi   55 hits
gbl_resourceType_ti     0 hits   |   gbl_resourceType_tmi    33 hits
dct_description_ti      0 hits   |   dct_description_tmi     55 hits
dct_publisher_ti        0 hits   |   dct_publisher_tmi       45 hits
dct_identifier_ti       0 hits   |   dct_identifier_tmi      47 hits
```

`gbl_resourceClass_ti^9` / `gbl_resourceType_ti^9` are a 5.x regression (they replaced `layer_geom_type_ti^9` / `layer_slug_ti^10`). The other three predate 4.x.

### How it happened

Three commits in #1510, in this order:

- `3f675626` "geom type replaced by resource class/type" — set `qf`/`pf` to `gbl_resourceClass_ti^9` / `gbl_resourceType_ti^9`
- `c5e12de0` "copyField resource class/type" — added the copyFields with `*_ti` destinations, consistent at that point
- `96ec14dc` "Schema.xml - multivalued fields need to copy to multivalued fields" — corrected the destinations to `*_tmi`, but did not touch `solrconfig.xml`

## Fix

Point `qf`/`pf` at the `*_tmi` fields the schema actually populates. Boost values and field order are unchanged, so this restores the ranking the config always intended.

`schema.xml` is deliberately left alone. Closing the gap from the other side — pointing the copyFields back at `*_ti` — would break indexing outright: Solr rejects a `copyField` from a multiValued source into a single-valued destination for any document with 2+ values, and all five sources are multiValued Aardvark `*_sm` fields. Our own fixtures hit this (`actual-polygon1.json` has `gbl_resourceType_sm: ["Polygon data", "Vector data"]`; 61 multi-valued instances of these five fields across the 55 fixtures), so `rake geoblacklight:index:seed` would fail. `96ec14dc` already made this call deliberately; `solrconfig.xml` just never caught up.

## Effect on relevance

Ranking shifts — that is the intended effect. Result sets do not change: these values were always matchable through the catch-all `text^1` field, so nothing appears or disappears. Same index, same query, old `qf` vs. new:

| Query | Old (dead `*_ti`) | New (`*_tmi`) |
| --- | --- | --- |
| `Imagery` | 13 hits, top score 1.211 | 13 hits, top score 8.934 |
| `Maps` | 40 hits — 7.325 / 6.872 / 5.200 | 40 hits — 7.986 / 7.913 / 7.913 |

`Imagery` is a `gbl_resourceClass_sm` value whose ^9 boost previously contributed nothing.

## Deploying: reload, don't reindex

**No reindex is required.** This changes only `/select` request-handler defaults in `solrconfig.xml`. The `*_tmi` fields it now boosts are already populated by copyFields this PR does not touch — they have shipped as `*_tmi` since v5.0.0, and since 4.x for description, identifier, and publisher.

Deployments do need to **reload the Solr core** so the new `solrconfig.xml` is read — solrconfig is parsed only at core load. Restart Solr, or in SolrCloud re-upload the configset and issue a RELOAD.

The one exception: if you locally patched `schema.xml` to point these copyFields at the singular `*_ti` fields in order to make the boosts fire, revert that patch — and reverting it *does* require a reindex, since copyFields are applied at index time.

## Regression guard

`spec/solr_config_spec.rb` asserts that every `qf`/`pf` field is either an explicit `<field>` or a `copyField` destination, deliberately ignoring dynamicFields — resolving only through a dynamicField is exactly the bug. This class of mistake has now shipped twice; the check is cheap and needs no running Solr.

## Verification

- New spec is red against the pre-fix config (5 dead fields per param) and green after.
- `docker compose up -d solr`, then all 55 fixtures indexed with status 0 — no multiValued copyField errors, confirming the schema is correct as-is.
- `echoParams=all` confirms live Solr serves the corrected `qf`/`pf`.
- `debugQuery=true`: all five `*_tmi` clauses appear in the parsed query, and `dct_description_tmi:raster` contributes 3.31 of the top hit's 8.38 total score.

Also fixes a stale `dct_description_ti` reference in a commented-out example in the generated `catalog_controller.rb`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
