### PR TITLE
Require selenium-webdriver >= 4.8

### DIFF
--- a/geoblacklight.gemspec
+++ b/geoblacklight.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec-rails"
   spec.add_development_dependency "engine_cart", "~> 2.0"
   spec.add_development_dependency "capybara", ">= 2.5.0"
-  spec.add_development_dependency "selenium-webdriver"
+  spec.add_development_dependency "selenium-webdriver", ">= 4.8"
   spec.add_development_dependency "factory_bot_rails"
   spec.add_development_dependency "simplecov", "~> 0.22"
   spec.add_development_dependency "foreman"


### PR DESCRIPTION
## Problem

`Gemfile.lock` is gitignored, so a local lock can drift arbitrarily far behind what CI resolves. The gemspec declared `selenium-webdriver` with no constraint at all, so nothing stopped it.

Below 4.8 there is no [Selenium Manager](https://www.selenium.dev/documentation/selenium_manager/), and the gem instead expects a `chromedriver` already on `PATH`. GitHub's `ubuntu-latest` runners happen to ship one, so the `test` job stays green — while a developer with a stale lock watches all 45 feature specs die at their first `visit`:

```
Selenium::WebDriver::Error::WebDriverError:
  Unable to find chromedriver. Please download the server from
  https://chromedriver.storage.googleapis.com/index.html and place it somewhere on your PATH.
```

That reads as a missing binary, and the obvious response — installing chromedriver by hand, then keeping it in step with Chrome — is the wrong fix. The actual repair is `bundle update selenium-webdriver`. The real hint is a warning rspec prints above the failures, easy to scroll past:

> Warning: You're using an unsupported version of selenium-webdriver, please upgrade to 4.8+.

## Change

One line: a `>= 4.8` floor, so a lock that predates Selenium Manager can't resolve in the first place. 4.8 is the release that added it. The style matches the neighboring `capybara", ">= 2.5.0"`.

## Verification

Locally, `4.1.0 -> 4.48.0` was enough to fix it outright: Selenium Manager then fetched a chromedriver matching the installed Chrome, and `bundle exec rake ci` went from 45 failures to **441 examples, 0 failures, line coverage 100.0% (1284/1284)**.

Development-dependency only — no effect on applications using the gem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)