### PR TITLE
Add Blacklight 8 to the CI matrix

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -48,12 +48,17 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    # FIXME: currently not compatible with BL8
+    # NOTE: when compatibility is restored, remove this and the fail-fast: false below
+    continue-on-error: ${{ matrix.blacklight_version == '8' }}
     strategy:
+      fail-fast: false
       matrix:
         ruby_version: ["3.3", "3.4", "4.0"]
         rails_version: ["8.1.1"]
+        blacklight_version: ["8", "9"]
 
-    name: test ruby ${{ matrix.ruby_version }} / rails ${{ matrix.rails_version }}
+    name: test ruby ${{ matrix.ruby_version }} / rails ${{ matrix.rails_version }} / blacklight ${{ matrix.blacklight_version }}
     steps:
       - uses: actions/checkout@v7
       - name: Set up Ruby
@@ -65,15 +70,17 @@ jobs:
         env:
           BUNDLE_FORCE_RUBY_PLATFORM: true
           RAILS_VERSION: ${{ matrix.rails_version }}
+          BLACKLIGHT_VERSION: "~> ${{ matrix.blacklight_version }}.0"
       - name: Run tests
         run: bundle exec rake ci
         env:
           BUNDLE_FORCE_RUBY_PLATFORM: true
           RAILS_VERSION: ${{ matrix.rails_version }}
+          BLACKLIGHT_VERSION: "~> ${{ matrix.blacklight_version }}.0"
           SOLR_URL: http://solr:SolrRocks@localhost:8983/solr/blacklight-core
       - name: Upload coverage artifacts
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: "coverage-${{ matrix.ruby_version }}-${{ matrix.rails_version }}"
+          name: "coverage-${{ matrix.ruby_version }}-${{ matrix.rails_version }}-blacklight${{ matrix.blacklight_version }}"
           path: coverage/

--- a/Gemfile
+++ b/Gemfile
@@ -28,5 +28,9 @@ else
       gem "rails", ENV["RAILS_VERSION"]
     end
   end
+
+  if ENV["BLACKLIGHT_VERSION"]
+    gem "blacklight", ENV["BLACKLIGHT_VERSION"]
+  end
 end
 # END ENGINE_CART BLOCK

--- a/spec/test_app_templates/lib/generators/test_app_generator.rb
+++ b/spec/test_app_templates/lib/generators/test_app_generator.rb
@@ -6,7 +6,11 @@ class TestAppGenerator < Rails::Generators::Base
   source_root File.expand_path("../../../../spec/test_app_templates", __FILE__)
 
   def add_gems
-    gem "blacklight"
+    if ENV["BLACKLIGHT_VERSION"]
+      gem "blacklight", ENV["BLACKLIGHT_VERSION"]
+    else
+      gem "blacklight"
+    end
 
     Bundler.with_unbundled_env do
       run "bundle install"


### PR DESCRIPTION
This adds BL8 to the test matrix, since we say we support it but
weren't testing it.

Turns out it doesn't run, so this is non-blocking until we
actually make it compatible.
