### PR TITLE
Raise the selenium-webdriver floor from 4.8 to 4.11

### DIFF
--- a/geoblacklight.gemspec
+++ b/geoblacklight.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec-rails"
   spec.add_development_dependency "engine_cart", "~> 2.0"
   spec.add_development_dependency "capybara", ">= 2.5.0"
-  spec.add_development_dependency "selenium-webdriver", ">= 4.8"
+  spec.add_development_dependency "selenium-webdriver", ">= 4.11"
   spec.add_development_dependency "factory_bot_rails"
   spec.add_development_dependency "simplecov", "~> 0.22"
   spec.add_development_dependency "foreman"


### PR DESCRIPTION
Follow-up to [#1935](https://github.com/geoblacklight/geoblacklight/pull/1935) / d379d8cb, which set this floor at 4.8. Companions: [#1949](https://github.com/geoblacklight/geoblacklight/pull/1949) (`release-4.x`), [#1950](https://github.com/geoblacklight/geoblacklight/pull/1950) (`release-5.x`).

## Why 4.8 is not enough

d379d8cb picked 4.8 because that is the release which added Selenium Manager, on the reasoning that Selenium Manager makes driver provisioning automatic. The reasoning holds; the version does not deliver it against current Chrome.

Selenium Manager only learned to resolve drivers through the Chrome for Testing endpoints in 4.11. Asked for a driver for the installed Chrome 152, the 4.10 `selenium-manager` binary walks backwards looking for a match and gives up:

```
WARN  Error getting version of chromedriver 150. Retrying with chromedriver 149 (attempt 3/5)
WARN  Error getting version of chromedriver 149. Retrying with chromedriver 148 (attempt 4/5)
WARN  Error getting version of chromedriver 148. Retrying with chromedriver 147 (attempt 5/5)
ERROR The chromedriver version cannot be discovered
```

So 4.8 through 4.10 satisfy the current floor while still failing every feature spec at its first `visit` with `Unable to find chromedriver` — exactly the failure d379d8cb set out to prevent. 4.48.0 provisions a driver for Chrome 152 without incident.

## Impact

Low. Nothing caps `selenium-webdriver` on `main`, so a fresh bundle resolves the latest and CI stays green either way. This only closes the gap for a stale gitignored lock, which is the scenario the original commit was written for.

For contrast, `release-4.x` was actively broken by this: its `webdrivers` gem pins `selenium-webdriver` to `~> 4.0, < 4.11`, so resolution was forced onto a non-working version regardless of lock freshness. That is handled in #1949.

🤖 Generated with [Claude Code](https://claude.com/claude-code)