### PR TITLE
Require Blacklight 9.1

### DIFF
--- a/app/helpers/geoblacklight_helper.rb
+++ b/app/helpers/geoblacklight_helper.rb
@@ -27,13 +27,11 @@ module GeoblacklightHelper
     document.public? || (document.same_institution? && user_signed_in?)
   end
 
-  # Bootstrap is light when no color mode is stated. Match that default explicitly so ogm-viewer
-  # doesn't fall back to the operating system's dark preference in an application without
-  # Blacklight's color-mode support. Blacklight added this setting in 9.1, so its absence means the
-  # same thing as false. When it is enabled, viewer_theme.js follows the resolved data-bs-theme on
-  # <html> instead.
+  # If you turn off dark mode support, Geoblacklight will display in light mode,
+  # but ogm-viewer will still try to honor a system dark mode preference. This
+  # ensures that everything stays light until you explicitly enable dark mode.
   def geoblacklight_viewer_theme
-    return if blacklight_config.respond_to?(:dark_mode_support) && blacklight_config.dark_mode_support
+    return if blacklight_config.dark_mode_support
 
     "light"
   end

--- a/app/models/concerns/geoblacklight/suppressed_records_search_behavior.rb
+++ b/app/models/concerns/geoblacklight/suppressed_records_search_behavior.rb
@@ -14,7 +14,7 @@ module Geoblacklight
     # @return [Blacklight::Solr::Request]
     def hide_suppressed_records(solr_params)
       # Show suppressed records when searching relationships
-      return if blacklight_params.fetch(:f,
+      return if search_state.params.fetch(:f,
         {}).keys.any? do |field|
                   Geoblacklight.configuration.relationships_shown.map do |_key, value|
                     value.field

--- a/geoblacklight.gemspec
+++ b/geoblacklight.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.required_rubygems_version = ">= 2.5.2"
 
   spec.add_dependency "rails", ">= 8", "< 9"
-  spec.add_dependency "blacklight", ">= 9.0", "< 10"
+  spec.add_dependency "blacklight", ">= 9.1", "< 10"
   spec.add_dependency "commonmarker", "~> 2.9"
   spec.add_dependency "config"
   spec.add_dependency "faraday", "~> 2.0"

--- a/spec/components/geoblacklight/item_map_viewer_component_spec.rb
+++ b/spec/components/geoblacklight/item_map_viewer_component_spec.rb
@@ -16,7 +16,11 @@ RSpec.describe Geoblacklight::ItemMapViewerComponent, type: :component do
       let(:document) { SolrDocument.new(JSON.parse(read_fixture(fixture_path))) }
 
       it "uses the viewer" do
-        expect(page).to have_css('ogm-viewer[theme="light"]')
+        expect(page).to have_css("ogm-viewer")
+      end
+
+      it "leaves the theme to the page's color mode" do
+        expect(page).to have_css("ogm-viewer:not([theme])")
       end
     end
   end

--- a/spec/components/geoblacklight/locator_map_component_spec.rb
+++ b/spec/components/geoblacklight/locator_map_component_spec.rb
@@ -18,8 +18,19 @@ RSpec.describe Geoblacklight::LocatorMapComponent, type: :component do
     expect(map["record-url"]).to be_present
   end
 
-  it "states Bootstrap's light default when dark mode support is unavailable" do
-    expect(map[:theme]).to eq "light"
+  it "leaves the theme to the page's color mode" do
+    expect(map[:theme]).to be_nil
+  end
+
+  context "when the application turns Blacklight's dark mode support off" do
+    before do
+      allow_any_instance_of(GeoblacklightHelper).to receive(:geoblacklight_viewer_theme).and_return("light")
+      render_inline(described_class.new(document: document))
+    end
+
+    it "passes the light default the helper states through to the viewer" do
+      expect(map[:theme]).to eq "light"
+    end
   end
 
   describe "the basemap" do

--- a/spec/components/geoblacklight/metadata_description_markdown_component_spec.rb
+++ b/spec/components/geoblacklight/metadata_description_markdown_component_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Geoblacklight::MetadataDescriptionMarkdownComponent, type: :compo
       key: "dct_description_sm",
       label: "Description",
       render_field?: true,
+      layout_component: nil,
       values: ["a **short**", "description"])
   end
 

--- a/spec/components/geoblacklight/overview_map_component_spec.rb
+++ b/spec/components/geoblacklight/overview_map_component_spec.rb
@@ -31,8 +31,8 @@ RSpec.describe Geoblacklight::OverviewMapComponent, type: :component do
     expect(map["data-controller"]).to eq "overview-map"
   end
 
-  it "states Bootstrap's light default when dark mode support is unavailable" do
-    expect(map[:theme]).to eq "light"
+  it "leaves the theme to the page's color mode" do
+    expect(map[:theme]).to be_nil
   end
 
   describe "the basemap" do

--- a/spec/components/geoblacklight/static_map_component_spec.rb
+++ b/spec/components/geoblacklight/static_map_component_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Geoblacklight::StaticMapComponent, type: :component do
     it "points it at the same endpoint the item viewer reads its own metadata from" do
       map = rendered.css("ogm-locator").first
       expect(map["record-url"]).to eq Rails.application.routes.url_helpers.viewer_solr_document_path(document)
-      expect(map["theme"]).to eq "light"
+      expect(map["theme"]).to be_nil
     end
   end
 end

--- a/spec/helpers/geoblacklight_helper_spec.rb
+++ b/spec/helpers/geoblacklight_helper_spec.rb
@@ -12,14 +12,6 @@ RSpec.describe GeoblacklightHelper, type: :helper do
       allow(helper).to receive(:blacklight_config).and_return(blacklight_config)
     end
 
-    context "before Blacklight has a dark mode setting" do
-      let(:blacklight_config) { Object.new }
-
-      it "states Bootstrap's implicit light default" do
-        expect(helper.geoblacklight_viewer_theme).to eq "light"
-      end
-    end
-
     context "when dark mode support is disabled" do
       let(:blacklight_config) { Struct.new(:dark_mode_support).new(false) }
 


### PR DESCRIPTION
9.1 adds per-field layout components (projectblacklight/blacklight#3808):
`MetadataFieldComponent` now resolves `field.layout_component` from the show
field configuration, so a field can be given its own layout without
subclassing the field component and copying its template.

It also ships the color-mode setting that `geoblacklight_viewer_theme` was
already written to anticipate. `dark_mode_support` defaults to true, so the
viewers stop pinning themselves to `theme="light"` and follow the page's
resolved `data-bs-theme` through viewer_theme.js instead. This is visible to
readers: viewers now honour dark mode. The `respond_to?` guard that stood in
for 9.0 is dead code and goes with it, along with the spec case for a config
that has no such setting.

`MetadataFieldComponent` reading `field.layout_component` also means any
`instance_double(Blacklight::FieldPresenter)` has to answer it.

Finally, 9.1 deprecates `blacklight_params` in favour of
`search_state.params`; the one call site is switched over. Blacklight defines
the former as the latter, so nothing changes but the warning.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
