### PR TITLE
Depend on standard directly rather than the standardrb alias

### DIFF
--- a/geoblacklight.gemspec
+++ b/geoblacklight.gemspec
@@ -40,6 +40,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "database_cleaner", "~> 2.0"
   spec.add_development_dependency "simplecov", "~> 0.22"
   spec.add_development_dependency "foreman"
-  spec.add_development_dependency "standardrb", "1.0.1"
+  spec.add_development_dependency "standard", "~> 1.56.0"
   spec.add_development_dependency "webmock", "~> 3.14"
 end


### PR DESCRIPTION
Fixes #1952 on `release-4.x`. Companions: [#1953](https://github.com/geoblacklight/geoblacklight/pull/1953) (`main`), [#1954](https://github.com/geoblacklight/geoblacklight/pull/1954) (`release-5.x`).

> [!IMPORTANT]
> **Stacked on [#1949](https://github.com/geoblacklight/geoblacklight/pull/1949)**, so the base is `selenium-webdriver-floor-4x` rather than `release-4.x`. Retarget to `release-4.x` once #1949 merges.
>
> `standard` requires Ruby >= 3.0, and this branch's linter job runs Ruby 2.7 until #1949 moves it to 3.2. Targeting `release-4.x` directly would fail to resolve.

`standardrb` is a one-line alias gem that ships no executable and declares `standard >= 0`, so pinning it to `1.0.1` pins nothing about the linter or its cop set. `Gemfile.lock` is gitignored, so the linter was not reproducible between checkouts. On this branch that drift is exactly what hid the five offenses corrected in #1949.

`~> 1.56.0` pins the minor and allows patches: `standard` pins `rubocop` tightly (`~> 1.88.0`), so a minor bump of `standard` can bump RuboCop's minor and bring new cops with it.

`bundle exec standardrb` is unaffected — `standard` provides that executable.

Verified this branch already lints clean under `standard 1.56.0` / `rubocop 1.88.2`: 172 files inspected, no offenses detected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)