### PR TITLE
Wait for Solr to be serving the core before yielding in with_solr

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,23 +10,7 @@ end
 
 require "engine_cart/rake_task"
 require "rspec/core/rake_task"
-require "open3"
-
-def system_with_error_handling(*args)
-  Open3.popen3(*args) do |_stdin, stdout, stderr, thread|
-    puts stdout.read
-    raise "Unable to run #{args.inspect}: #{stderr.read}" unless thread.value.success?
-  end
-end
-
-def with_solr(&block)
-  puts "Starting Solr"
-  system_with_error_handling "docker compose up -d solr"
-  yield
-ensure
-  puts "Stopping Solr"
-  system_with_error_handling "docker compose stop solr"
-end
+require "tasks/solr"
 
 task(:spec).clear
 RSpec::Core::RakeTask.new(:spec) do |t|

--- a/lib/geoblacklight.rb
+++ b/lib/geoblacklight.rb
@@ -3,6 +3,7 @@
 require "zeitwerk"
 loader = Zeitwerk::Loader.for_gem
 loader.ignore("#{__dir__}/generators")
+loader.ignore("#{__dir__}/tasks")
 loader.collapse("#{__dir__}/geoblacklight/wms_layer")
 loader.setup
 require "geoblacklight/engine"

--- a/lib/tasks/geoblacklight.rake
+++ b/lib/tasks/geoblacklight.rake
@@ -2,23 +2,7 @@
 
 require "rails/generators"
 require "generators/geoblacklight/install_generator"
-
-def system_with_error_handling(*args)
-  Open3.popen3(*args) do |_stdin, stdout, stderr, thread|
-    puts stdout.read
-    raise "Unable to run #{args.inspect}: #{stderr.read}" unless thread.value.success?
-  end
-end
-
-def with_solr(&block)
-  puts "Starting Solr"
-  system_with_error_handling "docker compose up -d solr"
-  sleep 5 # give solr a few seconds to load the core config and be ready
-  yield
-ensure
-  puts "Stopping Solr"
-  system_with_error_handling "docker compose stop solr"
-end
+require "tasks/solr"
 
 namespace :geoblacklight do
   desc "Run Solr and GeoBlacklight for interactive development"

--- a/lib/tasks/solr.rb
+++ b/lib/tasks/solr.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+# Helpers for interacting with Solr via docker compose
+
+require "open3"
+
+# Run in a thread with error handling, so we can ensure Solr gets stopped on failure
+def system_with_error_handling(*args)
+  Open3.popen3(*args) do |_stdin, stdout, stderr, thread|
+    puts stdout.read
+    raise "Unable to run #{args.inspect}: #{stderr.read}" unless thread.value.success?
+  end
+end
+
+# Downstream applications can create their own compose.yml which will shadow
+# ours; in that case they can change the name of the solr service and set it here.
+def solr_service
+  ENV.fetch("SOLR_SERVICE", "solr")
+end
+
+def wait_for_solr
+  script = File.expand_path("../../script/wait-for-solr", __dir__)
+  # Not system_with_error_handling: that buffers stdout until the process exits, so the
+  # progress lines would only appear once the wait was already over.
+  raise "Unable to run #{script}" unless system(script)
+end
+
+# Replacement for solr_wrapper.
+def with_solr(&block)
+  puts "Starting Solr"
+  system_with_error_handling "docker compose up -d #{solr_service}"
+  wait_for_solr
+  yield
+ensure
+  puts "Stopping Solr"
+  system_with_error_handling "docker compose stop #{solr_service}"
+end

