### PR TITLE
Support truncation for show page fields

### DIFF
--- a/app/assets/stylesheets/geoblacklight/global.css
+++ b/app/assets/stylesheets/geoblacklight/global.css
@@ -7,9 +7,21 @@
 }
 
 /* Truncation */
+/* NOTE: text truncation is line-based; field truncation is based on the number
+ * of items in that field. They apply to different elements (paragraph vs dd).
+ * Both use the CSS here. */
 .truncate-abstract {
   transition: none; /* No animation */
   position: relative;
+}
+
+.truncate-field {
+  margin: 0;
+  padding: 0;
+}
+
+.read-more-slot:empty {
+  display: none;
 }
 
 .truncate-abstract.collapse:not(.show),
@@ -29,7 +41,23 @@
     left: 0;
     width: 100%;
     height: 2em;
+    pointer-events: none;
     background-image: linear-gradient(to bottom, rgba(255, 255, 255, 0), var(--bs-body-bg) 65%);
+  }
+}
+
+.truncate-field > dd.truncate-preview {
+  position: relative;
+  max-height: 0.7em;
+  overflow: hidden;
+
+  /* Gradient fade effect */
+  &::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background-image: linear-gradient(to bottom, rgba(255, 255, 255, 0), var(--bs-body-bg) 85%);
   }
 }
 

--- a/app/components/geoblacklight/truncatable_metadata_field_layout_component.html.erb
+++ b/app/components/geoblacklight/truncatable_metadata_field_layout_component.html.erb
@@ -1,0 +1,7 @@
+<%= tag.div class: "truncate-field row", data: truncate_data do %>
+  <dt class="blacklight-<%= @key %> <%= @label_class %>"><%= label %></dt>
+  <% values.each do |v| %>
+    <%= v %>
+  <% end %>
+  <%= tag.dd class: read_more_slot_class %>
+<% end %>

--- a/app/components/geoblacklight/truncatable_metadata_field_layout_component.rb
+++ b/app/components/geoblacklight/truncatable_metadata_field_layout_component.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Geoblacklight
+  # Lays out a metadata field so that it shows only the first few of its values, with a
+  # button to reveal the rest. The label and the values are wrapped in a div so that
+  # app/javascript/geoblacklight/initializers/field_truncation.js can tell which values
+  # belong to the field; it reads the data attributes set here.
+  #
+  # Configure a show field to use it, optionally overriding the limit. Because this is a
+  # layout rather than a field component, it composes with whatever component the field
+  # already uses to render its values:
+  #
+  #   config.add_show_field field_config.subject, label: "Subject", link_to_facet: true,
+  #     layout_component: Geoblacklight::TruncatableMetadataFieldLayoutComponent, limit: 3
+  class TruncatableMetadataFieldLayoutComponent < Blacklight::MetadataFieldLayoutComponent
+    DEFAULT_LIMIT = 5
+
+    # @param read_more_text [String] label for the button that reveals the rest of the values
+    # @param close_text [String] label for the button once the values are revealed
+    # @param limit [Integer] number of values to show before hiding the rest
+    def initialize(read_more_text: nil, close_text: nil, limit: nil, **kwargs)
+      @read_more_text = read_more_text
+      @close_text = close_text
+      @limit = limit
+      super(**kwargs)
+    end
+
+    private
+
+    def truncate_data
+      {
+        read_more_text: @read_more_text || t("geoblacklight.truncate.read_more"),
+        close_text: @close_text || t("geoblacklight.truncate.close"),
+        button_label: t("geoblacklight.truncate.button_label"),
+        limit: @limit || @field.field_config[:limit] || DEFAULT_LIMIT
+      }
+    end
+
+    # A <dl> cannot hold a bare <button>, so the initializer moves the button into this
+    # empty <dd>. It takes the same columns as the values so that it lines up with them.
+    def read_more_slot_class
+      ["read-more-slot", @offset_class, @value_class]
+    end
+  end
+end

--- a/app/javascript/geoblacklight/core.js
+++ b/app/javascript/geoblacklight/core.js
@@ -1,6 +1,7 @@
 // Initializers
 import initializeTooltips from "geoblacklight/initializers/tooltips"
 import initializeTruncation from "geoblacklight/initializers/truncation"
