### PR TITLE
Require Blacklight 9

### DIFF
--- a/geoblacklight.gemspec
+++ b/geoblacklight.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.required_rubygems_version = ">= 2.5.2"
 
   spec.add_dependency "rails", ">= 8", "< 9"
-  spec.add_dependency "blacklight", ">= 8.0", "< 10"
+  spec.add_dependency "blacklight", ">= 9.0", "< 10"
   spec.add_dependency "commonmarker", "~> 2.9"
   spec.add_dependency "config"
   spec.add_dependency "faraday", "~> 2.0"


### PR DESCRIPTION
The impetus for this is twofold: first, the structure of facets
changes, and GBLv6's geosearch facet and styling are written to
assume BL9 conventions + accordion facet styles.

Second, and maybe more importantly, a fresh BL8 app using importmap
still installs a CSS processing pipeline, which pulls in sprockets.
You have to do some work to prevent this from happening, and it's
easier to just use the defaults that come with BL9.

For prior work that attempted to achieve BL8 compatibility, see
PRs #1940, #1941, #1943.