--- a/script/wait-for-solr
+++ b/script/wait-for-solr
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#
+# Wait until Solr is serving the core, not merely running.
+#
+# `docker compose up -d` returns as soon as the container starts, which is well before Solr
+# has created and loaded its core. It also returns successfully when the host port fails to
+# publish, leaving a container that is healthy inside but unreachable from the host. Both
+# cases used to sail past a `sleep 5` and fail on the first Solr request.
+#
+# The check is deliberately core-scoped. A node-level endpoint such as
+# /solr/admin/info/system answers 200 while the core is still being created, which is the
+# window this is here to close; the core's ping handler answers 404 until the core is there.
+#
+# Usage: script/wait-for-solr
+#   SOLR_URL            full core URL to poll (default http://127.0.0.1:8983/solr/blacklight-core)
+#   SOLR_WAIT_ATTEMPTS  give up after this many 2s attempts (default 30)
+#   SOLR_SERVICE        name of the Solr service in docker-compose.yml (default solr)
+set -uo pipefail
+
+url="${SOLR_URL:-http://127.0.0.1:8983/solr/blacklight-core}"
+url="${url%/}"
+attempts="${SOLR_WAIT_ATTEMPTS:-30}"
+
+until [ "$(curl -s -o /dev/null -w '%{http_code}' --max-time 2 "$url/admin/ping")" = "200" ]; do
+  attempts=$((attempts - 1))
+  if [ "$attempts" -le 0 ]; then
+    echo "Solr never became ready at $url/admin/ping" >&2
+    echo "Check \`docker compose port ${SOLR_SERVICE:-solr} 8983\`; if it prints nothing, run" >&2
+    echo "\`docker compose up -d --force-recreate ${SOLR_SERVICE:-solr}\`" >&2
+    exit 1
+  fi
+  echo "Waiting for Solr to be ready..."
+  sleep 2
+done
+
+echo "Solr is up and running!"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,7 +16,7 @@ SimpleCov.start "rails" do
   add_filter "lib/geoblacklight/version.rb"
   add_filter "lib/geoblacklight/engine.rb"
   add_filter "lib/generators"
-  add_filter "lib/tasks/geoblacklight.rake"
+  add_filter "lib/tasks"
   add_filter "/spec"
   add_filter ".internal_test_app/"
   minimum_coverage 100


### PR DESCRIPTION
## Problem

`with_solr` starts Solr with `docker compose up -d` and then sleeps 5 seconds. That command returns
as soon as the *container* starts, which is well before Solr has loaded its core, so the sleep is a
guess — and it is wrong in two different ways:

1. **Cold start.** On a fresh volume, where `solr-precreate` still has to copy configs in and create
   the core, 5 seconds is frequently not enough.
2. **Unpublished host port.** `docker compose up -d` also exits 0 when the host port fails to
   publish. The container runs, Solr is healthy *inside* it, but `NetworkSettings.Ports` is
   `{"8983/tcp":[]}` and nothing on the host can reach it. This is a known Docker Desktop failure
   mode after macOS sleep/wake, and no amount of sleeping fixes it.

In both cases the task sails past the sleep and the first Solr request dies with
`RSolr::Error::ConnectionRefused`, which points at nothing useful.

## Change

Replace the sleep with `script/wait-for-solr`, a bounded poll of the core's ping handler:

```sh
until [ "$(curl -s -o /dev/null -w '%{http_code}' --max-time 2 "$url/admin/ping")" = "200" ]; do
  ...
  echo "Waiting for Solr to be ready..."
  sleep 2
done
```

Both `with_solr` copies in this repo call it, and downstream applications can call it directly.

**The check is core-scoped on purpose.** A node-level endpoint such as
`/solr/admin/info/system` answers `200` while `solr-precreate` is still creating the core — exactly
the window this is here to close. Measured against a `solr:9.6.1` container started *without*
`solr-precreate`, so the node is up and `blacklight-core` does not exist:

| check | Solr up, core absent | cold start, core ready |
|---|---|---|
| `/solr/admin/info/system` + `grep '"status":0'` | **passes** ❌ | 1.71s |
| `/blacklight-core/admin/ping` | 404 ✅ | 1.95s |

