### PR TITLE
Let applications configure basemap tile URLs

### DIFF
--- a/app/assets/javascripts/geoblacklight/basemaps.js
+++ b/app/assets/javascripts/geoblacklight/basemaps.js
@@ -1,85 +1,95 @@
 // basemaps
 
-GeoBlacklight.Basemaps = {
-  darkMatter: L.tileLayer(
-    'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{retina}.png', {
-      attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://carto.com/attributions">Carto</a>',
-      maxZoom: 18,
-      worldCopyJump: true,
-      retina: '@2x',
-      detectRetina: false
-    }
-  ),
-  positron: L.tileLayer(
-    'https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{retina}.png', {
-      attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://carto.com/attributions">Carto</a>',
-      maxZoom: 18,
-      worldCopyJump: true,
-      retina: '@2x',
-      detectRetina: false
-    }
-  ),
-  positronLite: L.tileLayer(
-    'https://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}{retina}.png', {
-      attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://carto.com/attributions">Carto</a>',
-      maxZoom: 18,
-      worldCopyJump: true,
-      retina: '@2x',
-      detectRetina: false
-    }
-  ),
-  worldAntique: L.tileLayer(
-    'https://cartocdn_{s}.global.ssl.fastly.net/base-antique/{z}/{x}/{y}{retina}.png', {
-      attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://carto.com/attributions">Carto</a>',
-      maxZoom: 18,
-      worldCopyJump: true,
-      retina: '@2x',
-      detectRetina: false
-    }
-  ),
-  worldEco: L.tileLayer(
-    'https://cartocdn_{s}.global.ssl.fastly.net/base-eco/{z}/{x}/{y}{retina}.png', {
-      attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://carto.com/attributions">Carto</a>',
-      maxZoom: 18,
-      worldCopyJump: true,
-      retina: '@2x',
-      detectRetina: false
-    }
-  ),
-  flatBlue: L.tileLayer(
-    'https://cartocdn_{s}.global.ssl.fastly.net/base-flatblue/{z}/{x}/{y}{retina}.png', {
-      attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://carto.com/attributions">Carto</a>',
-      maxZoom: 18,
-      worldCopyJump: true,
-      retina: '@2x',
-      detectRetina: false
-    }
-  ),
-  midnightCommander: L.tileLayer(
-    'https://cartocdn_{s}.global.ssl.fastly.net/base-midnight/{z}/{x}/{y}{retina}.png', {
-      attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://carto.com/attributions">Carto</a>',
-      maxZoom: 18,
-      worldCopyJump: true,
-      retina: '@2x',
-      detectRetina: false
-    }
-  ),
-  openstreetmapHot: L.tileLayer(
-    'https://{s}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png', {
-      attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>, Tiles courtesy of <a href="http://hot.openstreetmap.org/" target="_blank">Humanitarian OpenStreetMap Team</a>', 
-      maxZoom: 19,
-      worldCopyJump: true,
-      retina: '@2x',
-      detectRetina: false
-    }
-  ),
-  openstreetmapStandard: L.tileLayer(
-    'https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
-      attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
-      maxZoom: 19,
-      worldCopyJump: true,
-      retina: '@2x',
-      detectRetina: false
-    }
-  )
+/**
+* Raster XYZ tile definitions for the basemaps GeoBlacklight ships with. Each
+* definition is passed to L.tileLayer as its options, so it carries the URL
+* template alongside the layer options it needs.
+*
+* Applications can change any of these, or add their own, by setting
+* LEAFLET.BASEMAPS in settings.yml. See selectBasemap in viewers/map.js.
+*/
+GeoBlacklight.BasemapDefinitions = {
+  darkMatter: {
+    url: 'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{retina}.png',
+    attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://carto.com/attributions">Carto</a>',
+    maxZoom: 18,
+    worldCopyJump: true,
+    retina: '@2x',
+    detectRetina: false
+  },
+  positron: {
+    url: 'https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{retina}.png',
+    attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://carto.com/attributions">Carto</a>',
+    maxZoom: 18,
+    worldCopyJump: true,
+    retina: '@2x',
+    detectRetina: false
+  },
+  positronLite: {
+    url: 'https://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}{retina}.png',
+    attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://carto.com/attributions">Carto</a>',
+    maxZoom: 18,
+    worldCopyJump: true,
+    retina: '@2x',
+    detectRetina: false
+  },
+  worldAntique: {
+    url: 'https://cartocdn_{s}.global.ssl.fastly.net/base-antique/{z}/{x}/{y}{retina}.png',
+    attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://carto.com/attributions">Carto</a>',
+    maxZoom: 18,
+    worldCopyJump: true,
+    retina: '@2x',
+    detectRetina: false
+  },
+  worldEco: {
+    url: 'https://cartocdn_{s}.global.ssl.fastly.net/base-eco/{z}/{x}/{y}{retina}.png',
+    attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://carto.com/attributions">Carto</a>',
+    maxZoom: 18,
+    worldCopyJump: true,
+    retina: '@2x',
+    detectRetina: false
+  },
+  flatBlue: {
+    url: 'https://cartocdn_{s}.global.ssl.fastly.net/base-flatblue/{z}/{x}/{y}{retina}.png',
+    attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://carto.com/attributions">Carto</a>',
+    maxZoom: 18,
+    worldCopyJump: true,
+    retina: '@2x',
+    detectRetina: false
+  },
+  midnightCommander: {
+    url: 'https://cartocdn_{s}.global.ssl.fastly.net/base-midnight/{z}/{x}/{y}{retina}.png',
+    attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://carto.com/attributions">Carto</a>',
+    maxZoom: 18,
+    worldCopyJump: true,
+    retina: '@2x',
+    detectRetina: false
+  },
+  openstreetmapHot: {
+    url: 'https://{s}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png',
+    attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>, Tiles courtesy of <a href="http://hot.openstreetmap.org/" target="_blank">Humanitarian OpenStreetMap Team</a>',
+    maxZoom: 19,
+    worldCopyJump: true,
+    retina: '@2x',
+    detectRetina: false
+  },
+  openstreetmapStandard: {
+    url: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+    attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+    maxZoom: 19,
+    worldCopyJump: true,
+    retina: '@2x',
+    detectRetina: false
+  }
 };
