### PR TITLE
Wire configurable basemaps into the viewers

### DIFF
--- a/app/components/geoblacklight/item_map_viewer_component.rb
+++ b/app/components/geoblacklight/item_map_viewer_component.rb
@@ -34,6 +34,8 @@ module Geoblacklight
         :class => "viewer ogm-viewer",
         "hide-title" => true,
         "theme" => helpers.geoblacklight_viewer_theme,
+        "light-basemap" => Geoblacklight.configuration.light_basemap_url,
+        "dark-basemap" => Geoblacklight.configuration.dark_basemap_url,
         "record-url" => helpers.viewer_solr_document_path(@document),
         :data => {restricted_origins: restricted_origins})
     end

--- a/app/components/geoblacklight/locator_map_component.rb
+++ b/app/components/geoblacklight/locator_map_component.rb
@@ -22,6 +22,8 @@ module Geoblacklight
         :id => @id,
         :class => "viewer locator-map",
         "theme" => helpers.geoblacklight_viewer_theme,
+        "light-basemap" => Geoblacklight.configuration.light_basemap_url,
+        "dark-basemap" => Geoblacklight.configuration.dark_basemap_url,
         "record-url" => helpers.viewer_solr_document_path(@document)
       }
     end

--- a/app/components/geoblacklight/overview_map_component.rb
+++ b/app/components/geoblacklight/overview_map_component.rb
@@ -39,6 +39,8 @@ module Geoblacklight
         :id => @id,
         :class => "viewer overview-map",
         "theme" => helpers.geoblacklight_viewer_theme,
+        "light-basemap" => Geoblacklight.configuration.light_basemap_url,
+        "dark-basemap" => Geoblacklight.configuration.dark_basemap_url,
         "search-bounds" => search_bounds,
         "view-bounds" => view_bounds,
         "geosearch" => @geosearch || nil,

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -2,13 +2,13 @@
 
 # OGM viewer components: the previewer, the map of where a set of records is, and the map of where
 # one of them is
-pin "ogm-viewer", to: "https://unpkg.com/ogm-viewer@1.1.0/dist/components/ogm-viewer.js"
-pin "ogm-overview", to: "https://unpkg.com/ogm-viewer@1.1.0/dist/components/ogm-overview.js"
-pin "ogm-locator", to: "https://unpkg.com/ogm-viewer@1.1.0/dist/components/ogm-locator.js"
+pin "ogm-viewer", to: "https://unpkg.com/ogm-viewer@1.2.0/dist/components/ogm-viewer.js"
+pin "ogm-overview", to: "https://unpkg.com/ogm-viewer@1.2.0/dist/components/ogm-overview.js"
+pin "ogm-locator", to: "https://unpkg.com/ogm-viewer@1.2.0/dist/components/ogm-locator.js"
 
 # OGM viewer library, used for constructing the location previewers handed to the results map.
 # Not preloaded because only the pages with that map want it; loaded dynamically there.
-pin "ogm-viewer/lib", to: "https://unpkg.com/ogm-viewer@1.1.0/dist/components/index.js", preload: false
+pin "ogm-viewer/lib", to: "https://unpkg.com/ogm-viewer@1.2.0/dist/components/index.js", preload: false
 
 # Geoblacklight
 pin_all_from Geoblacklight::Engine.root.join("app", "javascript", "geoblacklight"), under: "geoblacklight"

--- a/lib/geoblacklight/configuration.rb
+++ b/lib/geoblacklight/configuration.rb
@@ -48,23 +48,13 @@ module Geoblacklight
     # The dct_references_s URI key to use as a document's thumbnail image URL
     attribute :thumbnail_reference_key, :string, default: "http://schema.org/thumbnailUrl"
 
-    # Configure basemap provider for GeoBlacklight maps
-    # Valid basemaps include:
-    # 'positron'
-    # 'dark_matter'
-    # 'positron_lite'
-    # 'world_antique'
-    # 'world_eco'
-    # 'flat_blue'
-    # 'midnight_commander'
-    # 'openstreetmap_hot'
-    # 'openstreetmap_standard'
+    # The basemap used in light mode, as a URL to a MapLibre style document.
+    # Leave blank to use the viewer's default.
+    attribute :light_basemap_url, :string
 
-    # Basemap used in light mode
-    attribute :basemap_provider, :string, default: "positron"
-
-    # Basemap used in dark mode
-    attribute :dark_basemap_provider, :string, default: "dark_matter"
+    # The basemap used in dark mode, as a URL to a MapLibre style document.
+    # Leave blank to use the viewer's default.
+    attribute :dark_basemap_url, :string
 
     # Homepage Map Geometry
     # Leave null to default to entire world

--- a/spec/components/geoblacklight/item_map_viewer_component_spec.rb
+++ b/spec/components/geoblacklight/item_map_viewer_component_spec.rb
@@ -21,6 +21,26 @@ RSpec.describe Geoblacklight::ItemMapViewerComponent, type: :component do
     end
   end
 
