### PR TITLE
Stop gating /admin/ping on a healthcheckFile that never exists

### DIFF
--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -179,12 +179,6 @@
     <lst name="defaults">
       <str name="echoParams">all</str>
     </lst>
-    <!-- An optional feature of the PingRequestHandler is to configure the
-         handler with a "healthcheckFile" which can be used to enable/disable
-         the PingRequestHandler.
-         relative paths are resolved against the data dir
-      -->
-    <str name="healthcheckFile">server-enabled.txt</str>
   </requestHandler>
 
   <requestHandler name="/analysis/field"


### PR DESCRIPTION
## Problem

`solr/conf/solrconfig.xml` configures the ping handler with a `healthcheckFile`:

```xml
<str name="healthcheckFile">server-enabled.txt</str>
```

That optional `PingRequestHandler` feature gates the handler on a file in the data dir, and Solr
answers `503 Service disabled` whenever the file is absent. Nothing in GeoBlacklight or the Solr
Docker image ever creates it, so `/admin/ping` reports an unhealthy core **forever**:

```json
{"error":{"msg":"Service disabled","code":503}}
```

This is not confined to this repo's own Solr. `install_generator.rb` does
`directory "../../../../solr", "solr"`, copying this config wholesale into every generated
application — so every GeoBlacklight app ships a Solr whose conventional health endpoint is
permanently 503. Anything pointed at it (a Kubernetes liveness/readiness probe, a load balancer
health check, an uptime monitor) sees a core that never comes up.

It also bit #1937, which originally polled `/admin/ping` to decide when Solr was ready and hung
for the full timeout on CI.

## Change

Remove the setting, leaving a comment explaining why it should stay unset. Verified against a real
Solr started from this config:

| | before | after |
|---|---|---|
| `/admin/ping` | 503 | **200** |
| `/select?q=*:*&rows=0` | 200 | 200 |
| core init failures | none | none |

## Two guards in the config spec

**The ping handler stays ungated** — fails with a clear message if the setting comes back.

**The shipped XML is well-formed.** This one earned its place: my first draft of the replacement
comment used `--` as an em-dash, which XML forbids inside comments. Solr refused to load the core
at all (`SAXParseException`, both endpoints 500) — a considerably worse outcome than the bug being
fixed, and one that would have shipped into every generated app.

The existing specs did not notice, because `Nokogiri::XML` parses leniently by default and happily
produced a usable document from a file Solr rejected outright. The new example strict-parses both
`schema.xml` and `solrconfig.xml`. Confirmed it fails on exactly that mistake.

## Testing

- `bundle exec rake ci` locally: 442 examples, 0 failures, 100.0% coverage.
- Both new guards confirmed to fail when their respective regressions are reintroduced.
- `standardrb` clean.