+
+/**
+* Layer instances for the shipped definitions. Kept so that applications
+* referencing or replacing GeoBlacklight.Basemaps entries keep working.
+*/
+GeoBlacklight.Basemaps = {};
+
+Object.keys(GeoBlacklight.BasemapDefinitions).forEach(function(name) {
+  var definition = GeoBlacklight.BasemapDefinitions[name];
+  GeoBlacklight.Basemaps[name] = L.tileLayer(definition.url, definition);
+});

--- a/app/assets/javascripts/geoblacklight/basemaps.js
+++ b/app/assets/javascripts/geoblacklight/basemaps.js
@@ -33,38 +33,6 @@ GeoBlacklight.BasemapDefinitions = {
     retina: '@2x',
     detectRetina: false
   },
-  worldAntique: {
-    url: 'https://cartocdn_{s}.global.ssl.fastly.net/base-antique/{z}/{x}/{y}{retina}.png',
-    attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://carto.com/attributions">Carto</a>',
-    maxZoom: 18,
-    worldCopyJump: true,
-    retina: '@2x',
-    detectRetina: false
-  },
-  worldEco: {
-    url: 'https://cartocdn_{s}.global.ssl.fastly.net/base-eco/{z}/{x}/{y}{retina}.png',
-    attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://carto.com/attributions">Carto</a>',
-    maxZoom: 18,
-    worldCopyJump: true,
-    retina: '@2x',
-    detectRetina: false
-  },
-  flatBlue: {
-    url: 'https://cartocdn_{s}.global.ssl.fastly.net/base-flatblue/{z}/{x}/{y}{retina}.png',
-    attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://carto.com/attributions">Carto</a>',
-    maxZoom: 18,
-    worldCopyJump: true,
-    retina: '@2x',
-    detectRetina: false
-  },
-  midnightCommander: {
-    url: 'https://cartocdn_{s}.global.ssl.fastly.net/base-midnight/{z}/{x}/{y}{retina}.png',
-    attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://carto.com/attributions">Carto</a>',
-    maxZoom: 18,
-    worldCopyJump: true,
-    retina: '@2x',
-    detectRetina: false
-  },
   openstreetmapHot: {
     url: 'https://{s}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png',
     attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>, Tiles courtesy of <a href="http://hot.openstreetmap.org/" target="_blank">Humanitarian OpenStreetMap Team</a>',

--- a/app/assets/javascripts/geoblacklight/viewers/map.js
+++ b/app/assets/javascripts/geoblacklight/viewers/map.js
@@ -65,13 +65,30 @@ GeoBlacklight.Viewer.Map = GeoBlacklight.Viewer.extend({
 
   /**
   * Selects basemap if specified in data options, if not return positron.
+  *
+  * Applications can change a basemap's URL -- to add a CARTO API key, for
+  * example -- or define basemaps of their own by setting LEAFLET.BASEMAPS in
+  * settings.yml. Those values are merged over the shipped definition, so an
+  * override that gives only a url keeps the shipped attribution and zoom.
   */
   selectBasemap: function() {
-    var _this = this;
-    if (_this.data.basemap) {
-      return GeoBlacklight.Basemaps[_this.data.basemap];
-    } else {
-      return GeoBlacklight.Basemaps.positron;
+    var name = this.data.basemap || 'positron';
+    var options = this.data.leafletOptions || {};
+    var overrides = options.BASEMAPS || {};
+    var definition;
+
+    // A configured basemap wins, so an application can override a shipped one
+    if (overrides[name]) {
+      definition = L.extend(
+        {}, GeoBlacklight.BasemapDefinitions[name], overrides[name]
+      );
+      if (definition.url) {
+        return L.tileLayer(definition.url, definition);
+      }
     }
+
+    // Otherwise use the shipped layer, which an application may itself have
+    // replaced in GeoBlacklight.Basemaps
+    return GeoBlacklight.Basemaps[name] || GeoBlacklight.Basemaps.positron;
   }
 });

--- a/app/javascript/openlayers/basemaps.js
+++ b/app/javascript/openlayers/basemaps.js
@@ -14,26 +14,6 @@ export  const openLayersBasemaps = {
     attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://carto.com/attributions">Carto</a>',
     maxZoom: 18
   },
-  worldAntique: {
-    url: 'https://cartocdn_{a-d}.global.ssl.fastly.net/base-antique/{z}/{x}/{y}.png',
-    attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://carto.com/attributions">Carto</a>',
-    maxZoom: 18
-  },
-  worldEco: {
-    url: 'https://cartocdn_{a-d}.global.ssl.fastly.net/base-eco/{z}/{x}/{y}.png',
-    attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://carto.com/attributions">Carto</a>',
-    maxZoom: 18
-  },
-  flatBlue: {
-    url: 'https://cartocdn_{a-d}.global.ssl.fastly.net/base-flatblue/{z}/{x}/{y}.png',
-    attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://carto.com/attributions">Carto</a>',
-    maxZoom: 18
-  },
-  midnightCommander: {
-    url: 'https://cartocdn_{a-d}.global.ssl.fastly.net/base-midnight/{z}/{x}/{y}.png',
-    attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://carto.com/attributions">Carto</a>',
-      maxZoom: 18
-  },
   openstreetmapHot: {
     url: 'https://{a-c}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png',
     attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>, Tiles courtesy of <a href="http://hot.openstreetmap.org/" target="_blank">Humanitarian OpenStreetMap Team</a>', 

--- a/app/javascript/openlayers/ol_initializer.js
+++ b/app/javascript/openlayers/ol_initializer.js
@@ -33,15 +33,40 @@ export default class OlInitializer {
   }
 
   baseLayer () {
-    const basemap = openLayersBasemaps[this.data.basemap]
+    const basemap = this.basemapDefinition()
     const layer = new TileLayer({
       source: new XYZ({
         attributions: basemap["attribution"],
-        url: basemap["url"],
+        url: this.normalizeUrl(basemap["url"]),
         maxZoom: basemap["maxZoom"]
       })
     })
     return layer
+  }
+
+  // The basemap to draw, with any BASEMAPS values from settings.yml merged
+  // over the shipped definition. This lets an application change a basemap's
+  // URL -- to add a CARTO API key, for example -- without restating the rest
+  // of the definition, and lets it define basemaps of its own.
+  basemapDefinition () {
+    const name = this.data.basemap || 'positron'
+    const definition = {
+      ...openLayersBasemaps[name],
+      ...this.basemapOverrides()[name]
+    }
+    if (definition.url) return definition
+    return openLayersBasemaps.positron
+  }
+
+  basemapOverrides () {
+    return JSON.parse(this.data.leafletOptions || '{}').BASEMAPS || {}
+  }
+
+  // Leaflet and OpenLayers spell tile URL templates differently, so accept
+  // the Leaflet form a configured basemap is most likely to be written in:
+  // {s} becomes OpenLayers' subdomain range, and {retina} drops out.
+  normalizeUrl (url) {
+    return url.replace(/\{s\}/g, '{a-d}').replace(/\{retina\}/g, '')
   }
 
   initializePmtiles () {

--- a/lib/generators/geoblacklight/templates/catalog_controller.rb
+++ b/lib/generators/geoblacklight/templates/catalog_controller.rb
@@ -317,10 +317,6 @@ class CatalogController < ApplicationController
     # 'positron'
     # 'darkMatter'
     # 'positronLite'
-    # 'worldAntique'
-    # 'worldEco'
-    # 'flatBlue'
-    # 'midnightCommander'
     # 'openstreetmapHot'
     # 'openstreetmapStandard'
     #

--- a/lib/generators/geoblacklight/templates/catalog_controller.rb
+++ b/lib/generators/geoblacklight/templates/catalog_controller.rb
@@ -323,6 +323,9 @@ class CatalogController < ApplicationController
     # 'midnightCommander'
     # 'openstreetmapHot'
     # 'openstreetmapStandard'
+    #
+    # To change one of these basemaps' tile URLs, or to add a basemap of your
+    # own and name it here, set LEAFLET.BASEMAPS in settings.yml
 
     config.basemap_provider = "positron"
 

--- a/lib/generators/geoblacklight/templates/settings.yml
+++ b/lib/generators/geoblacklight/templates/settings.yml
@@ -229,6 +229,25 @@ WMS_PARAMS:
 # Settings for leaflet
 LEAFLET:
   MAP:
+  # Basemap definitions, keyed by the name config.basemap_provider selects.
+  # Anything set here is merged over the basemap GeoBlacklight ships with, so
+  # you can change just the url and keep the rest of the definition.
+  #
+  # CARTO now watermarks raster tiles requested without an API key, which
+  # affects the positron, positronLite and darkMatter basemaps. Request a free
+  # key at https://carto.com/basemaps/apikey/ and pass it as a key parameter:
+  # BASEMAPS:
+  #   positron:
+  #     url: 'https://basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png?key=YOUR_KEY'
+  #   darkMatter:
+  #     url: 'https://basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png?key=YOUR_KEY'
+  #
+  # You can also define a basemap of your own here and select it with
+  # config.basemap_provider = 'myBasemap' in your CatalogController:
+  #   myBasemap:
+  #     url: 'https://tiles.example.edu/{z}/{x}/{y}.png'
+  #     attribution: 'Tiles courtesy of Example University'
+  #     maxZoom: 18
   LAYERS:
     DETECT_RETINA: true
     INDEX:

--- a/spec/features/configurable_basemap_spec.rb
+++ b/spec/features/configurable_basemap_spec.rb
@@ -78,13 +78,16 @@ feature "Configurable basemap", js: true do
         text: "Tiles courtesy of Example University"
     end
   end
-  feature "using a basemap that does not exist" do
+  feature "using a basemap GeoBlacklight no longer ships" do
     before do
-      CatalogController.blacklight_config.basemap_provider = "nonexistent"
+      # worldEco was one of the CARTO basemaps served from the retired
+      # cartocdn fastly endpoints; applications still naming one should get a
+      # working basemap rather than none
+      CatalogController.blacklight_config.basemap_provider = "worldEco"
     end
     scenario "falls back to positron rather than drawing no basemap" do
       visit root_path
-      expect(page).to have_css "img[src*='light_all']"
+      expect(page).to have_css "img[src*='light_all']", visible: :all
     end
   end
 end

--- a/spec/features/configurable_basemap_spec.rb
+++ b/spec/features/configurable_basemap_spec.rb
@@ -34,4 +34,57 @@ feature "Configurable basemap", js: true do
       expect(page).to have_css "img[src*='hot']"
     end
   end
+  feature "with a configured tile URL for a shipped basemap" do
+    before do
+      CatalogController.blacklight_config.basemap_provider = "positron"
+      Settings.LEAFLET.BASEMAPS = {
+        positron: {
+          url: "https://basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png?key=fake-carto-key"
+        }
+      }
+    end
+    after { Settings.LEAFLET.BASEMAPS = nil }
+
+    scenario "requests tiles from the configured URL" do
+      visit root_path
+      expect(page).to have_css "img[src*='key=fake-carto-key']"
+    end
+    scenario "keeps the attribution from the shipped definition" do
+      visit root_path
+      expect(page).to have_css ".leaflet-control-attribution", text: "Carto"
+    end
+  end
+  feature "with a basemap the application defines itself" do
+    before do
+      CatalogController.blacklight_config.basemap_provider = "myBasemap"
+      Settings.LEAFLET.BASEMAPS = {
+        myBasemap: {
+          url: "/tiles/{z}/{x}/{y}.png",
+          attribution: "Tiles courtesy of Example University",
+          maxZoom: 18
+        }
+      }
+    end
+    after { Settings.LEAFLET.BASEMAPS = nil }
+
+    scenario "requests tiles from the application's basemap" do
+      visit root_path
+      # visible: :all because these tiles 404, so the images have no dimensions
+      expect(page).to have_css "img[src*='/tiles/']", visible: :all
+    end
+    scenario "credits the application's basemap" do
+      visit root_path
+      expect(page).to have_css ".leaflet-control-attribution",
+        text: "Tiles courtesy of Example University"
+    end
+  end
+  feature "using a basemap that does not exist" do
+    before do
+      CatalogController.blacklight_config.basemap_provider = "nonexistent"
+    end
+    scenario "falls back to positron rather than drawing no basemap" do
+      visit root_path
+      expect(page).to have_css "img[src*='light_all']"
+    end
+  end
 end


### PR DESCRIPTION
CARTO now watermarks raster tiles requested without an API key, so `positron`, `positronLite` and `darkMatter` draw "API KEY REQUIRED" across every tile. Keys are [free](https://carto.com/basemaps/apikey/) and need no CARTO account, but nothing in GeoBlacklight 4 lets an application change a basemap URL to carry one short of monkeypatching `GeoBlacklight.Basemaps` from application JS.

## Configuring a basemap

Set `LEAFLET.BASEMAPS` in `settings.yml`, keyed by the name `config.basemap_provider` selects. Values are merged over the shipped definition, so adding a key is one line and the attribution and zoom levels come along:

```yaml
LEAFLET:
  BASEMAPS:
    positron:
      url: 'https://basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png?key=YOUR_KEY'
```

A definition under a name GeoBlacklight does not ship becomes a new basemap, so this also covers pointing at another raster provider or an institution's own tile server:

```yaml
    myBasemap:
      url: 'https://tiles.example.edu/{z}/{x}/{y}.png'
      attribution: 'Tiles courtesy of Example University'
      maxZoom: 18
```

`Settings.LEAFLET` already reaches every viewer through `data-leaflet-options`, so no new plumbing was needed. All five elements that boot a Leaflet viewer carry it, including the bookmarks map.

Vector basemaps are out of scope — Leaflet cannot render a MapLibre style document without a plugin.

## Removing the four dead presets

`worldAntique`, `worldEco`, `flatBlue` and `midnightCommander` were served from `cartocdn_{s}.global.ssl.fastly.net`. Those endpoints now 301 to `basemaps01.carto.com`, which is gone, and the request ends in a 404 with an HTML body. Selecting any of the four draws a map with **no basemap at all**, and unlike the watermarked three there is nothing to configure — no URL or key revives them.

Both viewers now fall back to `positron` for an unknown basemap name rather than throwing on `undefined`, so an application still naming one of the four degrades to a working basemap instead of a blank map. **This is still a breaking change** for anyone selecting one of them, and wants a release note.

## Backwards compatibility

`basemaps.js` now holds `GeoBlacklight.BasemapDefinitions` as plain definitions and builds `GeoBlacklight.Basemaps` from them. The layer instances stay, and `selectBasemap` still returns the shipped instance when nothing is configured, so unconfigured behavior is byte-identical to today.

That fallthrough is load-bearing, not defensive. Surveying the 4.x deployments:

| Deployment | What it does to `GeoBlacklight.Basemaps` | `basemap_provider` |
|---|---|---|
| Princeton (`pulibrary/pulmap`) | `modules/basemaps.js` adds `esri` | `"esri"` — not a shipped preset |
| UW-Milwaukee (`UWM-Libraries/GeoDiscovery`) | `application.js` replaces `positron` | `"positron"` |
| BTAA (`geobtaa/geoportal`) | overrides `darkMatter`, `positron`, `positronLite`, `worldAntique`; adds `esri_world_imagery` | `'openstreetmapStandard'` |

Rebuilding layers purely from the definitions table would have broken Princeton outright and silently discarded UW-Milwaukee's and BTAA's overrides, reverting them to watermarked tiles. No deployment selects any of the four removed presets; BTAA re-defines `worldAntique` in its own JS but does not select it.

**Upgrade note for applications that already override a preset in JS:** configured settings take precedence over `GeoBlacklight.Basemaps`, and they merge over the *shipped* definition rather than over your override. So UW-Milwaukee setting `LEAFLET.BASEMAPS.positron.url` would get the key but lose the `subdomains`/`detectRetina`/`noWrap` options set in JS. For those applications, adding the key to their own `L.tileLayer` call is simpler.

## Note on GeoBlacklight 6

[#1947](https://github.com/geoblacklight/geoblacklight/pull/1947) replaces `basemap_provider` with `config.light_basemap_url` / `config.dark_basemap_url`, which take URLs to MapLibre **style documents**. That is deliberately not mirrored here: v4's Leaflet viewer needs a raster XYZ template (`{z}/{x}/{y}`), so a same-named setting would accept a different kind of value and fail silently if a style URL were pasted in. A v4 basemap URL will need to be replaced, not carried, on upgrade.

## Verification

- `spec/features/configurable_basemap_spec.rb` — five new scenarios: keyed URL applied, merge keeps the shipped attribution, an application-defined basemap and its attribution, and a removed preset falling back to positron
- The 18 map-rendering feature specs, covering every viewer subclass that calls `selectBasemap` (esri, index map, WMS, TileJSON, TMS, WMTS, XYZ, home, search results, split view, bookmarks, static map) — **59 examples, 0 failures**
- 31 assertions driven against the real source files for the merge semantics, non-mutation of shipped definitions, and every fallback path
- All nine shipped presets verified to resolve to identical url + options before and after the refactor
- `bundle exec standardrb` — 172 files, no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)