+  describe "the basemap" do
+    let(:document) { SolrDocument.new(JSON.parse(read_fixture("solr_documents/actual-polygon1.json"))) }
+
+    it "is left to the viewer's own default when none is configured" do
+      expect(page).to have_css("ogm-viewer:not([light-basemap]):not([dark-basemap])")
+    end
+
+    context "when the application configures its own" do
+      before do
+        allow(Geoblacklight.configuration).to receive(:light_basemap_url)
+          .and_return("https://tiles.example.edu/styles/light/style.json")
+        render_inline(described_class.new(document: document))
+      end
+
+      it "names the style document on the viewer" do
+        expect(page).to have_css('ogm-viewer[light-basemap="https://tiles.example.edu/styles/light/style.json"]')
+      end
+    end
+  end
+
   context "with an oembed record" do
     let(:document) { SolrDocument.new(JSON.parse(read_fixture("solr_documents/oembed.json"))) }
 

--- a/spec/components/geoblacklight/locator_map_component_spec.rb
+++ b/spec/components/geoblacklight/locator_map_component_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Geoblacklight::LocatorMapComponent, type: :component do
+  let(:document) { SolrDocument.new(JSON.parse(read_fixture("solr_documents/actual-polygon1.json"))) }
+
+  subject(:map) { page.find("ogm-locator") }
+
+  before { render_inline(described_class.new(document: document)) }
+
+  it "renders a locator the stylesheet can size" do
+    expect(map[:id]).to eq "locator-map"
+    expect(map[:class]).to eq "viewer locator-map"
+  end
+
+  it "points at the same record endpoint the item viewer reads" do
+    expect(map["record-url"]).to be_present
+  end
+
+  it "states Bootstrap's light default when dark mode support is unavailable" do
+    expect(map[:theme]).to eq "light"
+  end
+
+  describe "the basemap" do
+    it "is left to the viewer's own default when none is configured" do
+      expect(map["light-basemap"]).to be_nil
+      expect(map["dark-basemap"]).to be_nil
+    end
+
+    context "when the application configures its own" do
+      before do
+        allow(Geoblacklight.configuration).to receive(:dark_basemap_url)
+          .and_return("https://tiles.example.edu/styles/dark/style.json")
+        render_inline(described_class.new(document: document))
+      end
+
+      it "names the style document on the locator too, so every map on the page matches" do
+        expect(map["dark-basemap"]).to eq "https://tiles.example.edu/styles/dark/style.json"
+      end
+    end
+  end
+end

--- a/spec/components/geoblacklight/overview_map_component_spec.rb
+++ b/spec/components/geoblacklight/overview_map_component_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe Geoblacklight::OverviewMapComponent, type: :component do
   let(:url) { "/catalog?q=water" }
   let(:options) { {geosearch: true} }
   let(:homepage_map_geom) { nil }
+  let(:light_basemap_url) { nil }
+  let(:dark_basemap_url) { nil }
 
   subject(:map) { page.find("ogm-overview") }
 
@@ -13,6 +15,8 @@ RSpec.describe Geoblacklight::OverviewMapComponent, type: :component do
     # Stubbed for every example, because the one that reads it renders through the hook below
     allow(Geoblacklight.logger).to receive(:warn)
     allow(Geoblacklight.configuration).to receive(:homepage_map_geom).and_return(homepage_map_geom)
+    allow(Geoblacklight.configuration).to receive(:light_basemap_url).and_return(light_basemap_url)
+    allow(Geoblacklight.configuration).to receive(:dark_basemap_url).and_return(dark_basemap_url)
 
     with_controller_class(CatalogController) do
       with_request_url(url) do
@@ -29,6 +33,32 @@ RSpec.describe Geoblacklight::OverviewMapComponent, type: :component do
 
   it "states Bootstrap's light default when dark mode support is unavailable" do
     expect(map[:theme]).to eq "light"
+  end
+
+  describe "the basemap" do
+    it "is left to the viewer's own default when none is configured" do
+      expect(map["light-basemap"]).to be_nil
+      expect(map["dark-basemap"]).to be_nil
+    end
+
+    context "when the application configures its own" do
+      let(:light_basemap_url) { "https://tiles.example.edu/styles/light/style.json" }
+      let(:dark_basemap_url) { "https://tiles.example.edu/styles/dark/style.json" }
+
+      it "names a style document for each mode" do
+        expect(map["light-basemap"]).to eq "https://tiles.example.edu/styles/light/style.json"
+        expect(map["dark-basemap"]).to eq "https://tiles.example.edu/styles/dark/style.json"
+      end
+    end
+
+    context "when only the light-mode basemap is configured" do
+      let(:light_basemap_url) { "https://tiles.example.edu/styles/light/style.json" }
+
+      it "leaves dark mode to the viewer rather than reusing the light one" do
+        expect(map["light-basemap"]).to eq "https://tiles.example.edu/styles/light/style.json"
+        expect(map["dark-basemap"]).to be_nil
+      end
+    end
   end
 
   it "asks the controller for a search of the area a reader draws, and for the row a number belongs to" do


### PR DESCRIPTION
This is the groundwork needed to fix the CARTO watermarks appearing on basemaps (for v6), because it allows you to specify a basemap URL that includes an API key, which will remove the watermark.

- **Pin ogm-viewer to v1.2.0**  

- **Rename the basemap configuration properties for clarity**
  They are style URLs, and can't be bare names like 'positron'
  anymore.

- **Wire the basemap config into the viewers**
  