### PR TITLE
Remove the dead viewer help text configuration

### DIFF
--- a/lib/generators/geoblacklight/templates/settings.yml
+++ b/lib/generators/geoblacklight/templates/settings.yml
@@ -221,25 +221,6 @@
 #   EXCEPTIONS: "application/json"
 #   INFO_FORMAT: "application/json"
 
-# # Toggle the help text feature that offers users context
-# help_text:
-#   viewer_protocol:
-#     - "cog"
-#     - "dynamic_map_layer"
-#     - "feature_layer"
-#     - "iiif"
-#     - "iiif_manifest"
-#     - "image_map_layer"
-#     - "index_map"
-#     - "oembed"
-#     - "pmtiles"
-#     - "tiled_map_layer"
-#     - "tilejson"
-#     - "tms"
-#     - "wms"
-#     - "wmts"
-#     - "xyz"
-
 # iiif_drag_drop_link: "@manifest?manifest=@manifest"
 
 # # Toggle thumbnail images in the search results (index) view

--- a/lib/geoblacklight/configuration.rb
+++ b/lib/geoblacklight/configuration.rb
@@ -31,9 +31,6 @@ module Geoblacklight
     # Display Notes to display / Non-prefixed default bootstrap class is alert-secondary
     attr_accessor :display_notes_shown # typed as Hash
 
-    # Toggle the help text feature that offers users context
-    attr_accessor :help_text # typed as Hash
-
     # Non-search-field GeoBlacklight application permitted params
     attr_accessor :gbl_params # typed as Array
 
@@ -86,25 +83,6 @@ module Geoblacklight
         SRS: "EPSG:4326",
         EXCEPTIONS: "application/json",
         INFO_FORMAT: "application/json"
-      }
-      @help_text = {
-        viewer_protocol: %w[
-          cog
-          dynamic_map_layer
-          feature_layer
-          iiif
-          iiif_manifest
-          image_map_layer
-          index_map
-          oembed
-          pmtiles
-          tiled_map_layer
-          tilejson
-          tms
-          wms
-          wmts
-          xyz
-        ]
       }
 
       @restricted_origins = []

--- a/lib/geoblacklight/configuration/settings_builder.rb
+++ b/lib/geoblacklight/configuration/settings_builder.rb
@@ -18,7 +18,6 @@ module Geoblacklight
           assign(config, :overlap_ratio_boost, settings.OVERLAP_RATIO_BOOST)
           assign(config, :display_notes_shown, build_display_notes)
           assign(config, :institution, settings.INSTITUTION)
-          assign(config, :help_text, settings.HELP_TEXT&.to_h)
           assign(config, :iiif_drag_drop_link, settings.IIIF_DRAG_DROP_LINK)
           assign(config, :thumbnails_enabled, settings.THUMBNAILS_ENABLED)
           assign(config, :thumbnail_reference_key, settings.THUMBNAIL_REFERENCE_KEY)


### PR DESCRIPTION
`ViewerHelpTextComponent` and its `geoblacklight.help_text.viewer_protocol.*` locale keys went out with the ogm-viewer migration — the keys in 749a1974, the component and its spec in f9be07a4 — but the configuration that gated it stayed behind. Nothing under app/ has read `configuration.help_text` since, so the attribute, its 15-protocol default and the `SettingsBuilder` assignment all go, along with the block in the generated settings.yml that still documented it as a live option.

`HELP_TEXT` was the only one of the six top level keys GeoBlacklight 6 stops acting on that `SettingsBuilder` still read; `DOWNLOAD_FORMATS`, `ICON_MAPPING`, `LEAFLET`, `SIDEBAR_STATIC_MAP` and `TIMEOUT_DOWNLOAD` were already ignored in silence. Dropping the read makes it consistent with its siblings rather than opening a new gap, and the one warning it enabled was misleading: `CaseInsensitiveSettings` only knows about key case, so an application that still set `HELP_TEXT:` was told to rename it to `help_text:`, which would have preserved a dead setting under a new name.

Unrecognized top level keys stay unreported. `Settings` is the config gem's application-owned global, so applications legitimately add keys of their own, and reporting every key GeoBlacklight does not recognize would flag all of them. Nested entry attributes raise instead only because they go through `assign_attributes`, which raises on its own; `removed_attributes` exists to soften that, and there is no equivalent crash to soften here. The upgrade warning for this key belongs on release-5.x, where `DeprecatedConfiguration` already carries it.