### PR TITLE
Make Config classes emit more helpful warnings for missing/removed keys

### DIFF
--- a/lib/geoblacklight/configuration/display_note_shown_config.rb
+++ b/lib/geoblacklight/configuration/display_note_shown_config.rb
@@ -4,6 +4,9 @@ module Geoblacklight
     class DisplayNoteShownConfig
       include ActiveModel::Model
       include ActiveModel::Attributes
+      include SettingsAttributes
+
+      self.settings_section = "DISPLAY_NOTES_SHOWN"
 
       attribute :bootstrap_alert_class, :string
       attribute :icon, :string

--- a/lib/geoblacklight/configuration/relationship_config.rb
+++ b/lib/geoblacklight/configuration/relationship_config.rb
@@ -4,6 +4,13 @@ module Geoblacklight
     class RelationshipConfig
       include ActiveModel::Model
       include ActiveModel::Attributes
+      include SettingsAttributes
+
+      # GeoBlacklight 5 drew a per-relationship icon next to each related record.
+      # GeoBlacklight 6 labels them with a resource-class badge instead, but every
+      # config/settings.yml generated since 4.0 still sets this.
+      self.removed_attributes = %w[icon].freeze
+      self.settings_section = "RELATIONSHIPS_SHOWN"
 
       attribute :field, :string
       attribute :inverse, :string

--- a/lib/geoblacklight/configuration/relationships_config.rb
+++ b/lib/geoblacklight/configuration/relationships_config.rb
@@ -82,9 +82,9 @@ module Geoblacklight
       }.freeze
 
       def initialize(relationships = DEFAULT_RELATIONSHIPS)
-        @relationships = relationships.to_h.transform_values do |attrs|
-          attrs.is_a?(RelationshipConfig) ? attrs : RelationshipConfig.new(attrs)
-        end
+        @relationships = relationships.to_h
+          .transform_keys { |name| normalize_name(name) }
+          .transform_values { |attrs| config_for(attrs) }
       end
 
       def each(&block)
@@ -105,6 +105,18 @@ module Geoblacklight
 
       def method_missing(name, *args, **kwargs, &block) # rubocop:disable Style/MissingRespondToMissing
         @relationships.key?(name) ? @relationships[name] : super
+      end
+
+      private
+
+      def normalize_name(name)
+        name.to_s.downcase.to_sym
+      end
+
+      def config_for(attrs)
+        return attrs if attrs.is_a?(RelationshipConfig)
+
+        RelationshipConfig.new(attrs.to_h)
       end
     end
   end

