### PR TITLE
Require selenium-webdriver >= 4.11

### DIFF
--- a/geoblacklight.gemspec
+++ b/geoblacklight.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec-rails"
   spec.add_development_dependency "engine_cart", "~> 2.0"
   spec.add_development_dependency "capybara", ">= 2.5.0"
-  spec.add_development_dependency "selenium-webdriver"
+  spec.add_development_dependency "selenium-webdriver", ">= 4.11"
   spec.add_development_dependency "factory_bot_rails"
   spec.add_development_dependency "simplecov", "~> 0.22"
   spec.add_development_dependency "foreman"


### PR DESCRIPTION
Companion to [#1949](https://github.com/geoblacklight/geoblacklight/pull/1949) (`release-4.x`). This branch needs only the floor, not the `webdrivers` removal — that gem is already absent here.

## Why

`Gemfile.lock` is gitignored, so a local lock can drift arbitrarily far behind what CI resolves. Below 4.11 Selenium Manager cannot resolve a driver through the Chrome for Testing endpoints and the gem falls back to expecting a `chromedriver` already on `PATH`. GitHub's ubuntu runners ship one, so CI stays green while a developer with a stale lock watches every feature spec die at its first `visit`:

```
Selenium::WebDriver::Error::WebDriverError: Unable to find chromedriver
```

## Why 4.11 rather than 4.8

`main` set this floor to 4.8 in d379d8cb, the release that added Selenium Manager. That turns out not to be high enough. Asked for a driver for Chrome 152, the 4.10 `selenium-manager` binary walks backwards through versions and gives up:

```
WARN  Error getting version of chromedriver 150. Retrying with chromedriver 149 (attempt 3/5)
WARN  Error getting version of chromedriver 149. Retrying with chromedriver 148 (attempt 4/5)
WARN  Error getting version of chromedriver 148. Retrying with chromedriver 147 (attempt 5/5)
ERROR The chromedriver version cannot be discovered
```

Chrome for Testing support landed in 4.11.

## Scope

Unlike `release-4.x`, this branch carries no `webdrivers` gem capping `selenium-webdriver` to `< 4.11`, so a fresh bundle here already resolves a working version and the branch is not broken today. This only pins that down so a stale lock cannot silently regress it — the exact failure mode d379d8cb set out to prevent.

Note I verified the 4.10-vs-4.48 `selenium-manager` behavior directly, but did not bundle-and-run this branch; the reasoning above is from the dependency constraints plus that observed behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)