### PR TITLE
Let applications configure basemap tile URLs

### DIFF
--- a/app/javascript/geoblacklight/controllers/leaflet_viewer_controller.js
+++ b/app/javascript/geoblacklight/controllers/leaflet_viewer_controller.js
@@ -110,11 +110,26 @@ export default class LeafletViewerController extends Controller {
 
   // Select the configured basemap to use
   getBasemap() {
-    const basemapName = this.basemapValue || "positron";
-    return tileLayer(basemaps[basemapName].url, {
-      ...basemaps[basemapName],
+    const definition = this.basemapDefinition();
+    return tileLayer(definition.url, {
+      ...definition,
       detectRetina: this.optionsValue.LAYERS.DETECT_RETINA || false,
     });
+  }
+
+  // The basemap to draw, with any BASEMAPS values from settings.yml merged over
+  // the shipped definition. This lets an application change a basemap's URL --
+  // to add a CARTO API key, for example -- without restating the rest of the
+  // definition, and lets it define basemaps of its own. Falls back to positron
+  // for a name that resolves to nothing rather than drawing no basemap.
+  basemapDefinition() {
+    const name = this.basemapValue || "positron";
+    const definition = { ...basemaps[name], ...this.basemapOverrides()[name] };
+    return definition.url ? definition : basemaps.positron;
+  }
+
+  basemapOverrides() {
+    return this.optionsValue.BASEMAPS || {};
   }
 
   // Add the configured controls to the map

--- a/app/javascript/geoblacklight/controllers/openlayers_viewer_controller.js
+++ b/app/javascript/geoblacklight/controllers/openlayers_viewer_controller.js
@@ -14,6 +14,7 @@ export default class OpenlayersViewerController extends Controller {
     protocol: String,
     basemap: String,
     mapGeom: String,
+    options: Object,
   };
 
   async connect() {
@@ -55,9 +56,39 @@ export default class OpenlayersViewerController extends Controller {
 
   // Select the configured basemap to use
   getBasemap() {
-    const basemap = basemaps[this.basemapValue || "positron"];
-    const layer = new TileLayer({ source: new XYZ(basemap) });
+    const basemap = this.basemapDefinition();
+    const layer = new TileLayer({
+      source: new XYZ({
+        ...basemap,
+        url: this.normalizeUrl(basemap.url),
+        // The leaflet definitions spell this `attribution`; OpenLayers wants
+        // `attributions`. Accept either so one setting serves both viewers.
+        attributions: basemap.attributions || basemap.attribution,
+      }),
+    });
     return layer;
+  }
+
+  // The basemap to draw, with any BASEMAPS values from settings.yml merged over
+  // the shipped definition. This lets an application change a basemap's URL --
+  // to add a CARTO API key, for example -- without restating the rest of the
+  // definition, and lets it define basemaps of its own. Falls back to positron
+  // for a name that resolves to nothing rather than drawing no basemap.
+  basemapDefinition() {
+    const name = this.basemapValue || "positron";
+    const definition = { ...basemaps[name], ...this.basemapOverrides()[name] };
+    return definition.url ? definition : basemaps.positron;
+  }
+
+  basemapOverrides() {
+    return this.optionsValue.BASEMAPS || {};
+  }
+
+  // Leaflet and OpenLayers spell tile URL templates differently, so accept the
+  // leaflet form a configured basemap is most likely to be written in: {s}
+  // becomes OpenLayers' subdomain range, and {retina} drops out.
+  normalizeUrl(url) {
+    return url.replace(/\{s\}/g, "{a-d}").replace(/\{retina\}/g, "");
   }
 
   // Generate a layer based on the protocol

--- a/app/javascript/geoblacklight/leaflet/basemaps.js
+++ b/app/javascript/geoblacklight/leaflet/basemaps.js
@@ -23,38 +23,6 @@ export default {
     worldCopyJump: true,
     retina: "@2x",
   },
-  worldAntique: {
-    url: "https://cartocdn_{s}.global.ssl.fastly.net/base-antique/{z}/{x}/{y}{retina}.png",
-    attribution:
-      '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://carto.com/attributions">Carto</a>',
-    maxZoom: 18,
-    worldCopyJump: true,
-    retina: "@2x",
-  },
-  worldEco: {
-    url: "https://cartocdn_{s}.global.ssl.fastly.net/base-eco/{z}/{x}/{y}{retina}.png",
-    attribution:
-      '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://carto.com/attributions">Carto</a>',
-    maxZoom: 18,
-    worldCopyJump: true,
-    retina: "@2x",
-  },
-  flatBlue: {
-    url: "https://cartocdn_{s}.global.ssl.fastly.net/base-flatblue/{z}/{x}/{y}{retina}.png",
-    attribution:
-      '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://carto.com/attributions">Carto</a>',
-    maxZoom: 18,
-    worldCopyJump: true,
-    retina: "@2x",
-  },
-  midnightCommander: {
-    url: "https://cartocdn_{s}.global.ssl.fastly.net/base-midnight/{z}/{x}/{y}{retina}.png",
-    attribution:
-      '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://carto.com/attributions">Carto</a>',
-    maxZoom: 18,
-    worldCopyJump: true,
-    retina: "@2x",
-  },
   openstreetmapHot: {
     url: "https://{s}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png",
     attribution:

--- a/app/javascript/geoblacklight/openlayers/basemaps.js
+++ b/app/javascript/geoblacklight/openlayers/basemaps.js
@@ -14,26 +14,6 @@ export default {
     attributions: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://carto.com/attributionss">Carto</a>',
     maxZoom: 18
   },
-  worldAntique: {
-    url: 'https://cartocdn_{a-d}.global.ssl.fastly.net/base-antique/{z}/{x}/{y}.png',
-    attributions: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://carto.com/attributionss">Carto</a>',
-    maxZoom: 18
-  },
-  worldEco: {
-    url: 'https://cartocdn_{a-d}.global.ssl.fastly.net/base-eco/{z}/{x}/{y}.png',
-    attributions: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://carto.com/attributionss">Carto</a>',
-    maxZoom: 18
-  },
-  flatBlue: {
-    url: 'https://cartocdn_{a-d}.global.ssl.fastly.net/base-flatblue/{z}/{x}/{y}.png',
-    attributions: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://carto.com/attributionss">Carto</a>',
-    maxZoom: 18
-  },
-  midnightCommander: {
-    url: 'https://cartocdn_{a-d}.global.ssl.fastly.net/base-midnight/{z}/{x}/{y}.png',
-    attributions: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://carto.com/attributionss">Carto</a>',
-      maxZoom: 18
-  },
   openstreetmapHot: {
     url: 'https://{a-c}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png',
     attributions: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>, Tiles courtesy of <a href="http://hot.openstreetmap.org/" target="_blank">Humanitarian OpenStreetMap Team</a>', 

--- a/lib/generators/geoblacklight/templates/catalog_controller.rb
+++ b/lib/generators/geoblacklight/templates/catalog_controller.rb
@@ -315,6 +315,9 @@ class CatalogController < ApplicationController
     # 'midnightCommander'
     # 'openstreetmapHot'
     # 'openstreetmapStandard'
+    #
+    # To change one of these basemaps' tile URLs, or to add a basemap of your
+    # own and name it here, set LEAFLET.BASEMAPS in settings.yml
 
     config.basemap_provider = "positron"
 

--- a/lib/generators/geoblacklight/templates/catalog_controller.rb
+++ b/lib/generators/geoblacklight/templates/catalog_controller.rb
@@ -309,10 +309,6 @@ class CatalogController < ApplicationController
     # 'positron'
     # 'darkMatter'
     # 'positronLite'
-    # 'worldAntique'
-    # 'worldEco'
-    # 'flatBlue'
-    # 'midnightCommander'
     # 'openstreetmapHot'
     # 'openstreetmapStandard'
     #

--- a/lib/generators/geoblacklight/templates/settings.yml
+++ b/lib/generators/geoblacklight/templates/settings.yml
@@ -231,6 +231,25 @@ WMS_PARAMS:
 # Settings for leaflet
 LEAFLET:
   MAP:
+  # Basemap definitions, keyed by the name config.basemap_provider selects.
+  # Anything set here is merged over the basemap GeoBlacklight ships with, so
+  # you can change just the url and keep the rest of the definition.
+  #
+  # CARTO now watermarks raster tiles requested without an API key, which
+  # affects the positron, positronLite and darkMatter basemaps. Request a free
+  # key at https://carto.com/basemaps/apikey/ and pass it as a key parameter:
+  # BASEMAPS:
+  #   positron:
+  #     url: 'https://basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png?key=YOUR_KEY'
+  #   darkMatter:
+  #     url: 'https://basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png?key=YOUR_KEY'
+  #
+  # You can also define a basemap of your own here and select it with
+  # config.basemap_provider = 'myBasemap' in your CatalogController:
+  #   myBasemap:
+  #     url: 'https://tiles.example.edu/{z}/{x}/{y}.png'
+  #     attribution: 'Tiles courtesy of Example University'
+  #     maxZoom: 18
   BOUNDSOVERLAY:
     INDEX:
       color: '#3388ff'

--- a/spec/features/configurable_basemap_spec.rb
+++ b/spec/features/configurable_basemap_spec.rb
@@ -37,4 +37,60 @@ feature "Configurable basemap", js: true do
       expect(page).to have_css "img[src*='hot']", visible: :all
     end
   end
+
+  feature "with a configured tile URL for a shipped basemap" do
+    before do
+      CatalogController.blacklight_config.basemap_provider = "positron"
+      Settings.LEAFLET.BASEMAPS = {
+        positron: {
+          url: "https://basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png?key=fake-carto-key"
+        }
+      }
+    end
+    after { Settings.LEAFLET.BASEMAPS = nil }
+
+    scenario "requests tiles from the configured URL" do
+      visit root_path
+      expect(page).to have_css "img[src*='key=fake-carto-key']", visible: :all
+    end
+    scenario "keeps the attribution from the shipped definition" do
+      visit root_path
+      expect(page).to have_css ".leaflet-control-attribution", text: "Carto"
+    end
+  end
+
+  feature "with a basemap the application defines itself" do
+    before do
+      CatalogController.blacklight_config.basemap_provider = "myBasemap"
+      Settings.LEAFLET.BASEMAPS = {
+        myBasemap: {
+          url: "/tiles/{z}/{x}/{y}.png",
+          attribution: "Tiles courtesy of Example University",
+          maxZoom: 18
+        }
+      }
+    end
+    after { Settings.LEAFLET.BASEMAPS = nil }
+
+    scenario "requests tiles from the application's basemap" do
+      visit root_path
+      # visible: :all because these tiles 404, so the images have no dimensions
+      expect(page).to have_css "img[src*='/tiles/']", visible: :all
+    end
+    scenario "credits the application's basemap" do
+      visit root_path
+      expect(page).to have_css ".leaflet-control-attribution",
+        text: "Tiles courtesy of Example University"
+    end
+  end
+
+  feature "using a basemap that does not exist" do
+    before do
+      CatalogController.blacklight_config.basemap_provider = "nonexistent"
+    end
+    scenario "falls back to positron rather than drawing no basemap" do
+      visit root_path
+      expect(page).to have_css "img[src*='light_all']", visible: :all
+    end
+  end
 end

--- a/spec/features/configurable_basemap_spec.rb
+++ b/spec/features/configurable_basemap_spec.rb
@@ -84,9 +84,12 @@ feature "Configurable basemap", js: true do
     end
   end
 
-  feature "using a basemap that does not exist" do
+  feature "using a basemap GeoBlacklight no longer ships" do
     before do
-      CatalogController.blacklight_config.basemap_provider = "nonexistent"
+      # worldEco was one of the CARTO basemaps served from the retired
+      # cartocdn fastly endpoints; applications still naming one should get a
+      # working basemap rather than none
+      CatalogController.blacklight_config.basemap_provider = "worldEco"
     end
     scenario "falls back to positron rather than drawing no basemap" do
       visit root_path


### PR DESCRIPTION
The `release-5.x` counterpart to [#1957](https://github.com/geoblacklight/geoblacklight/pull/1957).

CARTO now watermarks raster tiles requested without an API key, so `positron`, `positronLite` and `darkMatter` draw "API KEY REQUIRED" across every tile. Keys are [free](https://carto.com/basemaps/apikey/) and need no CARTO account, but nothing in GeoBlacklight lets an application change a basemap URL to carry one short of mutating the basemaps module exported from `@geoblacklight/frontend`.

## Configuring a basemap

Set `LEAFLET.BASEMAPS` in `settings.yml`, keyed by the name `config.basemap_provider` selects. Values are merged over the shipped definition, so adding a key is one line and the attribution and zoom levels come along:

```yaml
LEAFLET:
  BASEMAPS:
    positron:
      url: 'https://basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png?key=YOUR_KEY'
```

A definition under a name GeoBlacklight does not ship becomes a new basemap, so this also covers pointing at another raster provider or an institution's own tile server:

```yaml
    myBasemap:
      url: 'https://tiles.example.edu/{z}/{x}/{y}.png'
      attribution: 'Tiles courtesy of Example University'
      maxZoom: 18
```

Vector basemaps are out of scope — leaflet cannot render a MapLibre style document without a plugin.

## Differences from the 4.x version

Less code, because v5's basemap tables are already plain definition objects rather than constructed `L.tileLayer` instances — no `BasemapDefinitions` split was needed, and `GeoBlacklight.Basemaps` back-compat does not apply.

Three things are specific to this branch:

- `Settings.LEAFLET` already reached the leaflet viewer, and `ItemMapViewerComponent` already emitted `openlayers-viewer-options-value` — the openlayers controller just never declared the value. Added.
- The openlayers controller normalizes `{s}` and `{retina}` in a configured URL, since one setting feeds two viewers whose tile URL templates differ and the shipped leaflet definitions are the likeliest thing to be copied.
- It also accepts leaflet's singular `attribution` in place of its own `attributions`, so one settings entry credits both viewers. (In 4.x both tables used the singular key, so this was not needed there.)

## Removing the four dead presets

`worldAntique`, `worldEco`, `flatBlue` and `midnightCommander` were served from `cartocdn_{s}.global.ssl.fastly.net`. Those endpoints now 301 to `basemaps01.carto.com`, which is gone, and the request ends in a 404 with an HTML body. Selecting any of the four draws a map with **no basemap at all**, and unlike the watermarked three there is nothing to configure — no URL or key revives them.

Both viewers now fall back to `positron` for a name that resolves to nothing rather than throwing on `undefined`, so an application still naming one degrades to a working basemap. **This is still a breaking change** for anyone selecting one of them, and wants a release note.

## Verification

- 18 assertions driven against the real controller files (imports stubbed) covering merge semantics, non-mutation of shipped definitions, every fallback path, `{s}`/`{retina}` normalization and the attribution alias — green at **both** commits, so each stands alone
- `bundle exec standardrb` — 353 files, no offenses
- Five new feature scenarios: keyed URL applied, merge keeps the shipped attribution, an application-defined basemap and its attribution, and a removed preset falling back to positron

I did not run the feature specs locally — that needs a `release-5.x` engine_cart app, and this worktree currently holds a 4.x one. CI is the first full run of them here, across both the importmap and vite jobs. Note `spec/features/layer_inspection_spec.rb` drives `#openlayers-viewer` in a browser, so the openlayers changes are exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)