--- a/lib/geoblacklight/configuration/settings_attributes.rb
+++ b/lib/geoblacklight/configuration/settings_attributes.rb
@@ -1,0 +1,85 @@
+module Geoblacklight
+  class Configuration
+    # Shared behavior for the small ActiveModel value objects that are built by
+    # mass-assigning a section of config/settings.yml -- RelationshipConfig and
+    # DisplayNoteShownConfig.
+    #
+    # Because config/settings.yml is only written when GeoBlacklight is first
+    # installed, an upgrading application's copy is whatever the installer wrote
+    # years ago. Assigning that hash directly onto an ActiveModel raises
+    # ActiveModel::UnknownAttributeError, naming a class the maintainer has never
+    # heard of, for a key they did not choose. This module makes three changes:
+    #
+    # * keys are matched case-insensitively, so an uppercase +FIELD:+ resolves the
+    #   same way the section name itself does (see CaseInsensitiveSettings)
+    # * attributes named in +removed_attributes+ are dropped with one deprecation
+    #   warning each, rather than raising
+    # * anything else still raises, but with a message that names the file to edit
+    #   and lists the keys that are accepted
+    #
+    # Include it *after* ActiveModel::Model and ActiveModel::Attributes:
+    #
+    #   class RelationshipConfig
+    #     include ActiveModel::Model
+    #     include ActiveModel::Attributes
+    #     include SettingsAttributes
+    #
+    #     self.removed_attributes = %w[icon].freeze
+    #     self.settings_section = "RELATIONSHIPS_SHOWN"
+    #   end
+    #
+    # The ordering matters and fails silently if you get it wrong. This module
+    # overrides ActiveModel::AttributeAssignment#attribute_writer_missing, so
+    # ActiveModel has to be lower in the ancestor chain. Rewriting this as an
+    # ActiveSupport::Concern that includes ActiveModel from its +included+ block
+    # would put ActiveModel *ahead* of this module, and its raising default would
+    # win with no error to say so.
+    module SettingsAttributes
+      def self.included(klass)
+        # Attribute names (as strings) that this version of GeoBlacklight no longer
+        # has any use for, but which an older config/settings.yml may still set.
+        klass.class_attribute :removed_attributes, instance_writer: false, default: [].freeze
+
+        # The config/settings.yml section this object is built from, used in messages.
+        klass.class_attribute :settings_section, instance_writer: false
+
+        klass.extend ClassMethods
+      end
+
+      module ClassMethods
+        # Warns at most once per removed attribute per process. The whole
+        # configuration is built once and memoized on Geoblacklight, and the fix is
+        # "edit config/settings.yml", so one line per key is all you need to see.
+        def warn_removed_attribute(name)
+          @warned_removed_attributes ||= Set.new
+          return unless @warned_removed_attributes.add?(name)
+
+          Geoblacklight::Deprecation.warn(
+            "config/settings.yml sets #{name} on a #{settings_section} entry. GeoBlacklight no " \
+            "longer reads it and the line can be deleted; support for it will be removed in a " \
+            "future version."
+          )
+        end
+
+        # Lets a spec assert on the warning more than once.
+        def reset_removed_attribute_warnings!
+          @warned_removed_attributes = nil
+        end
+      end
+
+      # ActiveModel calls this instead of raising when #assign_attributes is handed
+      # a key with no matching setter.
+      def attribute_writer_missing(name, value)
+        key = name.to_s.downcase
+
+        return public_send(:"#{key}=", value) if self.class.attribute_names.include?(key)
+        return self.class.warn_removed_attribute(key) if self.class.removed_attributes.include?(key)
+
+        raise Geoblacklight::Exceptions::InvalidSettings,
+          "config/settings.yml: a #{self.class.settings_section} entry sets #{name.to_s.inspect}, " \
+          "which GeoBlacklight does not recognize. It accepts only " \
+          "#{self.class.attribute_names.join(", ")}."
+      end
+    end
+  end
+end

--- a/lib/geoblacklight/exceptions.rb
+++ b/lib/geoblacklight/exceptions.rb
@@ -4,5 +4,9 @@ module Geoblacklight
   module Exceptions
     class WrongBoundingBoxFormat < StandardError
     end
+
+    # Raised when config/settings.yml sets a key GeoBlacklight does not recognize.
+    class InvalidSettings < StandardError
+    end
   end
 end