The core's ping answers `404` until the core is really there, which is what these tasks need.

Two things fall out of using curl rather than Ruby:

- **Basic auth is free.** `curl http://user:pass@host/…` turns URL credentials into an
  `Authorization: Basic` header itself, so this repo's CI `SOLR_URL` works with no extra handling.
- **URL resolution is free.** The generated `blacklight.yml` is
  `ENV['SOLR_URL'] || "http://127.0.0.1:8983/solr/blacklight-core"`, which is exactly
  `${SOLR_URL:-…}`. No need to read Blacklight's config — which also matters because
  `geoblacklight:server` has no `:environment` prerequisite.

`SOLR_WAIT_ATTEMPTS` bounds the wait (default 30 × 2s) so a Solr that never comes up fails with an
actionable message instead of hanging until the CI job limit:

```
Solr never became ready at http://127.0.0.1:9999/solr/blacklight-core/admin/ping
Check `docker compose port solr 8983`; if it prints nothing, run
`docker compose up -d --force-recreate solr`
```

### The compose service name is now configurable

`with_solr` hardcoded `docker compose up -d solr`, matching the service in *this repo's*
`compose.yml`. But this helper is defined on `Object` from a rake file that every downstream
application loads, so that name leaks into apps whose compose file calls the service something
else. Earthworks calls it `index`, and has to shadow `with_solr` wholesale to use these tasks at
all — which only works because its `Rakefile` happens to redefine the method *after*
`Rails.application.load_tasks`.

`SOLR_SERVICE` now overrides it, so those applications can drop the shadowing without renaming a
compose service to match this gem's internals. Default is unchanged.

### Notes for reviewers

- **This replaces an earlier `Geoblacklight::SolrServer` module** (99 lines + 124 lines of specs),
  per @jcoyne's review. Every Ruby-specific justification for that module turned out not to hold:
  auth and URL resolution are handled by curl and the shell as above, and the class was
  eager-loaded in production for no benefit — `lib/geoblacklight.rb` uses `Zeitwerk::Loader.for_gem`,
  and Rails' `:eager_load!` initializer calls `Zeitwerk::Loader.eager_load_all`, which broadcasts
  to gem loaders. A script sidesteps that question entirely.
- **`/admin/ping` is usable again** as of #1938, which removed the `healthcheckFile` that made the
  handler answer 503 forever. This branch is rebased on that.
- **Not in `bin/`**: the gemspec does `spec.executables = spec.files.grep(%r{^bin/})`, so a script
  there would become a gem executable. `script/` ships via `git ls-files` without that.
- **Not `system_with_error_handling`**: it buffers stdout until the process exits, so the progress
  lines would only appear once the wait was already over.
- **Three copies of `with_solr` existed**: this gem's `Rakefile`, `lib/tasks/geoblacklight.rake`,
  and (out of necessity) downstream apps. The first had *no* wait at all. Both in this repo now wait.

## Testing

Exercised against real containers on this branch:

- **Cold start** (no container present) through the gem's own `with_solr`: prints
  `Waiting for Solr to be ready...` then `Solr is up and running!`, and a
  `select?q=*:*&rows=0` inside the block returns `200`. Total 2.6s.
- **Core-absent false positive**: confirmed the node-level check passes while
  `/blacklight-core/admin/ping` and `select` both 404 and the first real request returns Solr's
  `"You must type the correct path"` HTML.
- **Basic auth**: verified against a netcat listener that curl sends
  `Authorization: Basic c29scjpTb2xyUm9ja3M=` from CI's `SOLR_URL`.
- **Timeout path**: unreachable port with `SOLR_WAIT_ATTEMPTS=2` fails at the bound with the message
  above, and the `ensure` still stops the service.
- **`SOLR_SERVICE=index`**: reaches both the `up` and `stop` commands.
- `standardrb` clean; `bash -n` clean.

No specs: the polling machinery the previous specs covered no longer exists.