+import initializeFieldTruncation from "geoblacklight/initializers/field_truncation"
 import initializeMetadataDownload from "geoblacklight/initializers/metadata_download"
 import initializeViewerTheme from "geoblacklight/initializers/viewer_theme"
 import initializeViewerRequests from "geoblacklight/initializers/viewer_requests"
@@ -42,6 +43,7 @@ Geoblacklight.listeners().forEach((listener) =>
 // Register our initializers
 Geoblacklight.onLoad(initializeTooltips)
 Geoblacklight.onLoad(initializeTruncation)
+Geoblacklight.onLoad(initializeFieldTruncation)
 Geoblacklight.onLoad(initializeMetadataDownload)
 Geoblacklight.onLoad(initializeViewerTheme)
 Geoblacklight.onLoad(initializeViewerRequests)

--- a/app/javascript/geoblacklight/initializers/field_truncation.js
+++ b/app/javascript/geoblacklight/initializers/field_truncation.js
@@ -1,0 +1,62 @@
+// Limit how many values a metadata field shows on the show page
+
+// Class that hides a field's values past its limit and adds a button to reveal them.
+// The hidden values are only hidden visually, so assistive technology is given the whole
+// list up front. That leaves the button useful to sighted users alone, so it is marked
+// aria-disabled and its label says why.
+class FieldTruncator {
+  constructor(element) {
+    this.slot = element.querySelector(":scope > dd.read-more-slot")
+    if (!this.slot) return
+
+    // this field was already truncated on an earlier turbo:load/turbo:frame-load
+    if (this.slot.firstElementChild) return
+
+    // if the field is already short enough, don't truncate it
+    const values = element.querySelectorAll(":scope > dd:not(.read-more-slot)")
+    const limit = parseInt(element.dataset.limit, 10) || 5
+    if (values.length <= limit) return
+
+    // the value at the limit is left in place but clipped, so that the list visibly runs
+    // on past the values it is showing; everything after it is hidden outright
+    this.preview = values[limit]
+    this.hidden = Array.from(values).slice(limit + 1)
+    this.readMoreText = element.dataset.readMoreText
+    this.closeText = element.dataset.closeText
+
+    // add the button
+    this.button = document.createElement("button")
+    this.button.classList.add("btn", "btn-link", "p-0", "border-0", "read-more")
+    this.button.setAttribute("aria-disabled", "true")
+    this.button.setAttribute("aria-label", element.dataset.buttonLabel)
+    this.button.addEventListener("click", this.toggle.bind(this))
+
+    // start collapsed
+    this.collapse()
+    this.slot.append(this.button)
+  }
+
+  toggle() {
+    if (this.expanded) this.collapse()
+    else this.expand()
+  }
+
+  collapse() {
+    this.preview.classList.add("truncate-preview")
+    this.hidden.forEach((value) => value.classList.add("visually-hidden"))
+    this.button.textContent = this.readMoreText
+    this.expanded = false
+  }
+
+  expand() {
+    this.preview.classList.remove("truncate-preview")
+    this.hidden.forEach((value) => value.classList.remove("visually-hidden"))
+    this.button.textContent = this.closeText
+    this.expanded = true
+  }
+}
+
+// Initialize truncation for every metadata field that limits its values
+export default function initializeFieldTruncation() {
+  document.querySelectorAll(".truncate-field").forEach((element) => new FieldTruncator(element))
+}

--- a/config/locales/geoblacklight.en.yml
+++ b/config/locales/geoblacklight.en.yml
@@ -140,6 +140,7 @@ en:
     truncate:
       read_more: "Read more"
       close: "Close"
+      button_label: "Show or hide the remaining values. Disabled because assistive technology has already been given all of them."
     show:
       attribute: "Attribute"
       value: "Value"

--- a/lib/generators/geoblacklight/templates/catalog_controller.rb
+++ b/lib/generators/geoblacklight/templates/catalog_controller.rb
@@ -151,7 +151,7 @@ class CatalogController < ApplicationController
 
     # DEFAULT FIELDS
     # The following fields all feature string values. If there is a value present in the metadata, they fields will show up on the item show page.
-    # The labels and order can be customed. Comment out fields to hide them.
+    # The labels and order can be customized. Comment out fields to hide them.
 
     config.add_show_field field_config.alternative_title, label: "Alternative Title",
       itemprop: "alt_title"
@@ -163,13 +163,14 @@ class CatalogController < ApplicationController
     config.add_show_field field_config.resource_class, label: "Resource Class", itemprop: "class"
     config.add_show_field field_config.resource_type, label: "Resource Type", itemprop: "type"
     config.add_show_field field_config.subject, label: "Subject", itemprop: "keywords",
-      link_to_facet: true
-    config.add_show_field field_config.theme, label: "Theme", itemprop: "theme"
+      link_to_facet: true, layout_component: Geoblacklight::TruncatableMetadataFieldLayoutComponent
+    config.add_show_field field_config.theme, label: "Theme", itemprop: "theme",
+      layout_component: Geoblacklight::TruncatableMetadataFieldLayoutComponent
     config.add_show_field field_config.temporal_coverage, label: "Temporal Coverage",
       itemprop: "temporal"
     config.add_show_field field_config.date_issued, label: "Date Issued", itemprop: "issued"
     config.add_show_field field_config.spatial_coverage, label: "Spatial Coverage", itemprop: "spatial",
-      link_to_facet: true
+      link_to_facet: true, layout_component: Geoblacklight::TruncatableMetadataFieldLayoutComponent
     config.add_show_field field_config.rights, label: "Rights", itemprop: "rights"
     config.add_show_field field_config.rights_holder, label: "Rights Holder",
       itemprop: "rights_holder"

--- a/spec/components/geoblacklight/truncatable_metadata_field_layout_component_spec.rb
+++ b/spec/components/geoblacklight/truncatable_metadata_field_layout_component_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Geoblacklight::TruncatableMetadataFieldLayoutComponent, type: :component do
+  subject(:component) { described_class.new(field:) }
+
+  let(:field_config) { Blacklight::Configuration::Field.new(key: "dct_subject_sm") }
+  let(:field) { instance_double(Blacklight::FieldPresenter, key: "dct_subject_sm", field_config:) }
+
+  def render_field(component)
+    render_inline(component) do |layout|
+      layout.with_label { "Subject" }
+      layout.with_value(value: "Forests", index: 0)
+      layout.with_value(value: "Land use", index: 1)
+    end
+  end
+
+  it "wraps the label and the values in a row of their own" do
+    render_field(component)
+
+    expect(page).to have_css("div.truncate-field.row > dt.blacklight-dct_subject_sm", text: "Subject")
+    expect(page).to have_css("div.truncate-field.row > dd", count: 3) # two values plus the button slot
+  end
+
+  it "keeps each value in its own dd, in the columns the layout would have used" do
+    render_field(component)
+
+    expect(page).to have_css("dd.col-md-9.blacklight-dct_subject_sm", text: "Forests")
+    expect(page).to have_css("dd.offset-md-3.col-md-9.blacklight-dct_subject_sm", text: "Land use")
+  end
+
+  it "renders an empty dd for the initializer to put the button in" do
+    render_field(component)
+
+    # A <dl> may not hold a bare <button>, so the button cannot be a sibling of the values
+    expect(page).to have_css("div.truncate-field > dd.read-more-slot.offset-md-3.col-md-9")
+    expect(page.find("dd.read-more-slot").text).to be_empty
+  end
+
+  it "sets up the data attributes for the JS initializer" do
+    render_field(component)
+
+    expect(page).to have_css(
+      ".truncate-field[data-limit='5'][data-read-more-text='Read more'][data-close-text='Close']"
+    )
+    expect(page).to have_css(".truncate-field[data-button-label*='assistive technology']")
+  end
+
+  context "when the truncation parameters are given to the component" do
+    subject(:component) do
+      described_class.new(field:, limit: 2, read_more_text: "More", close_text: "Less")
+    end
+
+    it "uses them instead of the defaults" do
+      render_field(component)
+
+      expect(page).to have_css(
+        ".truncate-field[data-limit='2'][data-read-more-text='More'][data-close-text='Less']"
+      )
+    end
+  end
+
+  context "when the field configuration sets a limit" do
+    let(:field_config) { Blacklight::Configuration::Field.new(key: "dct_subject_sm", limit: 3) }
+
+    it "uses the configured limit" do
+      render_field(component)
+
+      expect(page).to have_css(".truncate-field[data-limit='3']")
+    end
+  end
+
+  context "when the layout is given different columns" do
+    subject(:component) { described_class.new(field:, label_class: "col-2", value_class: "col-10", offset_class: "offset-2") }
+
+    it "puts the button slot in the same columns as the values" do
+      render_field(component)
+
+      expect(page).to have_css("dd.read-more-slot.offset-2.col-10")
+    end
+  end
+end

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -9,6 +9,21 @@ RSpec.describe CatalogController, type: :controller do
 
       expect(description_field.component).to eq Geoblacklight::MetadataDescriptionMarkdownComponent
     end
+
+    it "uses the truncatable layout for the fields that hold long lists of values" do
+      fields = Geoblacklight.configuration.fields
+      layouts = [fields.subject, fields.theme, fields.spatial_coverage].map do |key|
+        described_class.blacklight_config.show_fields[key].layout_component
+      end
+
+      expect(layouts).to all eq Geoblacklight::TruncatableMetadataFieldLayoutComponent
+    end
+
+    it "leaves the component free for the fields that use the truncatable layout" do
+      subject_field = described_class.blacklight_config.show_fields[Geoblacklight.configuration.fields.subject]
+
+      expect(subject_field.component).to eq Blacklight::MetadataFieldComponent
+    end
   end
 
   describe "#web_services" do

--- a/spec/features/truncated_metadata_spec.rb
+++ b/spec/features/truncated_metadata_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.feature "Metadata fields that limit their values" do
+  let(:group) { "div.truncate-field:has(dt.blacklight-dct_subject_sm)" }
+  let(:read_more) { find("#{group} > dd.read-more-slot button") }
+
+  # Princeton record carrying nine subject values, four more than the five it shows in full
+  scenario "The values past the limit are hidden until the reader asks for them", js: true do
+    visit solr_document_path("princeton-dc7h14b252v")
+
+    subjects = find(group)
+
+    # Every value keeps its own dd. The value at the limit is clipped to show that the list
+    # carries on; the ones after it are taken out of view entirely.
+    expect(subjects).to have_css("dd:not(.read-more-slot)", count: 9, visible: :all)
+    expect(subjects).to have_css("dd.truncate-preview", count: 1, visible: :all)
+    expect(subjects).to have_css("dd.visually-hidden", count: 3, visible: :all)
+
+    # The text assertions are scoped to the field: the viewer's own metadata panel lists
+    # every subject too, so a page-wide matcher would race with the viewer loading.
+    expect(subjects).to have_no_text("Physical maps")
+
+    read_more.click
+
+    expect(subjects).to have_no_css("dd.visually-hidden", visible: :all)
+    expect(subjects).to have_no_css("dd.truncate-preview", visible: :all)
+    expect(subjects).to have_text("Physical maps")
+    expect(read_more).to have_text("Close")
+
+    read_more.click
+
+    expect(subjects).to have_css("dd.visually-hidden", count: 3, visible: :all)
+    expect(subjects).to have_css("dd.truncate-preview", count: 1, visible: :all)
+    expect(read_more).to have_text("Read more")
+  end
+
+  scenario "The clipped value fades out, the way a clamped description does", js: true do
+    visit solr_document_path("princeton-dc7h14b252v")
+
+    preview = find("#{group} > dd.truncate-preview", visible: :all)
+    expect(preview.evaluate_script("getComputedStyle(this, '::after').backgroundImage")).to include "linear-gradient"
+
+    # A shade under one line tall, so the value reads as cut off rather than as its own entry
+    line_height = preview.evaluate_script("parseFloat(getComputedStyle(this).lineHeight)")
+    expect(preview.evaluate_script("this.getBoundingClientRect().height")).to be < line_height
+
+    # The gradient covers the value, so it must not swallow clicks on the link beneath it
+    expect(preview.evaluate_script("getComputedStyle(this, '::after').pointerEvents")).to eq "none"
+  end
+
+  scenario "The hidden values stay available to assistive technology", js: true do
+    visit solr_document_path("princeton-dc7h14b252v")
+
+    # visually-hidden leaves the values in the accessibility tree, so the button is of no use
+    # to assistive technology and says so rather than promising something it cannot deliver
+    expect(read_more[:"aria-disabled"]).to eq "true"
+    expect(read_more[:"aria-label"]).to include "assistive technology"
+
+    hidden = all("#{group} > dd.visually-hidden", visible: :all).last
+    expect(hidden.evaluate_script("getComputedStyle(this).display")).not_to eq "none"
+    expect(hidden.evaluate_script("getComputedStyle(this).visibility")).not_to eq "hidden"
+  end
+
+  scenario "Fields short enough to fit are left alone", js: true do
+    visit solr_document_path("princeton-dc7h14b252v")
+
+    # Wait for the initializer to have run before asserting that it skipped this field
+    expect(page).to have_css("#{group} > dd.read-more-slot button")
+
+    spatial = "div.truncate-field:has(dt.blacklight-dct_spatial_sm)"
+    expect(page).to have_no_css("#{spatial} > dd.read-more-slot button")
+    expect(page).to have_no_css("#{spatial} > dd.visually-hidden", visible: :all)
+    expect(page).to have_no_css("#{spatial} > dd.truncate-preview", visible: :all)
+  end
+end

--- a/spec/requests/catalog_show_spec.rb
+++ b/spec/requests/catalog_show_spec.rb
@@ -29,8 +29,30 @@ RSpec.describe "Catalog show page", type: :request do
 
     metadata = response_page.find(".document-metadata")
     expect(metadata).to have_css("dt", count: 16)
-    expect(metadata).to have_css("dd", count: 20)
+    expect(metadata).to have_css("dd:not(.read-more-slot)", count: 20)
     expect(metadata).to have_css("div.truncate-abstract", count: 1)
+  end
+
+  it "wraps the fields that limit their values around their label and values" do
+    get solr_document_path("stanford-dp018hs9766")
+
+    metadata = response_page.find(".document-metadata")
+    expect(metadata).to have_css("div.truncate-field[data-limit='5']", count: 3)
+    expect(metadata).to have_css("div.truncate-field > dt.blacklight-dct_subject_sm")
+    expect(metadata).to have_css("div.truncate-field > dt.blacklight-dcat_theme_sm")
+    expect(metadata).to have_css("div.truncate-field > dt.blacklight-dct_spatial_sm")
+
+    # The initializer puts the read more button in these
+    expect(metadata).to have_css("div.truncate-field > dd.read-more-slot", count: 3)
+  end
+
+  it "keeps each limited value in its own dd, with its microdata and facet link" do
+    get solr_document_path("stanford-dp018hs9766")
+
+    subjects = response_page.all("div.truncate-field > dd.blacklight-dct_subject_sm")
+    expect(subjects.size).to eq 2
+    expect(subjects.first).to have_css("span[itemprop='keywords'] a", count: 1)
+    expect(subjects.first).to have_link("Continental margins", href: /dct_subject_sm/)
   end
 
   it "allows a suppressed record to be viewed" do


### PR DESCRIPTION
This ended up being trickier than #1960 imagined: the `<dd>` elements need to be kept separate, but everything has to be wrapped in a `<div>`, and truncation needs to happen by number of _items_, not lines of text.

It ended up converging to an implementation similar to SearchWorks: a different truncation path for the fields than for text (like in descriptions). BL9.1's ability to give layout components to show page fields made this simpler.

Visually, it's just like description truncation:

<img width="451" height="274" alt="Screenshot 2026-09-04 at 13 32 27" src="https://github.com/user-attachments/assets/3f2d204c-92bf-44bb-b950-74faaa68b31f" />
