### PR TITLE
Make the generated view configuration idempotent

### DIFF
--- a/lib/generators/geoblacklight/templates/catalog_controller.rb
+++ b/lib/generators/geoblacklight/templates/catalog_controller.rb
@@ -32,8 +32,13 @@ class CatalogController < ApplicationController
 
     # GeoBlacklight Defaults
     # * Adds the "map" split view for catalog#index
-    config.view.split(partials: ["index"])
-    config.view.delete_field("list")
+    #
+    # Written to be idempotent: if anything below raises, Ruby leaves this class
+    # defined and the block is evaluated again against the same config. The more
+    # common `config.view.split(partials:)` form defines a zero-arity `split` reader
+    # on the first pass, so a second pass raises ArgumentError and masks the real error.
+    config.view[:split] = {partials: ["index"]}
+    config.view.delete_field("list") if config.view.to_h.key?(:list)
 
     # solr field configuration for search results/index views
     # config.index.show_link = 'title_display'

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -9,6 +9,31 @@ RSpec.describe CatalogController, type: :controller do
 
       expect(description_field.component).to eq Geoblacklight::MetadataDescriptionMarkdownComponent
     end
+
+    it "adds the split view and removes the list view" do
+      expect(described_class.blacklight_config.view.split.partials).to eq ["index"]
+      expect(described_class.blacklight_config.view.to_h).not_to include :list
+    end
+
+    # These two statements mirror the generated CatalogController (see
+    # lib/generators/geoblacklight/templates/catalog_controller.rb). Ruby leaves the
+    # class defined if its body raises, so a load error anywhere in that class
+    # re-evaluates the whole configure_blacklight block against the same config. The
+    # statements have to tolerate that, or the second pass raises and hides the
+    # original error.
+    it "applies its view configuration idempotently" do
+      config = Blacklight::Configuration.new
+
+      expect {
+        2.times do
+          config.view[:split] = {partials: ["index"]}
+          config.view.delete_field("list") if config.view.to_h.key?(:list)
+        end
+      }.not_to raise_error
+
+      expect(config.view.split.partials).to eq ["index"]
+      expect(config.view.to_h).not_to include :list
+    end
   end
 
   describe "#web_services" do


### PR DESCRIPTION
The generated CatalogController configures its views with:

    config.view.split(partials: ["index"])
    config.view.delete_field("list")

Neither statement tolerates being run twice. Ruby leaves a class defined
when its body raises, so the next reference re-requires the file, reopens
the same class, finds @blacklight_config still memoized on it, and runs
the whole configure_blacklight block again against the same config and the
same view object.

On the second pass `split` is no longer handled by method_missing:
NestedOpenStructWithHashAccess#method_missing called new_ostruct_member!
on the first pass, which defines a real zero-arity `split` reader. Calling
it with one argument raises ArgumentError. delete_field is the same story
for a different reason -- OpenStruct#delete_field raises NameError when
the field is already gone.

The effect is that any load error in a generated CatalogController is
replaced by a confusing secondary error pointing at an unrelated line,
hiding the one that actually matters. This showed up while testing against
Blacklight 8, where Blacklight::Facets does not exist: one spec file
reported the real NameError and another reported ArgumentError from line
35, because they were the first and second evaluation of the same file.

Use forms that can run more than once. Both produce an identical result to
the originals: same ViewConfig class, key: :split, partials: ["index"].

This is not Blacklight-version specific -- 8.13 and 9.0 ship a
byte-identical NestedOpenStructWithHashAccess and both raise on the
second call.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