--- a/spec/lib/geoblacklight/configuration/relationships_config_spec.rb
+++ b/spec/lib/geoblacklight/configuration/relationships_config_spec.rb
@@ -1,0 +1,121 @@
+require "spec_helper"
+
+RSpec.describe Geoblacklight::Configuration::RelationshipsConfig do
+  before do
+    allow(Geoblacklight::Deprecation).to receive(:warn)
+    Geoblacklight::Configuration::RelationshipConfig.reset_removed_attribute_warnings!
+  end
+
+  describe "the defaults" do
+    subject(:config) { described_class.new }
+
+    it "carries the twelve relationships, lowercased" do
+      expect(config.each_key.to_a).to eq(
+        %i[
+          member_of_ancestors member_of_descendants
+          part_of_ancestors part_of_descendants
+          relation_ancestors relation_descendants
+          replaces_ancestors replaces_descendants
+          source_ancestors source_descendants
+          version_of_ancestors version_of_descendants
+        ]
+      )
+    end
+
+    it "builds each entry as a RelationshipConfig" do
+      expect(config.map { |_name, entry| entry }).to all(be_a(Geoblacklight::Configuration::RelationshipConfig))
+    end
+
+    it "does not warn" do
+      config
+
+      expect(Geoblacklight::Deprecation).not_to have_received(:warn)
+    end
+  end
+
+  describe "a settings file carried over from GeoBlacklight 5" do
+    # Verbatim from the config/settings.yml that GeoBlacklight 4.0 and later wrote:
+    # uppercase entry names, an uppercase inverse, and an icon on every entry.
+    subject(:config) do
+      described_class.new(
+        MEMBER_OF_ANCESTORS: {
+          field: "pcdm_memberOf_sm",
+          icon: "parent-item",
+          inverse: :MEMBER_OF_DESCENDANTS,
+          label: "geoblacklight.relations.member_of_ancestors",
+          query_type: "ancestors"
+        },
+        MEMBER_OF_DESCENDANTS: {
+          field: "pcdm_memberOf_sm",
+          icon: "child-item",
+          inverse: :MEMBER_OF_ANCESTORS,
+          label: "geoblacklight.relations.member_of_descendants",
+          query_type: "descendants"
+        }
+      )
+    end
+
+    it "builds without raising" do
+      expect { config }.not_to raise_error
+    end
+
+    it "lowercases the entry names" do
+      expect(config.each_key.to_a).to eq(%i[member_of_ancestors member_of_descendants])
+    end
+
+    it "keeps the rest of each entry intact" do
+      expect(config[:member_of_ancestors].field).to eq("pcdm_memberOf_sm")
+      expect(config[:member_of_ancestors].query_type).to eq("ancestors")
+      expect(config[:member_of_ancestors].label).to eq("geoblacklight.relations.member_of_ancestors")
+    end
+
+    it "warns once about the icons rather than once per entry" do
+      config
+
+      expect(Geoblacklight::Deprecation).to have_received(:warn).once.with(/icon/)
+    end
+
+    # RelationsComponent builds each card's "Browse all ..." link from the entry
+    # name, and its regexp only matches the lowercase form. Left uppercase, the
+    # link renders as a titleized key instead of a sentence.
+    it "produces names that RelationsComponent can derive a browse label from" do
+      browse_keys = config.each_key.map { |name| name.to_s.sub(/_(ancestors|descendants)\z/, "") }
+
+      expect(browse_keys).to eq(%w[member_of member_of])
+    end
+  end
+
+  describe "lookup" do
+    subject(:config) { described_class.new(MEMBER_OF_ANCESTORS: {field: "pcdm_memberOf_sm"}) }
+
+    it "finds a normalized name with #[]" do
+      expect(config[:member_of_ancestors].field).to eq("pcdm_memberOf_sm")
+    end
+
+    it "reports a normalized name with #key?" do
+      expect(config.key?(:member_of_ancestors)).to be true
+      expect(config.key?(:MEMBER_OF_ANCESTORS)).to be false
+    end
+
+    it "answers a normalized name as a method" do
+      expect(config.member_of_ancestors.field).to eq("pcdm_memberOf_sm")
+    end
+
+    it "still raises NoMethodError for a name it does not have" do
+      expect { config.no_such_relationship }.to raise_error(NoMethodError)
+    end
+  end
+
+  describe "an unrecognized key" do
+    it "raises, naming the file and the key" do
+      expect { described_class.new(member_of_ancestors: {field: "x", quiery_type: "ancestors"}) }
+        .to raise_error(Geoblacklight::Exceptions::InvalidSettings, /"quiery_type"/)
+    end
+  end
+
+  it "passes an already-built RelationshipConfig through untouched" do
+    entry = Geoblacklight::Configuration::RelationshipConfig.new(field: "pcdm_memberOf_sm")
+
+    expect(described_class.new(member_of_ancestors: entry)[:member_of_ancestors]).to be(entry)
+  end
+end

