### PR TITLE
Depend on standard directly rather than the standardrb alias

### DIFF
--- a/geoblacklight.gemspec
+++ b/geoblacklight.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "factory_bot_rails"
   spec.add_development_dependency "simplecov", "~> 0.22"
   spec.add_development_dependency "foreman"
-  spec.add_development_dependency "standardrb", "1.0.1"
+  spec.add_development_dependency "standard", "~> 1.56.0"
   spec.add_development_dependency "webmock", "~> 3.14"
   spec.add_development_dependency "database_cleaner"
   spec.add_development_dependency "axe-core-rspec"


### PR DESCRIPTION
Fixes #1952.

`standardrb` is a one-line alias gem that ships no executable and declares `standard >= 0`, so pinning it to `1.0.1` pins nothing about the linter or its cop set. `Gemfile.lock` is gitignored, so the linter was not reproducible between checkouts.

`~> 1.56.0` pins the minor and allows patches: `standard` pins `rubocop` tightly (`~> 1.88.0`), so a minor bump of `standard` can bump RuboCop's minor and bring new cops with it.

`bundle exec standardrb` is unaffected — `standard` provides that executable.

Verified `main` already lints clean under `standard 1.56.0` / `rubocop 1.88.2`: 238 files inspected, no offenses detected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)