### PR TITLE
Restore BboxFilterQuery.call for Blacklight 8

### DIFF
--- a/app/models/concerns/geoblacklight/bbox_filter_query.rb
+++ b/app/models/concerns/geoblacklight/bbox_filter_query.rb
@@ -2,6 +2,18 @@
 
 module Geoblacklight
   class BboxFilterQuery
+    # Blacklight 9 instantiates a filter_query_builder with the blacklight_config and
+    # calls #call(filter, solr_params). Blacklight 8 has no such branch: it always does
+    # `filter.config.filter_query_builder.call(search_builder, filter, solr_params)`.
+    #
+    # @see https://github.com/projectblacklight/blacklight/blob/v8.12.3/lib/blacklight/solr/search_builder_behavior.rb#L132
+    # @param search_builder [Blacklight::SearchBuilder]
+    # @param filter [Geoblacklight::BboxFilterField]
+    # @param solr_params [Hash]
+    def self.call(search_builder, filter, solr_params)
+      new(blacklight_config: search_builder.blacklight_config).call(filter, solr_params)
+    end
+
     def call(filter, solr_params)
       @filter = filter
       [intersects_filter, relevancy_boost(solr_params)]

--- a/spec/models/concerns/geoblacklight/bbox_filter_query_spec.rb
+++ b/spec/models/concerns/geoblacklight/bbox_filter_query_spec.rb
@@ -104,6 +104,21 @@ RSpec.describe Geoblacklight::BboxFilterQuery do
     end
   end
 
+  describe ".call" do
+    # Blacklight 8 always invokes a filter_query_builder this way; Blacklight 9 only
+    # does so when the builder is not a Class. See
+    # https://github.com/projectblacklight/blacklight/blob/v8.12.3/lib/blacklight/solr/search_builder_behavior.rb#L132
+    let(:search_builder) { instance_double(Blacklight::SearchBuilder, blacklight_config:) }
+
+    it "accepts the Blacklight 8 signature" do
+      expect { described_class.call(search_builder, filter, solr_params) }.not_to raise_error
+    end
+
+    it "returns the same thing as the Blacklight 9 entry point" do
+      expect(described_class.call(search_builder, filter, solr_params)).to eq result
+    end
+  end
+
   describe "#intersects_filter" do
     let(:intersects_filter) { result.first }
 


### PR DESCRIPTION
## The problem

The gemspec allows `blacklight >= 8.0, < 10`, but bbox filtering only works on Blacklight 9.

Blacklight 9 picks between two shapes of `filter_query_builder` ([`search_builder_behavior.rb#L156-L162`](https://github.com/projectblacklight/blacklight/blob/main/lib/blacklight/solr/search_builder_behavior.rb#L156-L162)):

```ruby
filter_query_builder_class_or_proc = filter.config.filter_query_builder || DefaultFilterQueryBuilder
if filter_query_builder_class_or_proc.is_a?(Class)
  filter_query_builder = filter_query_builder_class_or_proc.new(blacklight_config: blacklight_config)
  filter_query, subqueries = filter_query_builder.call(filter, solr_parameters)
else
  filter_query, subqueries = filter_query_builder_class_or_proc.call(self, filter, solr_parameters)
end
```

Blacklight 8 has no such branch — it only ever does the second one ([`v8.12.3 search_builder_behavior.rb#L132`](https://github.com/projectblacklight/blacklight/blob/v8.12.3/lib/blacklight/solr/search_builder_behavior.rb#L132)):

```ruby
filter_query, subqueries = filter.config.filter_query_builder.call(self, filter, solr_parameters)
```

`BboxFilterQuery` is a Class, so on 9 it takes the first branch and works. On 8 it takes the second, and since the class method went away when the builder was converted to the instance form, it raises:

```
NoMethodError: undefined method 'call' for class Geoblacklight::BboxFilterQuery
```

the first time anyone draws a box on the map or follows a bbox-filtered URL. The generated `CatalogController` wires this up for every application:

```ruby
config.add_facet_field field_config.geometry, component: Geoblacklight::Facets::BboxFieldComponent,
  item_presenter: Geoblacklight::BboxItemPresenter, filter_class: Geoblacklight::BboxFilterField,
  filter_query_builder: Geoblacklight::BboxFilterQuery, ...
```

**CI does not catch it.** The matrix varies Ruby and Rails but not Blacklight, so it always resolves to 9.

## The fix

Add the Blacklight 8 entry point back as a thin delegation to the Blacklight 9 one. `Blacklight::SearchBuilder` delegates `blacklight_config` to its scope on both versions, so the shim has everything it needs.

Verified by loading the class before and after against a stub filter and search builder:

```
BEFORE  Blacklight 8 path (.call): NoMethodError -- undefined method 'call' for class Geoblacklight::BboxFilterQuery
AFTER   Blacklight 8 path (.call): OK
AFTER   both paths agree:            true
AFTER   Blacklight 9 path unchanged: true
```

The added spec exercises the Blacklight 8 signature and asserts both entry points return the same thing.

## A note on the alternative

The other fix is to raise the gemspec floor to `blacklight >= 9` and delete the shim. That is a bigger decision than this bug — it would drop a Blacklight the gemspec currently advertises — so I have gone with keeping the stated range working. Happy to switch if you would rather drop 8; in that case this PR becomes a one-line gemspec change instead.

Either way it is probably worth adding a Blacklight axis to the CI matrix, since nothing currently exercises the lower bound.

## How I found it

While inventorying what changes between `release-5.x` and `main`, to add deprecation warnings on 5.x for the 6.0 upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)