--- a/spec/lib/geoblacklight/configuration/settings_attributes_spec.rb
+++ b/spec/lib/geoblacklight/configuration/settings_attributes_spec.rb
@@ -1,0 +1,113 @@
+require "spec_helper"
+
+RSpec.describe Geoblacklight::Configuration::SettingsAttributes do
+  # Exercised through the two real classes that include it rather than a stub, so
+  # these also cover the wiring in each class.
+  shared_examples "a settings-backed value object" do |section:|
+    it "declares the settings.yml section it is built from" do
+      expect(described_class.settings_section).to eq(section)
+    end
+
+    it "resolves an uppercase key to its lowercase attribute" do
+      attribute = described_class.attribute_names.first
+
+      expect(described_class.new(attribute.upcase.to_sym => "a value").public_send(attribute)).to eq("a value")
+    end
+
+    it "assigns recognized attributes without complaint" do
+      attributes = described_class.attribute_names.to_h { |name| [name.to_sym, "a value"] }
+
+      expect { described_class.new(attributes) }.not_to raise_error
+    end
+
+    it "raises for an unrecognized key, naming the section and what is accepted" do
+      expect { described_class.new(no_such_key: "a value") }.to raise_error(
+        Geoblacklight::Exceptions::InvalidSettings,
+        /#{section}.*"no_such_key".*#{Regexp.escape(described_class.attribute_names.join(", "))}/m
+      )
+    end
+
+    # ActiveModel::AttributeAssignment defines a raising attribute_writer_missing.
+    # If SettingsAttributes is ever included before ActiveModel -- for instance by
+    # rewriting it as an ActiveSupport::Concern that includes ActiveModel itself --
+    # ActiveModel's version wins and every example above starts failing for a
+    # reason that has nothing to do with the behavior being tested.
+    it "installs its override ahead of ActiveModel's raising default" do
+      expect(described_class.instance_method(:attribute_writer_missing).owner)
+        .to eq(Geoblacklight::Configuration::SettingsAttributes)
+    end
+  end
+
+  describe Geoblacklight::Configuration::RelationshipConfig do
+    before do
+      allow(Geoblacklight::Deprecation).to receive(:warn)
+      described_class.reset_removed_attribute_warnings!
+    end
+
+    it_behaves_like "a settings-backed value object", section: "RELATIONSHIPS_SHOWN"
+
+    it "treats icon as removed" do
+      expect(described_class.removed_attributes).to eq(%w[icon])
+    end
+
+    it "builds successfully from a verbatim GeoBlacklight 5 entry" do
+      config = described_class.new(
+        field: "pcdm_memberOf_sm",
+        icon: "parent-item",
+        inverse: :member_of_descendants,
+        label: "geoblacklight.relations.member_of_ancestors",
+        query_type: "ancestors"
+      )
+
+      expect(config.field).to eq("pcdm_memberOf_sm")
+      expect(config.query_type).to eq("ancestors")
+    end
+
+    it "does not carry the removed attribute" do
+      expect(described_class.attribute_names).not_to include("icon")
+    end
+
+    it "warns that icon is no longer read" do
+      described_class.new(icon: "parent-item")
+
+      expect(Geoblacklight::Deprecation).to have_received(:warn).with(/icon.*RELATIONSHIPS_SHOWN/)
+    end
+
+    it "warns about an uppercase removed attribute too" do
+      described_class.new({ICON: "parent-item"})
+
+      expect(Geoblacklight::Deprecation).to have_received(:warn).with(/icon/)
+    end
+
+    it "warns only once however many entries set it" do
+      12.times { described_class.new(field: "pcdm_memberOf_sm", icon: "parent-item") }
+
+      expect(Geoblacklight::Deprecation).to have_received(:warn).once
+    end
+
+    it "does not warn when no removed attribute is set" do
+      described_class.new(field: "pcdm_memberOf_sm")
+
+      expect(Geoblacklight::Deprecation).not_to have_received(:warn)
+    end
+  end
+
+  describe Geoblacklight::Configuration::DisplayNoteShownConfig do
+    before { allow(Geoblacklight::Deprecation).to receive(:warn) }
+
+    it_behaves_like "a settings-backed value object", section: "DISPLAY_NOTES_SHOWN"
+
+    it "has no removed attributes" do
+      expect(described_class.removed_attributes).to be_empty
+    end
+
+    # icon means opposite things in the two classes: RelationshipConfig drops it,
+    # while here it is a real attribute that has to survive.
+    it "keeps icon, which is one of its own attributes" do
+      config = described_class.new(icon: "circle-info-solid", note_prefix: "Info: ")
+
+      expect(config.icon).to eq("circle-info-solid")
+      expect(Geoblacklight::Deprecation).not_to have_received(:warn)
+    end
+  end
+end

--- a/spec/lib/geoblacklight/configuration/settings_builder_spec.rb
+++ b/spec/lib/geoblacklight/configuration/settings_builder_spec.rb
@@ -191,6 +191,38 @@ RSpec.describe Geoblacklight::Configuration::SettingsBuilder do
         expect(Geoblacklight::Deprecation).to have_received(:warn).with(a_string_matching(/DISPLAY_NOTES_SHOWN/i))
       end
     end
+
+    describe "relationships_shown" do
+      it "preserves the defaults when RELATIONSHIPS_SHOWN is absent" do
+        expect(described_class.new(settings: {}).build.relationships_shown.each_key.to_a)
+          .to include(:member_of_ancestors, :version_of_descendants)
+      end
+
+      # The block every config/settings.yml generated since GeoBlacklight 4.0
+      # contains. Before GeoBlacklight tolerated the icon attribute, this raised
+      # ActiveModel::UnknownAttributeError while the configuration was built --
+      # which in production meant the application would not boot.
+      it "builds from a GeoBlacklight 5 block with icons and uppercase names" do
+        allow(Geoblacklight::Deprecation).to receive(:warn)
+        settings = {
+          RELATIONSHIPS_SHOWN: {
+            MEMBER_OF_ANCESTORS: {
+              field: "pcdm_memberOf_sm",
+              icon: "parent-item",
+              inverse: :MEMBER_OF_DESCENDANTS,
+              label: "geoblacklight.relations.member_of_ancestors",
+              query_type: "ancestors"
+            }
+          }
+        }
+
+        result = described_class.new(settings: settings).build.relationships_shown
+
+        expect(result.each_key.to_a).to eq([:member_of_ancestors])
+        expect(result[:member_of_ancestors].field).to eq("pcdm_memberOf_sm")
+        expect(result[:member_of_ancestors].query_type).to eq("ancestors")
+      end
+    end
   end
 end
 

--- a/spec/lib/geoblacklight/relations/relation_response_spec.rb
+++ b/spec/lib/geoblacklight/relations/relation_response_spec.rb
@@ -65,10 +65,10 @@ RSpec.describe Geoblacklight::Relations::RelationResponse do
     it "fails for a bad query type request" do
       relationships = Geoblacklight.configuration.relationships_shown
       Geoblacklight.configuration.relationships_shown = Geoblacklight::Configuration::RelationshipsConfig.new(
-        BAD: {field: "dct_source_sm", query_type: "bad_query_type", label: "geoblacklight.relations.source_ancestors"}
+        bad: {field: "dct_source_sm", query_type: "bad_query_type", label: "geoblacklight.relations.source_ancestors"}
       )
 
-      expect { relation_resp.BAD }.to raise_error(ArgumentError)
+      expect { relation_resp.bad }.to raise_error(ArgumentError)
     ensure
       Geoblacklight.configuration.relationships_shown = relationships
     end


### PR DESCRIPTION
ActiveModel already includes a attribute_writer_missing hook; this lets
us have the Config classes with items that changed between v5 and v6 use
it to emit helpful warnings instead of raising, so that upgrading is
easier.

Without this, a pre-existing settings.yml with things like configured
relationship icons (from v5 or before) will blow up on upgrading to v6.
